### PR TITLE
Change default RAM size for host, client, and minion

### DIFF
--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -65,6 +65,7 @@ module "cli-sles12sp3" {
   product_version = "3.1-nightly"
   name = "cli-sles12sp3"
   image = "sles12sp3"
+  memory = 768
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_register = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
@@ -76,6 +77,7 @@ module "min-sles12sp3" {
   product_version = "3.1-nightly"
   name = "min-sles12sp3"
   image = "sles12sp3"
+  memory = 768
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_connect_to_master = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
@@ -88,6 +90,7 @@ module "minssh-sles12sp3" {
   base_configuration = "${module.base.configuration}"
   name = "minssh-sles12sp3"
   image = "sles12sp3"
+  memory = 768
   ssh_key_path = "./salt/controller/id_rsa.pub"
   gpg_keys = ["default/gpg_keys/galaxy.key"]
 }
@@ -99,6 +102,7 @@ module "min-centos7" {
   product_version = "3.1-nightly"
   name = "min-centos7"
   image = "centos7"
+  memory = 768
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_connect_to_master = false
   ssh_key_path = "./salt/controller/id_rsa.pub"

--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -71,6 +71,7 @@ module "cli-sles12sp3" {
   product_version = "3.1-nightly"
   name = "cli-sles12sp3"
   image = "sles12sp3"
+  memory = 768
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_register = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
@@ -82,6 +83,7 @@ module "min-sles12sp3" {
   product_version = "3.1-nightly"
   name = "min-sles12sp3"
   image = "sles12sp3"
+  memory = 768
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_connect_to_master = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
@@ -94,6 +96,7 @@ module "minssh-sles12sp3" {
   base_configuration = "${module.base.configuration}"
   name = "minssh-sles12sp3"
   image = "sles12sp3"
+  memory = 768
   ssh_key_path = "./salt/controller/id_rsa.pub"
   gpg_keys = ["default/gpg_keys/galaxy.key"]
 }
@@ -105,6 +108,7 @@ module "min-centos7" {
   product_version = "3.1-nightly"
   name = "min-centos7"
   image = "centos7"
+  memory = 768
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_connect_to_master = false
   ssh_key_path = "./salt/controller/id_rsa.pub"


### PR DESCRIPTION
This PR changes the default memory size from `512 MB` to `768 MB` for generic host, client, and minion in the libvirt module.

Rationale: I noticed very bad responsiveness at the end of SLE 12 SP4 minion at end of 3.2 testsuite. Error count was 92 with 0.5 GB, mostly due to timeouts. I retested exactly same setup with 1.5 GB (yeah, not 0.75 GB like here) and saw the failure count get down to 30.

The change in this PR is rather conservative: production test suites already put 1 GB on all clients, excepted PXE boot minion.

This PR leaves unchanged the explicit setting of 512 MB in `main.tf` for the mirror.
