### PR TITLE
Fix parsing of Host module in openstack

### DIFF
--- a/modules/openstack/host/main.tf
+++ b/modules/openstack/host/main.tf
@@ -111,7 +111,7 @@ swap_file_size: ${var.swap_file_size}
 authorized_keys: [${trimspace(file(var.base_configuration["ssh_key_path"]))},${trimspace(file(var.ssh_key_path))}]
 gpg_keys: [${join(", ", formatlist("'%s'", var.gpg_keys))}]
 reset_ids: true
-ipv6: ${${join(", ", formatlist("'%s': '%s'", keys(var.ipv6), values(var.ipv6)))}}
+ipv6: {${join(", ", formatlist("'%s': '%s'", keys(var.ipv6), values(var.ipv6)))}}
 ${var.grains}
 
 EOF


### PR DESCRIPTION
Fix parsing of Host module in openstack.

This produces the following error when parsing the openstack/host/main.tf file:

Error: Error loading /home/juliogonzalez/Documents/development/git/suse/sumaform/modules/openstack/host/main.tf: Error reading provisioners for null_resource[host_salt_configuration]: parse error at 15:9: expected expression but found invalid sequence "$"