### PR TITLE
Disable ipv6 in config files when disabled by user

### DIFF
--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -26,6 +26,16 @@ avahi_restrict_interfaces:
     - require:
       - pkg: avahi_pkg
 
+{% if grains.get('ipv6')['enable'] | default('1') != '1' %}
+avahi_disable_ipv6:
+  file.replace:
+    - name: /etc/avahi/avahi-daemon.conf
+    - pattern: "use-ipv6=yes"
+    - repl: "use-ipv6=no"
+    - require:
+      - pkg: avahi_pkg
+{% endif %}
+
 mdns_declare_domains:
   file.append:
     - name: /etc/mdns.allow

--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -38,7 +38,11 @@ legacy_permanent_hostname:
 hosts_file_hack:
   cmd.script:
     - name: salt://default/set_ip_in_etc_hosts.py.jinja
+    {% if grains.get('ipv6')['enable'] | default('1') == '1' %}
     - args: "{{ grains['hostname'] }} {{ grains['domain'] }}"
+    {% else %}
+    - args: "--no-ipv6 {{ grains['hostname'] }} {{ grains['domain'] }}"
+    {% endif %}
     - template: jinja
     - context:
     {% if grains.get('osmajorrelease', None)|int() == 15 %}

--- a/salt/default/set_ip_in_etc_hosts.py.jinja
+++ b/salt/default/set_ip_in_etc_hosts.py.jinja
@@ -5,12 +5,17 @@ import re
 import socket
 import subprocess
 import sys
+import optparse
 
-if len(sys.argv) != 3:
-    print("Usage: set_ip_in_etc_hosts.py <HOSTNAME> <DOMAIN>")
+parser = optparse.OptionParser()
+parser.add_option('--no-ipv6', action="store_false", dest="ipv6_is_enabled", default=True, help="do not set up IPv6 address")
+options, args = parser.parse_args()
+
+if len(args) != 2:
+    print("Usage: set_ip_in_etc_hosts.py [--no-ipv6] <HOSTNAME> <DOMAIN>")
     sys.exit(1)
 
-_, hostname, domain = sys.argv
+hostname, domain = args
 fqdn = hostname + "." + domain
 
 def guess_address(fqdn, hostname, socket_type, invalid_prefixes, default):
@@ -43,9 +48,14 @@ def update_hosts_file(fqdn, hostname, repl):
 
 update_hosts_file(fqdn, hostname, "")
 ipv4 = guess_address(fqdn, hostname, socket.AF_INET, "127\\.0\\.", "127.0.1.1")
-# we explicitly exclude link-local addresses as we currently can't get the interface names
-ipv6 = guess_address(fqdn, hostname, socket.AF_INET6, "(::1$)|(fe[89ab][0-f]:)", "# ipv6 address not found for names:")
-repl = "\n\n{0} {1} {2}\n{3} {4} {5}\n".format(ipv4, fqdn, hostname, ipv6, fqdn, hostname)
+
+if options.ipv6_is_enabled:
+    # we explicitly exclude link-local addresses as we currently can't get the interface names
+   ipv6 = guess_address(fqdn, hostname, socket.AF_INET6, "(::1$)|(fe[89ab][0-f]:)", "# ipv6 address not found for names:")
+   repl = "\n\n{0} {1} {2}\n{3} {4} {5}\n".format(ipv4, fqdn, hostname, ipv6, fqdn, hostname)
+else:
+   repl = "\n\n{0} {1} {2}\n".format(ipv4, fqdn, hostname)
+
 update_hosts_file(fqdn, hostname, repl)
 
 print("/etc/hosts updated.")


### PR DESCRIPTION
It is now possible to disable IPv6 as a whole from `main.tf`:
```
ipv6 = {
  enable = false
  (...)
}
```

On the other hand, sumaform prepares a few IPv6 settings:
 * in `/etc/hosts`
 * in `/etc/avahi/avahi-daemon.conf`

no matter whether IPv6 is enabled or not.

This PR fixes this situation.
