### PR TITLE
Make it possible to disable IPv6 (fully or only RAs)

### DIFF
--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -11,6 +11,7 @@ module "client" {
   gpg_keys = "${var.gpg_keys}"
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
+  ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = true
   grains = <<EOF

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -95,3 +95,8 @@ variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
 }
+
+variable "ipv6" {
+  description = "enable/disable IPv6"
+  default = true
+}

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -64,6 +64,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 // Provider-specific variables
 
 variable "image" {
@@ -94,9 +103,4 @@ variable "mac" {
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
-}
-
-variable "ipv6" {
-  description = "enable/disable IPv6"
-  default = true
 }

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -21,6 +21,7 @@ module "controller" {
   additional_packages = "${var.additional_packages}"
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
+  ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = false
   grains = <<EOF

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -106,6 +106,7 @@ variable "swap_file_size" {
   description = "Swap file size in MiB, or 0 for none"
   default = 4096
 }
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
@@ -127,7 +128,7 @@ variable "git_profiles_repo" {
 }
 
 variable "server_http_proxy" {
-  description = "Define hostname and port used by SUSE Manager http proxy"
+  description = "Hostname and port used by SUSE Manager http proxy"
   default = ""
 }
 

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -148,3 +148,8 @@ variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
 }
+
+variable "ipv6" {
+  description = "enable/disable IPv6"
+  default = true
+}

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -112,6 +112,15 @@ variable "ssh_key_path" {
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 variable "git_profiles_repo" {
   description = "URL of git repository with alternate Docker and Kiwi profiles, see README_ADVANCED.md"
   default = "default"
@@ -147,9 +156,4 @@ variable "mac" {
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
-}
-
-variable "ipv6" {
-  description = "enable/disable IPv6"
-  default = true
 }

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -98,7 +98,7 @@ gpg_keys: [${join(", ", formatlist("'%s'", var.gpg_keys))}]
 connect_to_base_network: ${var.connect_to_base_network}
 connect_to_additional_network: ${var.connect_to_additional_network}
 reset_ids: true
-ipv6: ${var.ipv6}
+ipv6: {${join(", ", formatlist("'%s': '%s'", keys(var.ipv6), values(var.ipv6)))}}
 ${var.grains}
 
 EOF

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -98,6 +98,7 @@ gpg_keys: [${join(", ", formatlist("'%s'", var.gpg_keys))}]
 connect_to_base_network: ${var.connect_to_base_network}
 connect_to_additional_network: ${var.connect_to_additional_network}
 reset_ids: true
+ipv6: ${var.ipv6}
 ${var.grains}
 
 EOF

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -100,3 +100,8 @@ variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
 }
+
+variable "ipv6" {
+  description = "enable/disable IPv6"
+  default = true
+}

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -54,6 +54,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 variable "connect_to_base_network" {
   description = "true if you want a card connected to the main network, see README_ADVANCED.md"
   default = true
@@ -99,9 +108,4 @@ variable "additional_disk" {
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
-}
-
-variable "ipv6" {
-  description = "enable/disable IPv6"
-  default = true
 }

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -11,6 +11,7 @@ module "minion" {
   gpg_keys = "${var.gpg_keys}"
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
+  ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = true
   grains = <<EOF

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -89,6 +89,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 variable "additional_grains" {
   description = "custom grain string to be added to this minion's configuration"
   default = ""
@@ -124,9 +133,4 @@ variable "mac" {
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
-}
-
-variable "ipv6" {
-  description = "enable/disable IPv6"
-  default = true
 }

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -125,3 +125,8 @@ variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
 }
+
+variable "ipv6" {
+  description = "enable/disable IPv6"
+  default = true
+}

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -25,6 +25,7 @@ module "suse_manager" {
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
+  ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = false
   grains = <<EOF

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -242,3 +242,8 @@ variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
 }
+
+variable "ipv6" {
+  description = "enable/disable IPv6"
+  default = true
+}

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -181,6 +181,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 variable "pts" {
   description = "Whether this instance is part of a Performance Testsuite"
   default = false
@@ -241,9 +250,4 @@ variable "additional_disk" {
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
-}
-
-variable "ipv6" {
-  description = "enable/disable IPv6"
-  default = true
 }

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -24,6 +24,7 @@ module "suse_manager_proxy" {
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
+  ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = true
   grains = <<EOF

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -130,3 +130,8 @@ variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
 }
+
+variable "ipv6" {
+  description = "enable/disable IPv6"
+  default = true
+}

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -99,6 +99,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 // Provider-specific variables
 
 variable "image" {
@@ -129,9 +138,4 @@ variable "mac" {
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""
-}
-
-variable "ipv6" {
-  description = "enable/disable IPv6"
-  default = true
 }

--- a/modules/libvirt/virthost/main.tf
+++ b/modules/libvirt/virthost/main.tf
@@ -14,6 +14,7 @@ module "virthost" {
   additional_packages = "${var.additional_packages}"
   gpg_keys = "${var.gpg_keys}"
   ssh_key_path = "${var.ssh_key_path}"
+  ipv6 = "${var.ipv6}"
   additional_grains = <<EOF
 
 hvm_disk_image: "${var.hvm_disk_image}"

--- a/modules/libvirt/virthost/variables.tf
+++ b/modules/libvirt/virthost/variables.tf
@@ -64,6 +64,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 variable "hvm_disk_image" {
   description = "URL to the disk image to use for KVM guests"
   default = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse423.x86_64.qcow2"
@@ -99,9 +108,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "ipv6" {
-  description = "enable/disable IPv6"
-  default = true
 }

--- a/modules/libvirt/virthost/variables.tf
+++ b/modules/libvirt/virthost/variables.tf
@@ -100,3 +100,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "ipv6" {
+  description = "enable/disable IPv6"
+  default = true
+}

--- a/modules/openstack/client/main.tf
+++ b/modules/openstack/client/main.tf
@@ -11,6 +11,7 @@ module "client" {
   gpg_keys = "${var.gpg_keys}"
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
+  ipv6 = "${var.ipv6}"
   grains = <<EOF
 
 product_version: ${var.product_version}

--- a/modules/openstack/client/variables.tf
+++ b/modules/openstack/client/variables.tf
@@ -64,6 +64,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 // Provider-specific variables
 
 variable "image" {

--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -21,6 +21,7 @@ module "controller" {
   additional_packages = "${var.additional_packages}"
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
+  ipv6 = "${var.ipv6}"
   grains = <<EOF
 
 git_username: ${var.git_username}

--- a/modules/openstack/controller/variables.tf
+++ b/modules/openstack/controller/variables.tf
@@ -102,6 +102,15 @@ variable "ssh_key_path" {
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 variable "git_profiles_repo" {
   description = "URL of git repository with alternate Docker and Kiwi profiles, see README_ADVANCED.md"
   default = "default"

--- a/modules/openstack/controller/variables.tf
+++ b/modules/openstack/controller/variables.tf
@@ -25,7 +25,7 @@ variable "git_repo" {
 }
 
 variable "server_http_proxy" {
-  description = "Define hostname and port used by SUSE Manager http proxy"
+  description = "Hostname and port used by SUSE Manager http proxy"
   default = ""
 }
 

--- a/modules/openstack/host/main.tf
+++ b/modules/openstack/host/main.tf
@@ -111,6 +111,7 @@ swap_file_size: ${var.swap_file_size}
 authorized_keys: [${trimspace(file(var.base_configuration["ssh_key_path"]))},${trimspace(file(var.ssh_key_path))}]
 gpg_keys: [${join(", ", formatlist("'%s'", var.gpg_keys))}]
 reset_ids: true
+ipv6: ${${join(", ", formatlist("'%s': '%s'", keys(var.ipv6), values(var.ipv6)))}}
 ${var.grains}
 
 EOF

--- a/modules/openstack/host/variables.tf
+++ b/modules/openstack/host/variables.tf
@@ -54,6 +54,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 // Provider-specific variables
 
 variable "image" {

--- a/modules/openstack/minion/main.tf
+++ b/modules/openstack/minion/main.tf
@@ -11,6 +11,7 @@ module "minion" {
   gpg_keys = "${var.gpg_keys}"
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
+  ipv6 = "${var.ipv6}"
   grains = <<EOF
 
 product_version: ${var.product_version}

--- a/modules/openstack/minion/variables.tf
+++ b/modules/openstack/minion/variables.tf
@@ -89,6 +89,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 // Provider-specific variables
 
 variable "image" {

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -25,6 +25,7 @@ module "suse_manager" {
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
+  ipv6 = "${var.ipv6}"
   grains = <<EOF
 
 product_version: ${var.product_version}

--- a/modules/openstack/suse_manager/variables.tf
+++ b/modules/openstack/suse_manager/variables.tf
@@ -181,6 +181,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 variable "pts" {
   description = "Whether this instance is part of a Performance Testsuite"
   default = false

--- a/modules/openstack/suse_manager_proxy/main.tf
+++ b/modules/openstack/suse_manager_proxy/main.tf
@@ -24,6 +24,7 @@ module "suse_manager_proxy" {
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
+  ipv6 = "${var.ipv6}"
   grains = <<EOF
 
 product_version: ${var.product_version}

--- a/modules/openstack/suse_manager_proxy/variables.tf
+++ b/modules/openstack/suse_manager_proxy/variables.tf
@@ -99,6 +99,15 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  type = "map"
+  default = {
+    enable = true
+    accept_ra = true
+  }
+}
+
 // Provider-specific variables
 
 variable "image" {

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -63,40 +63,66 @@ authorized_keys:
     - makedirs: True
 {% endif %}
 
-{% if not grains.get('ipv6', 1) %}
+{% if grains.get('ipv6')['enable'] | default('1') == '1' %}
 
-disable_ipv6_accept_ra:
-  sysctl.present:
-    - name: net.ipv6.conf.default.accept_ra
-    - value: 0
-
-{# disable/enable is just a trick make accept_ra work #}
-disable_ipv6_all:
-  sysctl.present:
-    - name: net.ipv6.conf.all.disable_ipv6
-    - value: 1
-
-enable_ipv6_all:
+ipv6_enable_all:
   sysctl.present:
     - name: net.ipv6.conf.all.disable_ipv6
     - value: 0
+
+{# net.ipv6.conf.all.accept_ra cannot be used, we have to proceed one interface at a time #}
+{% set ifaces = grains.get('ip6_interfaces').keys() %}
+
+{% if grains.get('ipv6')['accept_ra'] | default('1') == '1' %}
+
+{% for iface in ifaces %}
+ipv6_accept_ra_{{ iface }}:
+  sysctl.present:
+    - name: net.ipv6.conf.{{ iface }}.accept_ra
+    - value: 2
+{% endfor %}
 
 {% else %}
 
-enable_ipv6_accept_ra:
+{% for iface in ifaces %}
+ipv6_reject_ra_{{ iface }}:
   sysctl.present:
-    - name: net.ipv6.conf.default.accept_ra
-    - value: 1
-
-{# disable/enable is just a trick make accept_ra work #}
-disable_ipv6_all:
-  sysctl.present:
-    - name: net.ipv6.conf.all.disable_ipv6
-    - value: 1
-
-enable_ipv6_all:
-  sysctl.present:
-    - name: net.ipv6.conf.all.disable_ipv6
+    - name: net.ipv6.conf.{{ iface }}.accept_ra
     - value: 0
+
+delete_existing_dynamic_addresses_{{ iface }}:
+  cmd.run:
+    - name: |
+        for dynaddr in $(ip -6 a s dev {{ iface }} | grep 'inet6 2' | awk '{print $2}'); do
+          ip -6 a d $dynaddr dev {{ iface }}
+        done
+
+{% if grains['os'] == 'SUSE' %}
+avoid_wicked_messing_up_{{ iface }}:
+  file.replace:
+    - name: /etc/sysconfig/network/ifcfg-{{ iface }}
+    - pattern: "BOOTPROTO *= *[Dd][Hh][Cc][Pp] *$"
+    - repl: "BOOTPROTO=dhcp4"
+    - ignore_if_missing: true
+{% endif %}
+{% endfor %}
+
+{% if grains['os'] == 'Ubuntu' %}
+avoid_networkd_messing_up:
+  file.append:
+    - name: /etc/netplan/01-netcfg.yaml
+    - text: "      accept-ra: no"
+  cmd.run:
+    - name: 'netplan apply'
+{% endif %}
+
+{% endif %}
+
+{% else %}
+
+ipv6_disable_all:
+  sysctl.present:
+    - name: net.ipv6.conf.all.disable_ipv6
+    - value: 1
 
 {% endif %}

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -62,3 +62,41 @@ authorized_keys:
 {% endfor %}
     - makedirs: True
 {% endif %}
+
+{% if not grains.get('ipv6', 1) %}
+
+disable_ipv6_accept_ra:
+  sysctl.present:
+    - name: net.ipv6.conf.default.accept_ra
+    - value: 0
+
+{# disable/enable is just a trick make accept_ra work #}
+disable_ipv6_all:
+  sysctl.present:
+    - name: net.ipv6.conf.all.disable_ipv6
+    - value: 1
+
+enable_ipv6_all:
+  sysctl.present:
+    - name: net.ipv6.conf.all.disable_ipv6
+    - value: 0
+
+{% else %}
+
+enable_ipv6_accept_ra:
+  sysctl.present:
+    - name: net.ipv6.conf.default.accept_ra
+    - value: 1
+
+{# disable/enable is just a trick make accept_ra work #}
+disable_ipv6_all:
+  sysctl.present:
+    - name: net.ipv6.conf.all.disable_ipv6
+    - value: 1
+
+enable_ipv6_all:
+  sysctl.present:
+    - name: net.ipv6.conf.all.disable_ipv6
+    - value: 0
+
+{% endif %}


### PR DESCRIPTION
**Work in progress - not ready yet** 

This PR is written on top of @mcalmer 's #533 PR

The `ipv6` variable is becoming a map:
```
  type = "map"
  default = {
    enable = true
    accept_ra = true
  }
```
I hesitated with a tristate, but the map is more open to future extensions (yes, I know, YAGNI...). Feel free to disagree and find the tristate simpler, it's easy to change.

As those settings are not really provider-specific, I ported them to openstack as well.

The results go to `/etc/sysctl.d/99-salt.conf`:
```
net.ipv6.conf.lo.accept_ra = 0
net.ipv6.conf.eth0.accept_ra = 0
net.ipv6.conf.eth1.accept_ra = 0
net.ipv6.conf.all.disable_ipv6 = 1
```

When disabling RAs:
 - existing dynamic addresses are removed (otherwise, they time out only after a delay that is too long);
 - we also make sure that the network manager does not destroy our efforts: wicked on SLE, networkd on Ubuntu.

**The documentation and examples are still missing**
