### PR TITLE
Add 4.0 and fix release notes for Head

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -9,13 +9,15 @@ Some modules have a `product_version` variable that determines the software prod
 Legal values for released software are:
  * `3.0-released`   (latest released Maintenance Update for SUSE Manager 3.0 and Tools)
  * `3.1-released`   (latest released Maintenance Update for SUSE Manager 3.1 and Tools)
- * `3.2-released`   (latest released alpha/beta/gold master candidate for SUSE Manager 3.2 and Tools)
+ * `3.2-released`   (latest released Maintenance Update for SUSE Manager 3.2 and Tools)
+ * `4.0-released`   (latest released Maintenance Update for SUSE Manager 4.0 and Tools)
  * `uyuni-released` (latest released version for Uyuni Server and Proxy, from systemsmanagement:Uyuni:Stable, for Tools use `head`)
 
 Legal values for work-in-progress software are:
  * `3.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:3.0)
  * `3.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:3.1)
  * `3.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:3.2)
+ * `4.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.0)
  * `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head if OS is SLE12 or systemsmanagement:Uyuni:Master otherwise)
  * `test` (corresponds to the Build Service project Devel:Galaxy:Manager:TEST or a user-defined repo, see below)
 

--- a/modules/aws/host/variables.tf
+++ b/modules/aws/host/variables.tf
@@ -64,7 +64,7 @@ variable "name_prefix" {
 }
 
 variable "product_version" {
-  description = "Main product version (eg. 3.2-released, 3.2-nightly, 3.1-nightly, head)"
+  description = "Main product version (eg. 4.0-released, 4.0-nightly, 3.2-released, 3.2-nightly, 3.1-nightly, head)"
   default = "null"
 }
 

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -6,6 +6,8 @@ variable "testsuite-branch" {
     "3.1-nightly" = "Manager-3.1"
     "3.2-released" = "Manager-3.2"
     "3.2-nightly" = "Manager-3.2"
+    "4.0-released" = "Manager-4.0"
+    "4.0-nightly" = "Manager-4.0"
     "head" = "master"
     "test" = "master"
     "uyuni-released" = "master"

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -6,6 +6,8 @@ variable "images" {
     "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
+    "4.0-released" = "sles15sp1"
+    "4.0-nightly" = "sles15sp1"
     "head" = "sles15sp1"
     "test" = "sles15sp1"
     "uyuni-released" = "opensuse423"

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-nightly, 3.2-released, head, test, uyuni-released"
+  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, head, test, uyuni-released"
   type = "string"
 }
 

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -6,6 +6,8 @@ variable "images" {
     "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
+    "4.0-released" = "sles15sp1"
+    "4.0-nightly" = "sles15sp1"
     "head" = "sles15sp1"
     "uyuni-released" = "opensuse423"
   }

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-released, 3.2-nightly, head"
+  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, head"
   type = "string"
 }
 

--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -6,6 +6,8 @@ variable "testsuite-branch" {
     "3.1-nightly" = "Manager-3.1"
     "3.2-released" = "Manager-3.2"
     "3.2-nightly" = "Manager-3.2"
+    "4.0-released" = "Manager-4.0"
+    "4.0-nightly" = "Manager-4.0"
     "head" = "master"
     "test" = "master"
     "uyuni-released" = "master"

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -6,6 +6,8 @@ variable "images" {
     "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
+    "4.0-released" = "sles15sp1"
+    "4.0-nightly" = "sles15sp1"
     "head" = "sles15sp1"
     "test" = "sles15sp1"
     "uyuni-released" = "opensuse423"

--- a/modules/openstack/suse_manager/variables.tf
+++ b/modules/openstack/suse_manager/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-nightly, 3.2-released, head, test"
+  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, head, test"
   type = "string"
 }
 

--- a/modules/openstack/suse_manager_proxy/main.tf
+++ b/modules/openstack/suse_manager_proxy/main.tf
@@ -6,6 +6,8 @@ variable "images" {
     "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
+    "4.0-released" = "sles15sp1"
+    "4.0-nightly" = "sles15sp1"
     "head" = "sles15sp1"
     "uyuni-released" = "opensuse423"
   }

--- a/modules/openstack/suse_manager_proxy/variables.tf
+++ b/modules/openstack/suse_manager_proxy/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-released, 3.2-nightly, head"
+  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, head"
   type = "string"
 }
 

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -56,6 +56,10 @@ scc:
     - SUSE-Manager-Server-3.1-Updates
     - SUSE-Manager-Server-3.2-Pool
     - SUSE-Manager-Server-3.2-Updates
+    - SLE-Product-SUSE-Manager-Server-4.0-Pool
+    - SLE-Product-SUSE-Manager-Server-4.0-Updates
+    - SLE-Module-SUSE-Manager-Server-4.0-Pool
+    - SLE-Module-SUSE-Manager-Server-4.0-Updates
     # SUSE Manager Proxy
     - SUSE-Manager-Proxy-3.0-Pool
     - SUSE-Manager-Proxy-3.0-Updates
@@ -63,6 +67,15 @@ scc:
     - SUSE-Manager-Proxy-3.1-Updates
     - SUSE-Manager-Proxy-3.2-Pool
     - SUSE-Manager-Proxy-3.2-Updates
+    - SLE-Product-SUSE-Manager-Proxy-4.0-Pool
+    - SLE-Product-SUSE-Manager-Proxy-4.0-Updates
+    - SLE-Module-SUSE-Manager-Proxy-4.0-Pool
+    - SLE-Module-SUSE-Manager-Proxy-4.0-Updates
+    # Retail Branch Server
+    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Pool
+    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Updates
+    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-Pool
+    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-Updates
     # SUSE Manager Tools
     - SLES11-SP4-SUSE-Manager-Tools
     - SLE-Manager-Tools12-Pool
@@ -118,9 +131,13 @@ http:
   # SUSE Manager Head (SLE15-SP1)
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Server-4.0-POOL-x86_64-Media1
     archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/ToSLE/SLE_15_SP1/
+    archs: [x86_64]
 
-  # SUSE Manager Head Proxy (SLE12-SP4)
+  # SUSE Manager Head Proxy (SLE15-SP1)
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/ToSLE/SLE_15_SP1/
     archs: [x86_64]
 
   # SUSE Manager 3.0 devel
@@ -133,6 +150,12 @@ http:
 
   # SUSE Manager 3.2 devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2/SLE_12_SP3
+    archs: [x86_64]
+
+  # SUSE Manager 4.0 devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0/SLE_15_SP1
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/ToSLE/SLE_15_SP1/
     archs: [x86_64]
 
   # SLE 11 SP4 Manager Tools 3.2 devel
@@ -149,6 +172,22 @@ http:
 
   # RES 7 Manager Tools 3.2 devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
+    archs: [x86_64]
+
+  # SLE 11 SP4 Manager Tools 4.0 devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse
+    archs: [x86_64]
+
+  # SLE 12 (GA and all SPs) Manager Tools 4.0 devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1
+    archs: [x86_64]
+
+  # SLE 15 Manager Tools 4.0 devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1
+    archs: [x86_64]
+
+  # RES 7 Manager Tools 4.0 devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
     archs: [x86_64]
 
   # SUSE Manager Head devel

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -58,8 +58,8 @@ tools_pool_repo:
 
 tools_additional_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
-    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-11-x86_64.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-11-x86_64.repo
     - template: jinja
 
 {% elif 'head' in grains.get('product_version') | default('', true) %}
@@ -204,8 +204,8 @@ tools_update_repo:
 
 tools_additional_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
-    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-12-x86_64.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-12-x86_64.repo
     - template: jinja
 
 {% elif ('head' in grains.get('product_version') | default('', true)) or ('test' in grains.get('product_version') | default('', true)) %}
@@ -241,8 +241,8 @@ tools_update_repo:
 
 tools_additional_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-15-x86_64.repo
-    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-15-x86_64.repo
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-15-x86_64.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-15-x86_64.repo
     - template: jinja
 
 {% elif ('head' in grains.get('product_version') | default('', true)) or ('test' in grains.get('product_version') | default('', true)) %}
@@ -361,8 +361,8 @@ tools_update_repo:
 {% elif 'nightly' in grains.get('product_version') | default('', true) %}
 tools_update_repo:
   file.managed:
-    - name: /etc/yum.repos.d/Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-x86_64.repo
-    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-x86_64.repo
+    - name: /etc/yum.repos.d/Devel_Galaxy_Manager_4.0_RES-Manager-Tools-7-x86_64.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_4.0_RES-Manager-Tools-7-x86_64.repo
     - template: jinja
     - require:
       - cmd: galaxy_key

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_4.0.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_4.0.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_4.0]
+name=Devel Project for SUSE Manager 4.0 (SLE_15_SP1)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0/SLE_15_SP1/
+priority=96

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_4.0_RES-Manager-Tools-7-x86_64.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_4.0_RES-Manager-Tools-7-x86_64.repo
@@ -1,0 +1,5 @@
+[Devel_Galaxy_Manager_4.0_RES-Manager-Tools-7-x86_64]
+name=Devel_Galaxy_Manager_4.0_RES-Manager-Tools-7-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-11-x86_64.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-11-x86_64.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-11-x86_64]
+name=Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-11-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse/
+priority=98

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-12-x86_64.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-12-x86_64.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-12-x86_64]
+name=Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-12-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1/
+priority=98

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-15-x86_64.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-15-x86_64.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-15-x86_64]
+name=Devel_Galaxy_Manager_4.0_SLE-Manager-Tools-15-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
+priority=98

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_4.0_ToSLE.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_4.0_ToSLE.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_4.0_ToSLE]
+name=Devel Project for SUSE Manager 4.0 (packages submitted directly to SLE)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/ToSLE/SLE_15_SP1/
+priority=96

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_Head_ToSLE.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_Head_ToSLE.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_Head_ToSLE]
+name=Devel Project for SUSE Manager Head (packages submitted directly to SLE)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head:/ToSLE/SLE_15_SP1/
+priority=96

--- a/salt/repos/repos.d/SLE-15-SP1-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-15-SP1-x86_64-Pool.repo
@@ -2,5 +2,4 @@
 name=SLE-Module-Basesystem15-SP1-x86_64-Pool
 type=rpm-md
 enabled=1
-#baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Basesystem-POOL-x86_64-Media1/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/

--- a/salt/repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Pool.repo
@@ -2,5 +2,4 @@
 name=SLE-Module-Python2-SLE-15-SP1-x86_64-Pool
 type=rpm-md
 enabled=1
-#baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Python2-POOL-x86_64-Media1/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/

--- a/salt/repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Update.repo
+++ b/salt/repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SLE-Module-Python2-SLE-15-SP1-x86_64-Update]
+name=SLE-Module-Python2-SLE-15-SP1-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/

--- a/salt/repos/repos.d/SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Pool.repo
@@ -1,0 +1,5 @@
+[SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Pool]
+name=SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Proxy/4.0/x86_64/product/

--- a/salt/repos/repos.d/SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Update.repo
+++ b/salt/repos/repos.d/SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Update]
+name=SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Proxy/4.0/x86_64/update/

--- a/salt/repos/repos.d/SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Pool.repo
@@ -1,0 +1,5 @@
+[SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Pool]
+name=SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Retail-Branch-Server/4.0/x86_64/

--- a/salt/repos/repos.d/SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Update.repo
+++ b/salt/repos/repos.d/SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Update]
+name=SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Retail-Branch-Server/4.0/x86_64/

--- a/salt/repos/repos.d/SLE-Module-SUSE-Manager-Server-4.0-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Module-SUSE-Manager-Server-4.0-x86_64-Pool.repo
@@ -1,0 +1,5 @@
+[SLE-Module-SUSE-Manager-Server-4.0-x86_64-Pool]
+name=SLE-Module-SUSE-Manager-Server-4.0-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Server/4.0/x86_64/product/

--- a/salt/repos/repos.d/SLE-Module-SUSE-Manager-Server-4.0-x86_64-Update.repo
+++ b/salt/repos/repos.d/SLE-Module-SUSE-Manager-Server-4.0-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SLE-Module-SUSE-Manager-Server-4.0-x86_64-Update]
+name=SLE-Module-SUSE-Manager-Server-4.0-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Server/4.0/x86_64/update/

--- a/salt/repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool.repo
@@ -2,5 +2,4 @@
 name=SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool
 type=rpm-md
 enabled=1
-#baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Server-Applications-POOL-x86_64-Media1/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/

--- a/salt/repos/repos.d/SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Pool.repo
@@ -2,5 +2,4 @@
 name=SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Pool
 type=rpm-md
 enabled=1
-#baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product/
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Web-Scripting-POOL-x86_64-Media1/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product/

--- a/salt/repos/repos.d/SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Pool.repo
@@ -1,0 +1,5 @@
+[SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Pool]
+name=SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Proxy/4.0/x86_64/product/

--- a/salt/repos/repos.d/SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Update.repo
+++ b/salt/repos/repos.d/SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Update]
+name=SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Proxy/4.0/x86_64/update/

--- a/salt/repos/repos.d/SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Pool.repo
@@ -1,0 +1,5 @@
+[SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Pool]
+name=SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Retail-Branch-Server/4.0/x86_64/product/

--- a/salt/repos/repos.d/SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Update.repo
+++ b/salt/repos/repos.d/SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Update]
+name=SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Retail-Branch-Server/4.0/x86_64/update/

--- a/salt/repos/repos.d/SLE-Product-SUSE-Manager-Server-4.0-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Product-SUSE-Manager-Server-4.0-x86_64-Pool.repo
@@ -1,0 +1,5 @@
+[SLE-Product-SUSE-Manager-Server-4.0-x86_64-Pool]
+name=SLE-Product-SUSE-Manager-Server-4.0-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.0/x86_64/product/

--- a/salt/repos/repos.d/SLE-Product-SUSE-Manager-Server-4.0-x86_64-Update.repo
+++ b/salt/repos/repos.d/SLE-Product-SUSE-Manager-Server-4.0-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SLE-Product-SUSE-Manager-Server-4.0-x86_64-Update]
+name=SLE-Product-SUSE-Manager-Server-4.0-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Server/4.0/x86_64/update/

--- a/salt/repos/repos.d/SUSE-Manager-4.0-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SUSE-Manager-4.0-x86_64-Pool.repo
@@ -1,0 +1,6 @@
+[SUSE-Manager-4.0-x86_64-Pool]
+name=SUSE-Manager-4.0-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.0/x86_64/product/
+priority=97

--- a/salt/repos/repos.d/SUSE-Manager-Proxy-4.0-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SUSE-Manager-Proxy-4.0-x86_64-Pool.repo
@@ -1,0 +1,6 @@
+[SUSE-Manager-Proxy-4.0-x86_64-Pool]
+name=SUSE-Manager-Proxy-4.0-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0/images/repo/SLE-Module-SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1/
+priority=97

--- a/salt/repos/suse_manager_proxy.sls
+++ b/salt/repos/suse_manager_proxy.sls
@@ -42,6 +42,44 @@ suse_manager_proxy_update_repo:
     - template: jinja
 {% endif %}
 
+{% if '4.0' in grains['product_version'] %}
+suse_manager_proxy_product_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Pool.repo
+    - source: salt://repos/repos.d/SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Pool.repo
+    - template: jinja
+
+suse_manager_proxy_product_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Update.repo
+    - source: salt://repos/repos.d/SLE-Product-SUSE-Manager-Proxy-4.0-x86_64-Update.repo
+    - template: jinja
+
+suse_manager_proxy_module_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Pool.repo
+    - template: jinja
+
+suse_manager_proxy_module_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Update.repo
+    - source: salt://repos/repos.d/SLE-Module-SUSE-Manager-Proxy-4.0-x86_64-Update.repo
+    - template: jinja
+
+module_server_applications_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Server_Applications_Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool.repo
+    - template: jinja
+
+module_server_applications_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Server_Applications_Update.repo
+    - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Update.repo
+    - template: jinja
+{% endif %}
+
 {% if 'uyuni-released' in grains['product_version'] %}
 suse_manager_proxy_pool_repo:
   file.managed:
@@ -61,6 +99,14 @@ suse_manager_proxy_pool_repo:
     - source: salt://repos/repos.d/SUSE-Manager-Proxy-Head-x86_64-Pool.repo
     {% endif %}
     - template: jinja
+
+{% if grains['osfullname'] != 'Leap' %}
+suse_manager_devel_releasenotes_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_ToSLE.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_Head_ToSLE.repo
+    - template: jinja
+{% endif %}
 
 suse_manager_devel_repo:
   file.managed:
@@ -110,6 +156,20 @@ suse_manager_devel_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2.repo
     - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.2.repo
+    - template: jinja
+{% endif %}
+
+{% if '4.0-nightly' in grains['product_version'] %}
+suse_manager_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_4.0.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_4.0.repo
+    - template: jinja
+
+suse_manager_devel_releasenotes_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_4.0_ToSLE.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_4.0_ToSLE.repo
     - template: jinja
 {% endif %}
 

--- a/salt/repos/suse_manager_server.sls
+++ b/salt/repos/suse_manager_server.sls
@@ -42,6 +42,68 @@ suse_manager_update_repo:
     - template: jinja
 {% endif %}
 
+{% if '4.0' in grains['product_version'] %}
+suse_manager_server_product_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-Product-SUSE-Manager-Server-4.0-x86_64-Pool.repo
+    - source: salt://repos/repos.d/SLE-Product-SUSE-Manager-Server-4.0-x86_64-Pool.repo
+    - template: jinja
+
+suse_manager_server_product_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-Product-SUSE-Manager-Server-4.0-x86_64-Update.repo
+    - source: salt://repos/repos.d/SLE-Product-SUSE-Manager-Server-4.0-x86_64-Update.repo
+    - template: jinja
+
+suse_manager_server_module_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-Module-SUSE-Manager-Server-4.0-x86_64-Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-SUSE-Manager-Server-4.0-x86_64-Pool.repo
+    - template: jinja
+
+suse_manager_server_module_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-Module-SUSE-Manager-Server-4.0-x86_64-Update.repo
+    - source: salt://repos/repos.d/SLE-Module-SUSE-Manager-Server-4.0-x86_64-Update.repo
+    - template: jinja
+
+module_server_applications_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Server_Applications_Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool.repo
+    - template: jinja
+
+module_server_applications_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Server_Applications_Update.repo
+    - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Update.repo
+    - template: jinja
+
+module_web_scripting_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Web_Scripting_Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Pool.repo
+    - template: jinja
+
+module_web_scripting_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Web_Scripting_Update.repo
+    - source: salt://repos/repos.d/SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Update.repo
+    - template: jinja
+
+module_python2_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Python2_Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Pool.repo
+    - template: jinja
+
+module_python2_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Python2_Update.repo
+    - source: salt://repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Update.repo
+    - template: jinja
+{% endif %}
+
 {% if 'uyuni-released' in grains['product_version'] %}
 suse_manager_pool_repo:
   file.managed:
@@ -61,6 +123,14 @@ suse_manager_pool_repo:
     - source: salt://repos/repos.d/SUSE-Manager-Head-x86_64-Pool.repo
     {% endif %}
     - template: jinja
+
+{% if grains['osfullname'] != 'Leap' %}
+suse_manager_devel_releasenotes_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_ToSLE.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_Head_ToSLE.repo
+    - template: jinja
+{% endif %}
 
 suse_manager_devel_repo:
   file.managed:
@@ -103,6 +173,12 @@ module_python2_pool_repo:
     - name: /etc/zypp/repos.d/Module_Python2_Pool.repo
     - source: salt://repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Pool.repo
     - template: jinja
+
+module_python2_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Python2_Update.repo
+    - source: salt://repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Update.repo
+    - template: jinja
 {% endif %}
 {% endif %}
 
@@ -127,6 +203,20 @@ suse_manager_devel_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2.repo
     - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.2.repo
+    - template: jinja
+{% endif %}
+
+{% if '4.0-nightly' in grains['product_version'] %}
+suse_manager_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_4.0.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_4.0.repo
+    - template: jinja
+
+suse_manager_devel_releasenotes_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_4.0_ToSLE.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_4.0_ToSLE.repo
     - template: jinja
 {% endif %}
 

--- a/salt/suse_manager_proxy/config-answers.txt
+++ b/salt/suse_manager_proxy/config-answers.txt
@@ -4,8 +4,10 @@ HTTP_PROXY=''
 VERSION='3.0'
 {% elif '3.1' in grains['product_version'] %}
 VERSION='3.1'
+{% elif '3.2' in grains['product_version'] %}
+VERSION='3.2
 {% else %}
-VERSION='3.2'
+VERSION='4.0'
 {% endif %}
 TRACEBACK_EMAIL=''
 USE_SSL=Y/n


### PR DESCRIPTION
- Add 4.0 everywhere for nightlies and released, for server, proxy, and client tools, and retail product and module for the future.
- Add the ToSLE Head subproject, wich contains now the release notes. We have then on a separate project to make the submissions easier, as release-notes are to be submitted directly to SLE.

Verify:
- [x] 4.0-nightly, without mirror
- [x] 4.0-released, without mirror
- [x] 4.0-nightly, with mirror
- [x] 4.0-released, with mirror