### PR TITLE
Use "owners" field for existing images lookup

### DIFF
--- a/main.tf.aws.example
+++ b/main.tf.aws.example
@@ -35,6 +35,9 @@ data "aws_ebs_snapshot" "data_disk_snapshot" {
 
 data "aws_ami" "opensuse422" {
   most_recent = true
+  owners = [
+    // add "self" or your AWS account ID to restrict search
+  ]
 
   filter {
     name   = "name"
@@ -44,6 +47,9 @@ data "aws_ami" "opensuse422" {
 
 data "aws_ami" "sles12sp1" {
   most_recent = true
+  owners = [
+    // add "self" or your AWS account ID to restrict search
+  ]
 
   filter {
     name   = "name"


### PR DESCRIPTION
This PR specifies the value of mandatory field `"owners"` when querying available images in the AWS example.

I used value `"amazon"`, which is okay for the community AMIs that I am using for SUSE BYOS images. I am not sure this value is okay for the sumaform images @moio has in mind.