### PR TITLE
Fix grains variable to work for host

### DIFF
--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -99,7 +99,7 @@ connect_to_base_network: ${var.connect_to_base_network}
 connect_to_additional_network: ${var.connect_to_additional_network}
 reset_ids: true
 ipv6: {${join(", ", formatlist("'%s': '%s'", keys(var.ipv6), values(var.ipv6)))}}
-${var.grains}
+grains: ${var.grains}
 
 EOF
 


### PR DESCRIPTION
Before it wasn't working because the definition wasn't there. I tested with a custom grain now and it is applied. It's still a string only, I will see if I can make it a list later.