### PR TITLE
Workaround for bsc#1108218 not needed anymore

### DIFF
--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -43,7 +43,7 @@ kvm_host: ${var.kvmhost_configuration["hostname"]}
 pxeboot_mac: ${var.pxeboot_configuration["macaddr"]}
 role: controller
 branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["product_version"]) : var.branch}
-git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#master:testsuite/features/profiles" : var.git_profiles_repo}
+git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo}
 server_http_proxy: ${var.server_http_proxy}
 
 EOF

--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -39,7 +39,7 @@ ubuntu_minion: ${var.ubuntu_configuration["hostname"]}
 ssh_minion: ${var.minionssh_configuration["hostname"]}
 role: controller
 branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["product_version"]) : var.branch}
-git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#master:testsuite/features/profiles" : var.git_profiles_repo}
+git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo}
 server_http_proxy: ${var.server_http_proxy}
 
 EOF


### PR DESCRIPTION
It's not needed anymore to specify the branch when building OS image. This PR uses the URL form shared with Docker.
