### PR TITLE
Update run-testsuite to use the new rake tasks

### DIFF
--- a/salt/controller/run-testsuite.sh
+++ b/salt/controller/run-testsuite.sh
@@ -9,7 +9,9 @@ if [ -z "$1" ]; then
 fi
 # this to run cucumber features in parallel
 if [[ $1 = "parallel" ]]; then
-   rake core
-   rake secondary_parallel
-   rake post_run
+   rake cucumber:core
+   rake parallel:init_clients
+   rake cucumber:secondary
+   rake parallel:secondary_parallelizable
+   rake cucumber:finishing
 fi


### PR DESCRIPTION
After the improvements made in the test suite to support parallel cucumber features, that script was outdated.
In fact, I'm not sure if that code was never used before :)