### PR TITLE
virthost: export chassis manufacturer using QEMU args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial 
 sudo: false
 language: python
 python:
@@ -7,8 +7,8 @@ python:
 addons:
   apt:
     sources:
-      - sourceline: 'deb http://repo.saltstack.com/apt/ubuntu/14.04/amd64/latest trusty main'
-        key_url: 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/latest/SALTSTACK-GPG-KEY.pub'
+      - sourceline: 'deb http://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest xenial main'
+        key_url: 'https://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest/SALTSTACK-GPG-KEY.pub'
     packages:
       - salt-common
       - rpm2cpio

--- a/modules/libvirt/virthost/sysinfos.xsl
+++ b/modules/libvirt/virthost/sysinfos.xsl
@@ -28,12 +28,6 @@
           <xsl:text>SUSE</xsl:text>
         </xsl:element>
       </xsl:element>
-      <xsl:element name="chassis">
-        <xsl:element name="entry">
-          <xsl:attribute name="name">manufacturer</xsl:attribute>
-          <xsl:text>SUSE</xsl:text>
-        </xsl:element>
-      </xsl:element>
     </xsl:element>
     <!-- DMI types 4 and 17 aren't affected by the smbios config, use qemu args to change them -->
     <xsl:element name="commandline" namespace="http://libvirt.org/schemas/domain/qemu/1.0">
@@ -48,6 +42,12 @@
       </xsl:element>
       <xsl:element name="arg" namespace="http://libvirt.org/schemas/domain/qemu/1.0">
         <xsl:attribute name="value">type=4,manufacturer=SUSE</xsl:attribute>
+      </xsl:element>
+      <xsl:element name="arg" namespace="http://libvirt.org/schemas/domain/qemu/1.0">
+        <xsl:attribute name="value">-smbios</xsl:attribute>
+      </xsl:element>
+      <xsl:element name="arg" namespace="http://libvirt.org/schemas/domain/qemu/1.0">
+        <xsl:attribute name="value">type=3,manufacturer=SUSE</xsl:attribute>
       </xsl:element>
     </xsl:element>
     <xsl:element name="os">


### PR DESCRIPTION
Since the sysinfo/chassis configuration element has been introduced in
libvirt 4.1.0 and we may test with older releases, set the chassis using
qemu arguments directly.

Fixes SUSE/spacewalk#8942