### PR TITLE
Feat: change create_first_user exit condition

### DIFF
--- a/salt/suse_manager_server/initial_content.sls
+++ b/salt/suse_manager_server/initial_content.sls
@@ -7,7 +7,7 @@ create_first_user:
   http.wait_for_successful_query:
     - method: POST
     - name: https://localhost/rhn/newlogin/CreateFirstUser.do
-    - match: Discover a new way of managing your servers
+    - status: 200
     - data: "submitted=true&\
              orgName=SUSE&\
              login={{ grains.get('server_username') | default('admin', true) }}&\


### PR DESCRIPTION
With the new login developed in:

https://github.com/uyuni-project/uyuni/pull/564#

the page content for the login page will be rendered using JavaScript.

This means that `http.wait_for_successful_query` will never read its
exit condition, specified under `match` (because it will be rendered via
JS).

This PR changes exit condition by testing the HTTP status code received
from the server after the POST request to create the first user.

A more robust change would be:

```
-    - match: Discover a new way of managing your servers
+    - match: <script src="/javascript/manager/login/login.renderer.bundle.js
```

but it would obviously be non-compatible with older versions of the
product.