### PR TITLE
[WIP] All clients as optional

### DIFF
--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -58,6 +58,7 @@ module "srv" {
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 
+# optional
 module "cli-sles12sp3" {
   source = "./modules/libvirt/client"
   base_configuration = "${module.base.configuration}"
@@ -69,6 +70,7 @@ module "cli-sles12sp3" {
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 
+# optional
 module "min-sles12sp3" {
   source = "./modules/libvirt/minion"
   base_configuration = "${module.base.configuration}"

--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -65,6 +65,7 @@ module "srv" {
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 
+# optional
 module "cli-sles12sp3" {
   source = "./modules/openstack/client"
   base_configuration = "${module.base.configuration}"
@@ -76,6 +77,7 @@ module "cli-sles12sp3" {
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 
+# optional
 module "min-sles12sp3" {
   source = "./modules/openstack/minion"
   base_configuration = "${module.base.configuration}"

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -45,11 +45,17 @@ variable "proxy_configuration" {
 variable "client_configuration" {
   description = "use ${module.<CLIENT_NAME>.configuration}, see main.tf.libvirt-testsuite.example"
   type = "map"
+  default = {
+    hostname = "null"
+  }
 }
 
 variable "minion_configuration" {
   description = "use ${module.<MINION_NAME>.configuration}, see main.tf.libvirt-testsuite.example"
   type = "map"
+  default = {
+    hostname = "null"
+  }
 }
 
 variable "minionssh_configuration" {


### PR DESCRIPTION
Not sure about the reason behind to have minion and traditional clients as mandatory, when you define a controller in our main.tf
As an idea, that PR makes all clients optional.


Here the card for test suite support: https://github.com/SUSE/spacewalk/issues/7786