### PR TITLE
Fix taskomatic debug parameters after getting rid of Tanuki wrapper

### DIFF
--- a/salt/suse_manager_server/taskomatic.sls
+++ b/salt/suse_manager_server/taskomatic.sls
@@ -18,7 +18,7 @@ taskomatic_config:
   file.replace:
     - name: /etc/rhn/taskomatic.conf
     - pattern: JAVA_OPTS="
-    - repl: JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=n -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ salt['network.interfaces']()['eth0']['inet'][0]['address'] }}
+    - repl: JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['fqdn'] }}:8001,server=y,suspend=n -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['fqdn'] }}
 {% endif %}
     - require:
       - sls: suse_manager_server.rhn


### PR DESCRIPTION
This was addressed here https://github.com/uyuni-project/sumaform/commit/b833c7f8de3f7a1494ff0911c78770be99ec60e5, but it's not possible to connect the debugger to taskomatic.

This address the problem.