### PR TITLE
Add cucumber-html-reporter js module on the controller node

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -80,6 +80,17 @@ install_gems_via_bundle:
       - pkg: cucumber_requisites
       - cmd: spacewalk_git_repository
 
+install_npm:
+  pkg.installed:
+    - name: npm8
+
+# https://github.com/gkushang/cucumber-html-reporter
+install_cucumber_html_reporter_via_npm:
+  cmd.run:
+    - name: npm install cucumber-html-reporter --save-dev
+    - require:
+      - pkg: install_npm
+
 spacewalk_git_repository:
   cmd.run:
 {%- if grains.get("git_repo") == "default" %}


### PR DESCRIPTION
Install the required `npm` package and the [cucumber-html-reporter](https://github.com/gkushang/cucumber-html-reporter) js module on the controller node.

The js module is a `cucumber result output generator` based on the `JSON` output generated by Cucumber itself. For details how the [cucumber-html-reporter](https://github.com/gkushang/cucumber-html-reporter) works please refer to the plugin project itself.

The basic usage of this module is implemented in [this PR](https://github.com/uyuni-project/uyuni/pull/1008). Simply let
- Cucumber produce `JSON` output data [addressed in this PR](https://github.com/uyuni-project/uyuni/pull/967)
- have an `index.js` file to set properties and drive the module
- run `node index.js` to generate the cucumber output `HTML` result