### PR TITLE
Use apt-mirror to mirror Ubuntu repos

### DIFF
--- a/modules/aws/mirror/main.tf
+++ b/modules/aws/mirror/main.tf
@@ -81,6 +81,7 @@ authorized_keys: null
 additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 reset_ids: true
+ubuntu_distros: [${join(", ", formatlist("'%s'", var.ubuntu_distros))}]
 
 EOF
 

--- a/modules/aws/mirror/variables.tf
+++ b/modules/aws/mirror/variables.tf
@@ -72,3 +72,8 @@ variable "name_prefix" {
   description = "A prefix for names of objects created by this module"
   default = "sumaform"
 }
+
+variable "ubuntu_distros" {
+  description = "List of Ubuntu versions to mirror among 16.04, 18.04, xenial, bionic"
+  default = []
+}

--- a/modules/libvirt/README.md
+++ b/modules/libvirt/README.md
@@ -72,6 +72,18 @@ Note you are encouraged to specify an additional libvirt storage pool name (`dat
 
 Omitting the `data_pool` variable results in the default "default" storage pool being used.
 
+The `mirror` can also synchronize Ubuntu official repositories.
+To enable mirroring Ubuntu versions add the corresponding version numbers to the `ubuntu_distros` variable as follows:
+
+```hcl
+module "mirror" {
+  source = "./modules/libvirt/mirror"
+  base_configuration = "${module.base.configuration}"
+
+  ubuntu_distros = ['16.04', '18.04']
+}
+```
+
 Note that `mirror` must be populated before any host can be deployed - by default its cache is refreshed nightly via `cron`, you can also schedule a one-time refresh via the `/root/mirror.sh` script.
 
 ## Customize virtual hardware

--- a/modules/libvirt/mirror/main.tf
+++ b/modules/libvirt/mirror/main.tf
@@ -22,6 +22,7 @@ role: mirror
 cc_username: ${var.base_configuration["cc_username"]}
 cc_password: ${var.base_configuration["cc_password"]}
 data_disk_device: vdb
+ubuntu_distros: [${join(", ", formatlist("'%s'", var.ubuntu_distros))}]
 
 EOF
 

--- a/modules/libvirt/mirror/variables.tf
+++ b/modules/libvirt/mirror/variables.tf
@@ -24,6 +24,11 @@ variable "ssh_key_path" {
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }
 
+variable "ubuntu_distros" {
+  description = "List of Ubuntu versions to mirror among 16.04, 18.04, xenial, bionic"
+  default = []
+}
+
 // Provider-specific variables
 
 variable "running" {

--- a/modules/openstack/mirror/main.tf
+++ b/modules/openstack/mirror/main.tf
@@ -13,6 +13,7 @@ role: mirror
 cc_username: ${var.base_configuration["cc_username"]}
 cc_password: ${var.base_configuration["cc_password"]}
 data_disk_device: vdb
+ubuntu_distros: [${join(", ", formatlist("'%s'", var.ubuntu_distros))}]
 
 EOF
 

--- a/modules/openstack/mirror/variables.tf
+++ b/modules/openstack/mirror/variables.tf
@@ -24,6 +24,11 @@ variable "ssh_key_path" {
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }
 
+variable "ubuntu_distros" {
+  description = "List of Ubuntu versions to mirror among 16.04, 18.04, xenial, bionic"
+  default = []
+}
+
 // Provider-specific variables
 
 variable "floating_ips" {

--- a/salt/mirror/apt-mirror.list
+++ b/salt/mirror/apt-mirror.list
@@ -1,0 +1,20 @@
+
+set mirror_path    /srv/mirror/
+set defaultarch    amd64
+set nthreads       20
+
+##
+## Sources
+##
+
+{% set ubuntu_names = {'16.04': 'xenial', '18.04': 'bionic'} %}
+
+{% for distro in grains['ubuntu_distros']|default([], true) %}
+{% set distro_name = ubuntu_names.get(distro, distro) %}
+deb http://archive.ubuntu.com/ubuntu {{distro_name}} main
+deb http://archive.ubuntu.com/ubuntu {{distro_name}}-updates main
+deb http://archive.ubuntu.com/ubuntu {{distro_name}}-security main
+
+{% endfor %}
+
+clean http://archive.ubuntu.com/ubuntu

--- a/salt/mirror/init.sls
+++ b/salt/mirror/init.sls
@@ -40,6 +40,17 @@ scc_data_refresh_script:
     - source: salt://mirror/refresh_scc_data.py
     - mode: 755
 
+apt-mirror:
+  pkg.installed:
+    - require:
+      - sls: default
+  file.managed:
+    - name: /etc/apt-mirror.list
+    - source: salt://mirror/apt-mirror.list
+    - template: jinja
+    - require:
+      - pkg: apt-mirror
+
 mirror_script:
   file.managed:
     - name: /root/mirror.sh

--- a/salt/mirror/init.sls
+++ b/salt/mirror/init.sls
@@ -78,6 +78,8 @@ mirror_directory:
     - group: users
     - mode: 755
     - makedirs: True
+    - require:
+      - pkg: apache2
   mount.mounted:
     - name: /srv/mirror
     - device: /dev/{{grains['data_disk_device']}}1
@@ -121,6 +123,8 @@ exports_file:
 rpcbind:
   service.running:
     - enable: True
+    - require:
+      - pkg: nfs_kernel_support
 
 nfs_kernel_support:
   pkg.installed:

--- a/salt/mirror/mirror.sh
+++ b/salt/mirror/mirror.sh
@@ -6,4 +6,6 @@ cd /srv/mirror
 minima -c /root/minima.yaml sync 2>&1 | tee /var/log/minima.log
 /root/refresh_scc_data.py {{ grains.get("cc_username") }}:{{ grains.get("cc_password") }}
 
+apt-mirror
+
 chmod -R 777 .

--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -8,6 +8,7 @@ include:
   - repos.suse_manager_server
   - repos.testsuite
   - repos.virthost
+  - repos.mirror
 
 {% if grains['os'] == 'SUSE' %}
 

--- a/salt/repos/mirror.sls
+++ b/salt/repos/mirror.sls
@@ -1,0 +1,11 @@
+{% if grains.get('role') == 'mirror' %}
+
+# We need that repository for apt-mirror
+tools_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/systemsmanagement-sumaform-tools.repo
+    - source: salt://repos/repos.d/systemsmanagement-sumaform-tools.repo
+    - template: jinja
+
+{% endif %}
+


### PR DESCRIPTION
To enable cloning the Ubuntu repositories, edit the apt-mirror.list
file.