### PR TITLE
Feat: enable Ubuntu Manager Tools by product ver

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -401,22 +401,16 @@ tools_update_repo:
     - file: /etc/apt/sources.list.d/Ubuntu1804-Client-Tools.list
 {% if 'head' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
-    - name: deb {{ tools_repo_url }} /
-    - key_url: {{ tools_repo_url }}/Release.key
 {% elif '4.0' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
-    - name: deb {{ tools_repo_url }} /
-    - key_url: {{ tools_repo_url }}/Release.key
 {% elif '3.2' in grains.get('product_version') | default('', true) %}
 # We only have one shared Client Tools repository, so we are using 4.0 even for 3.2
 {% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
-    - name: deb {{ tools_repo_url }} /
-    - key_url: {{ tools_repo_url }}/Release.key
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu1804-Uyuni-Client-Tools/xUbuntu_18.04' %}
+{% endif %}
     - name: deb {{ tools_repo_url }} /
     - key_url: {{ tools_repo_url }}/Release.key
-{% endif %}
 
 tools_update_repo_raised_priority:
   file.append:

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -395,6 +395,29 @@ disable_apt_daily_upgrade_service:
 disable_apt_daily_wait:
   cmd.run:
     - name: systemd-run --property="After=apt-daily.service apt-daily-upgrade.service" --wait /bin/true
+
+tools_update_repo:
+  pkgrepo.managed:
+    - file: /etc/apt/sources.list.d/Ubuntu18.04-SUSE-Manager-Tools.list
+{% if 'head' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
+    - name: deb {{ tools_repo_url }} /
+    - key_url: {{ tools_repo_url }}/Release.key
+{% elif '4.0' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
+    - name: deb {{ tools_repo_url }} /
+    - key_url: {{ tools_repo_url }}/Release.key
+{% elif '3.2' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
+    - name: deb {{ tools_repo_url }} /
+    - key_url: {{ tools_repo_url }}/Release.key
+{% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu1804-Uyuni-Client-Tools/xUbuntu_18.04' %}
+    - name: deb {{ tools_repo_url }} /
+    - key_url: {{ tools_repo_url }}/Release.key
+    - file: /etc/apt/sources.list.d/Ubuntu1804-Uyuni-Client-Tools.list
+{% endif %}
+
 {% endif %}
 
 {% if grains['additional_repos'] %}

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -408,6 +408,8 @@ tools_update_repo:
 {% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu1804-Uyuni-Client-Tools/xUbuntu_18.04' %}
+{% elif 'uyuni-released' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu1804-Uyuni-Client-Tools/xUbuntu_18.04' %}
 {% endif %}
     - name: deb {{ tools_repo_url }} /
     - key_url: {{ tools_repo_url }}/Release.key
@@ -437,6 +439,11 @@ tools_update_repo_raised_priority:
     - text: |
             Package: *
             Pin: release l=systemsmanagement:Uyuni:Master:Ubuntu1804-Uyuni-Client-Tools
+            Pin-Priority: 800
+{% elif 'uyuni-released' in grains.get('product_version') | default('', true) %}
+    - text: |
+            Package: *
+            Pin: release l=systemsmanagement:Uyuni:Stable:Ubuntu1804-Uyuni-Client-Tools
             Pin-Priority: 800
 {% endif %}
 {% endif %}

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -409,8 +409,7 @@ tools_update_repo:
     - key_url: {{ tools_repo_url }}/Release.key
 {% elif '3.2' in grains.get('product_version') | default('', true) %}
 # We only have one shared Client Tools repository, so we are using 4.0 even for 3.2
-# TODO: HEAD _MUST_ be changed to 4.0 as soon as 4.0 Client Tools are released
-{% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
+{% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
     - name: deb {{ tools_repo_url }} /
     - key_url: {{ tools_repo_url }}/Release.key
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
@@ -435,10 +434,10 @@ tools_update_repo_raised_priority:
             Pin: release l=Devel:Galaxy:Manager:4.0:Ubuntu18.04-SUSE-Manager-Tools
             Pin-Priority: 800
 {% elif '3.2' in grains.get('product_version') | default('', true) %}
-# TODO: Pin _MUST_ be changed to 4.0 as soon as 4.0 Client Tools are released.
+# We only have one shared Client Tools repository, so we are using 4.0 even for 3.2
     - text: |
             Package: *
-            Pin: release l=Devel:Galaxy:Manager:Head:Ubuntu18.04-SUSE-Manager-Tools
+            Pin: release l=Devel:Galaxy:Manager:4.0:Ubuntu18.04-SUSE-Manager-Tools
             Pin-Priority: 800
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
     - text: |

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -408,7 +408,8 @@ tools_update_repo:
     - name: deb {{ tools_repo_url }} /
     - key_url: {{ tools_repo_url }}/Release.key
 {% elif '3.2' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
+# The client tools are common for all versions of SUSE Manager: that is why you see 4.0 instead of 3.2 in the following line
+{% set tools_repo_url = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04' %}
     - name: deb {{ tools_repo_url }} /
     - key_url: {{ tools_repo_url }}/Release.key
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}


### PR DESCRIPTION
Automatically add Ubuntu client tools based on the `product_version` specified in minion configuration.
This is useful to remove `additional_repos` to manually specify Ubuntu client tools.

Fix https://github.com/SUSE/spacewalk/issues/7888