### PR TITLE
Fix systemd-detect-virt to return 1

### DIFF
--- a/salt/virthost/systemd-detect-virt
+++ b/salt/virthost/systemd-detect-virt
@@ -1,3 +1,4 @@
 #!/bin/sh
 
 echo "none"
+exit 1


### PR DESCRIPTION
So we can fully reproduce exactly the same results we would get on a non-virtual instance:
```
juliogonzalez@juliogonzalez:~$ /usr/bin/systemd-detect-virt 
none
juliogonzalez@juliogonzalez:~$ echo $?
1
```
(until now we were returning 0)