### PR TITLE
Fix baseproduct for SUSE Manager 4

### DIFF
--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -35,6 +35,15 @@ suse_manager_packages:
       - sls: repos
       - sls: suse_manager_server.firewall
 
+{% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' %}
+baseproduct_link:
+  file.symlink:
+    - name: /etc/products.d/baseproduct
+    - target: SUSE-Manager-Server.prod
+    - require:
+      - pkg: suse_manager_packages
+{% endif %}
+
 environment_setup_script:
   file.managed:
     - name: /root/setup_env.sh


### PR DESCRIPTION
The `/etc/products.d/baseproduct` symlink was not set correctly.

@mcalmer this is also true for Uyuni, right?