### PR TITLE
Support openSUSE clients for Uyuni

### DIFF
--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -10,7 +10,7 @@ variable "images" {
     "4.0-nightly" = "sles15sp1"
     "head" = "sles15sp1"
     "test" = "sles15sp1"
-    "uyuni-released" = "opensuse423"
+    "uyuni-released" = "opensuse151"
   }
 }
 

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -9,7 +9,7 @@ variable "images" {
     "4.0-released" = "sles15sp1"
     "4.0-nightly" = "sles15sp1"
     "head" = "sles15sp1"
-    "uyuni-released" = "opensuse423"
+    "uyuni-released" = "opensuse151"
   }
 }
 

--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -10,7 +10,11 @@ client_cucumber_requisites:
       - spacewalk-client-setup
       - spacewalk-check
       - spacewalk-oscap
+      {% if grains['osfullname'] == 'Leap' %}
+      - mgr-cfg-actions
+      {% else %}
       - rhncfg-actions
+      {% endif %}
       - openscap-utils
       - man
       - wget

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -24,6 +24,23 @@ os_update_repo:
     - name: /etc/zypp/repos.d/openSUSE-Leap-{{ grains['osrelease'] }}-Update.repo
     - source: salt://repos/repos.d/openSUSE-Leap-Update.repo
     - template: jinja
+
+{% if not grains.get('role') or not grains.get('role').startswith('suse_manager') %}
+{% if 'uyuni-master' in grains.get('product_version') | default('', true) %}
+tools_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/systemsmanagement_Uyuni_Master_openSUSE_Leap_15-Uyuni-Client-Tools.repo
+    - source: salt://repos/repos.d/systemsmanagement_Uyuni_Master_openSUSE_Leap_15-Uyuni-Client-Tools.repo
+    - template: jinja
+{% elif 'uyuni-released' in grains.get('product_version') | default('', true) %}
+tools_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/systemsmanagement_Uyuni_Stable_openSUSE_Leap_15-Uyuni-Client-Tools.repo
+    - source: salt://repos/repos.d/systemsmanagement_Uyuni_Stable_openSUSE_Leap_15-Uyuni-Client-Tools.repo
+    - template: jinja
+{% endif %}
+{% endif %}
+
 {% elif grains['osfullname'] == 'SLES' %}
 
 {% if grains['osrelease'] == '11.4' %}

--- a/salt/repos/repos.d/systemsmanagement_Uyuni_Master_openSUSE_Leap_15-Uyuni-Client-Tools.repo
+++ b/salt/repos/repos.d/systemsmanagement_Uyuni_Master_openSUSE_Leap_15-Uyuni-Client-Tools.repo
@@ -1,0 +1,8 @@
+[systemsmanagement_Uyuni_Master_openSUSE_Leap_15-Uyuni-Client-Tools]
+name=systemsmanagement:Uyuni:Master:openSUSE_Leap_15-Uyuni-Client-Tools (openSUSE_Leap_15.0)
+type=rpm-md
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+gpgcheck=1
+gpgkey=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+enabled=1
+priority=98

--- a/salt/repos/repos.d/systemsmanagement_Uyuni_Stable.repo
+++ b/salt/repos/repos.d/systemsmanagement_Uyuni_Stable.repo
@@ -1,6 +1,6 @@
 [systemsmanagement_Uyuni_Stable]
 name=Uyuni builds from Stable Project
 type=rpm-md
-baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_42.3/
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_15.1/
 enabled=1
 priority=96

--- a/salt/repos/repos.d/systemsmanagement_Uyuni_Stable_openSUSE_Leap_15-Uyuni-Client-Tools.repo
+++ b/salt/repos/repos.d/systemsmanagement_Uyuni_Stable_openSUSE_Leap_15-Uyuni-Client-Tools.repo
@@ -1,0 +1,8 @@
+[systemsmanagement_Uyuni_Stable_openSUSE_Leap_15-Uyuni-Client-Tools]
+name=systemsmanagement:Uyuni:Stable:openSUSE_Leap_15-Uyuni-Client-Tools (openSUSE_Leap_15.0)
+type=rpm-md
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+gpgcheck=1
+gpgkey=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+enabled=1
+priority=98


### PR DESCRIPTION
* add client tools for openSUSE
* use `mgr-cfg-actions` instead of `rhncfg-actions` for Uyuni client tools
* server is now based on 15.1 based, not on 42.3 anymore
