### PR TITLE
Feat: remove SUSE Manager 3.0 and 3.1

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -361,7 +361,7 @@ module "master" {
 
   name = "master"
   product_version = "3.2-released"
-  iss_slave = "servers.tf.local"
+  iss_slave = "slave.tf.local"
 }
 
 module "slave" {

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -7,15 +7,11 @@ Some modules have a `product_version` variable that determines the software prod
  * in `minion`, `client`, etc. `product_version` determines the SUSE Manager Tools version.
 
 Legal values for released software are:
- * `3.0-released`   (latest released Maintenance Update for SUSE Manager 3.0 and Tools)
- * `3.1-released`   (latest released Maintenance Update for SUSE Manager 3.1 and Tools)
  * `3.2-released`   (latest released Maintenance Update for SUSE Manager 3.2 and Tools)
  * `4.0-released`   (latest released Maintenance Update for SUSE Manager 4.0 and Tools)
  * `uyuni-released` (latest released version for Uyuni Server and Proxy, from systemsmanagement:Uyuni:Stable, for Tools use `head`)
 
 Legal values for work-in-progress software are:
- * `3.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:3.0)
- * `3.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:3.1)
  * `3.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:3.2)
  * `4.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.0)
  * `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head if OS is SLE12 or systemsmanagement:Uyuni:Master otherwise)
@@ -43,7 +39,7 @@ module "suma31pg" {
   base_configuration = "${module.base.configuration}"
 
   name = "suma31pg"
-  product_version = "3.1-released"
+  product_version = "3.2-released"
 }
 ```
 
@@ -150,7 +146,7 @@ module "suma3pg" {
   base_configuration = "${module.base.configuration}"
 
   name = "suma3pg"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   channels = ["sles12-sp2-pool-x86_64"]
 }
 ```
@@ -172,7 +168,7 @@ module "suma3pg" {
   base_configuration = "${module.base.configuration}"
 
   name = "suma3pg"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   channels = ["sles12-sp3-pool-x86_64", "sles12-sp3-updates-x86_64"]
   cloned_channels = "[{ channels: [sles12-sp3-pool-x86_64, sles12-sp3-updates-x86_64], prefix: cloned-2017-q1, date: 2017-03-31 }]"
 }
@@ -313,7 +309,7 @@ module "suma3pg" {
   base_configuration = "${module.base.configuration}"
 
   name = "suma3pg"
-  product_version = "3.0-nightly"
+  product_version = "3.2-nightly"
 }
 
 module "proxy" {
@@ -321,7 +317,7 @@ module "proxy" {
   base_configuration = "${module.base.configuration}"
 
   name = "proxy"
-  product_version = "3.0-nightly"
+  product_version = "3.2-nightly"
   server_configuration = "${module.suma3pg.configuration}"
 }
 
@@ -346,7 +342,7 @@ module "proxy" {
   base_configuration = "${module.base.configuration}"
 
   name = "proxy"
-  product_version = "3.0-nightly"
+  product_version = "3.2-nightly"
   server_configuration = "${module.suma3pg.configuration}"
 
   minion = false
@@ -364,7 +360,7 @@ module "master" {
   base_configuration = "${module.base.configuration}"
 
   name = "master"
-  product_version = "3.1-released"
+  product_version = "3.2-released"
   iss_slave = "suma3pgs.tf.local"
 }
 
@@ -373,7 +369,7 @@ module "slave" {
   base_configuration = "${module.base.configuration}"
 
   name = "slave"
-  product_version = "3.1-released"
+  product_version = "3.2-released"
   iss_master = "${module.master.configuration["hostname"]}"
 }
 ```
@@ -576,7 +572,7 @@ module "suma3pg" {
   base_configuration = "${module.base.configuration}"
 
   name = "suma3pg"
-  product_version = "3.0-nightly"
+  product_version = "3.2-nightly"
   smt = "http://smt.suse.de"
 }
 ```
@@ -693,7 +689,7 @@ module "suma31pg" {
   base_configuration = "${module.base.configuration}"
 
   name = "suma31pg"
-  product_version = "3.1-released"
+  product_version = "3.2-released"
   log_server = "logstash.mgr.suse.de:5045"
 }
 ```

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -34,11 +34,11 @@ module "minsles12sp1" {
   product_version = "nightly"
 }
 
-module "suma31pg" {
+module "server" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
-  name = "suma31pg"
+  name = "server"
   product_version = "3.2-released"
 }
 ```
@@ -65,12 +65,12 @@ For other modules like `suse_manager` there is a default selection if nothing is
 The following example creates a SUSE Manager server using "nightly" packages from version 3.2 based on SLES 12 SP3:
 
 ```hcl
-module "suma3pg" {
+module "server" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
   image = "sles12sp3"
-  name = "suma3pg"
+  name = "server"
   product_version = "3.2-nightly"
 }
 ```
@@ -87,12 +87,12 @@ module "minionsles12sp1" {
 
   name = "minionsles12sp1"
   image = "sles12sp1"
-  server_configuration = "${module.suma3pg.configuration}"
+  server_configuration = "${module.server.configuration}"
   count = 10
 }
 ```
 
-This will create 10 minions connected to the `suma3pg` server.
+This will create 10 minions connected to the `server` server.
 
 
 ## Turning convenience features off
@@ -141,11 +141,11 @@ Available Channels:
 Then add it to the `channels` variable in a SUSE Manager Server module:
 
 ```hcl
-module "suma3pg" {
+module "server" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
-  name = "suma3pg"
+  name = "server"
   product_version = "3.2-nightly"
   channels = ["sles12-sp2-pool-x86_64"]
 }
@@ -163,11 +163,11 @@ Channels specified via the `channels` variable above can be automatically cloned
 A libvirt example follows:
 
 ```hcl
-module "suma3pg" {
+module "server" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
-  name = "suma3pg"
+  name = "server"
   product_version = "3.2-nightly"
   channels = ["sles12-sp3-pool-x86_64", "sles12-sp3-updates-x86_64"]
   cloned_channels = "[{ channels: [sles12-sp3-pool-x86_64, sles12-sp3-updates-x86_64], prefix: cloned-2017-q1, date: 2017-03-31 }]"
@@ -204,7 +204,7 @@ module "base" {
   ...
 }
 
-module "suma3pg" {
+module "server" {
   ...
   mac = "42:54:00:00:00:66"
   ...
@@ -293,7 +293,7 @@ module "min" {
 
   name = "min"
   image = "sles12sp2"
-  server_configuration = "${module.suma3pg.configuration}"
+  server_configuration = "${module.server.configuration}"
   activation_key = "1-DEFAULT"
 }
 ```
@@ -304,11 +304,11 @@ module "min" {
 A `proxy` module is similar to a `client` module but has a `product_version` and a `server` variable pointing to the upstream server. You can then point clients to the proxy, as in the example below:
 
 ```hcl
-module "suma3pg" {
+module "server" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
-  name = "suma3pg"
+  name = "server"
   product_version = "3.2-nightly"
 }
 
@@ -318,7 +318,7 @@ module "proxy" {
 
   name = "proxy"
   product_version = "3.2-nightly"
-  server_configuration = "${module.suma3pg.configuration}"
+  server_configuration = "${module.server.configuration}"
 }
 
 module "clisles12sp1" {
@@ -343,7 +343,7 @@ module "proxy" {
 
   name = "proxy"
   product_version = "3.2-nightly"
-  server_configuration = "${module.suma3pg.configuration}"
+  server_configuration = "${module.server.configuration}"
 
   minion = false
 }
@@ -361,7 +361,7 @@ module "master" {
 
   name = "master"
   product_version = "3.2-released"
-  iss_slave = "suma3pgs.tf.local"
+  iss_slave = "servers.tf.local"
 }
 
 module "slave" {
@@ -555,7 +555,7 @@ module "minionswarm" {
 
   name = "ms"
   count = 2
-  server_configuration = "${module.suma3pg.configuration}"
+  server_configuration = "${module.server.configuration}"
 }
 ```
 
@@ -567,11 +567,11 @@ This will create 400 minions on 2 swarm hosts. Currently only SLES 12 SP1 with t
 You can configure SUSE Manager instances to download packages from an SMT server instead of SCC, in case a `mirror` is not used:
 
 ```hcl
-module "suma3pg" {
+module "server" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
-  name = "suma3pg"
+  name = "server"
   product_version = "3.2-nightly"
   smt = "http://smt.suse.de"
 }
@@ -589,7 +589,7 @@ module "minsles12sp1" {
 
   name = "minsles12sp1"
   image = "sles12sp1"
-  server_configuration = "${module.suma3pg.configuration}"
+  server_configuration = "${module.server.configuration}"
 
   additional_repos {
     virtualization_containers = "http://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP2/"
@@ -624,11 +624,11 @@ It is possible to install Prometheus exporters on a SUSE Manager Server instance
 
 
 ```hcl
-module "suma31pg" {
+module "server" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
-  name = "suma31pg"
+  name = "server"
   product_version = "head"
   monitored = true
 }
@@ -636,7 +636,7 @@ module "suma31pg" {
 module "grafana" {
   source = "./modules/libvirt/grafana"
   base_configuration = "${module.base.configuration}"
-  server_configuration = "${module.suma31pg.configuration}"
+  server_configuration = "${module.server.configuration}"
 }
 ```
 
@@ -655,7 +655,7 @@ A libvirt example follows:
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
-  name = "suma31pg"
+  name = "server"
   product_version = "head"
   apparmor = true
 ```
@@ -684,11 +684,11 @@ You may also start collecting new profiles with:
 SUSE Manager Server modules support forwarding logs to log servers via the `log_server` variable. A libvirt example follows:
 
 ```hcl
-module "suma31pg" {
+module "server" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
-  name = "suma31pg"
+  name = "server"
   product_version = "3.2-released"
   log_server = "logstash.mgr.suse.de:5045"
 }
@@ -742,7 +742,7 @@ You can deploy a locust host to test http performance of your SUSE Manager Serve
 module "locust" {
   source = "./modules/libvirt/locust"
   base_configuration = "${module.base.configuration}"
-  server_configuration = "${module.suma31pg.configuration}"
+  server_configuration = "${module.server.configuration}"
   // optionally, specify a custom locustfile:
   // locust_file = "./my_locustfile.py"
 }
@@ -756,7 +756,7 @@ This host can also be monitored via Prometheus and Grafana by adding `locust_con
 module "grafana" {
   source = "./modules/libvirt/grafana"
   base_configuration = "${module.base.configuration}"
-  server_configuration = "${module.suma31pg.configuration}"
+  server_configuration = "${module.server.configuration}"
   locust_configuration = "${module.locust.configuration}"
 }
 ```
@@ -767,7 +767,7 @@ In case you need to simulate a big amount of users, Locust's master-slave mode c
 module "locust" {
   source = "./modules/libvirt/locust"
   base_configuration = "${module.base.configuration}"
-  server_configuration = "${module.suma31pg.configuration}"
+  server_configuration = "${module.server.configuration}"
   locust_file = "./my_heavy_locustfile.py"
   slave_count = 5
 }
@@ -797,11 +797,11 @@ With the default configuration, whenever SUSE Manager server hosts are configure
 This setting can be overridden with a custom 'from' address by supplying the parameter: `from_email`. A libvirt example would be:
 
 ```hcl
-module "suma3pg" {
+module "server" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
-  name = "suma3pg"
+  name = "server"
   product_version = "head"
 
   from_email = "root@mbologna.openvpn.suse.de"

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -42,14 +42,14 @@ Error applying plan:
 
 1 error(s) occurred:
 
-* libvirt_domain.domain: Error defining libvirt domain: [Code-9] [Domain-20] operation failed: domain 'suma3pg' already exists with uuid b7ea7c0c-a2d5-4671-a2b5-ce17923ad326
+* libvirt_domain.domain: Error defining libvirt domain: [Code-9] [Domain-20] operation failed: domain 'server' already exists with uuid b7ea7c0c-a2d5-4671-a2b5-ce17923ad326
 ```
 
 In this case, Terraform thinks a resource does not exist and must be created (in other words, the resource is not yet in the [Terraform state](https://www.terraform.io/docs/state/)), while in reality it's there already.
 
 This typically happens in case of errors, or if a previous `terraform apply` failed. In those cases, there is no bug and you have to fix the situation yourself — Terraform is right about complaining the world is not in the state it expects.
 
-The most straightforward way to solve this is to delete the corresponding resource manually (eg. using `virsh undefine suma3pg` or graphically in `virt-manager` in libvirt) and then `terraform apply` the configuration again.
+The most straightforward way to solve this is to delete the corresponding resource manually (eg. using `virsh undefine server` or graphically in `virt-manager` in libvirt) and then `terraform apply` the configuration again.
 
 The other possibility would be to fix `terraform.tfstate` manually, which is sometimes possible by copypasting carefully JSON sections from backups - but in general this is error prone and discouraged.
 
@@ -60,7 +60,7 @@ Typical error message follows:
 ```
 Error refreshing state: 1 error(s) occurred:
 
-* libvirt_volume.main_disk: Can't retrieve volume /var/lib/libvirt/images/suma3pg-main-disk
+* libvirt_volume.main_disk: Can't retrieve volume /var/lib/libvirt/images/server-main-disk
 ```
 
 This means you have removed manually a Terraform-managed resource, so Terraform believes a resource existed (it's in the [Terraform state](https://www.terraform.io/docs/state/)) but it does not. This is in general a bug, so an issue should be reported ([example](https://github.com/dmacvicar/terraform-provider-libvirt/issues/74)).
@@ -70,9 +70,9 @@ Anyway you can work around the problem by removing the resource from the Terrafo
 ```
 $ terraform state list
 ...
-module.suma3pg.module.suse_manager.libvirt_volume.main_disk
+module.server.module.suse_manager.libvirt_volume.main_disk
 ...
-$ terraform state rm module.suma3pg.module.suse_manager.libvirt_volume.main_disk
+$ terraform state rm module.server.module.suse_manager.libvirt_volume.main_disk
 Item removal successful.
 ```
 
@@ -81,7 +81,7 @@ Item removal successful.
 Typical error message follows:
 
 ```
-Could not resolve hostname suma3pg.tf.local: Name or service not known
+Could not resolve hostname server.tf.local: Name or service not known
 ```
 
 Check that:
@@ -177,10 +177,10 @@ A: you can use [Terraform's taint command](https://www.terraform.io/docs/command
 ```
 $ terraform state list
 ...
-module.suma3pg.module.suse_manager.libvirt_volume.main_disk
+module.server.module.suse_manager.libvirt_volume.main_disk
 
-$ terraform taint -module=suma3pg.suse_manager libvirt_volume.main_disk
-The resource libvirt_volume.main_disk in the module root.suma3pg.suse_manager has been marked as tainted!
+$ terraform taint -module=server.suse_manager libvirt_volume.main_disk
+The resource libvirt_volume.main_disk in the module root.server.suse_manager has been marked as tainted!
 ```
 ## Q: how to force the re-download of an image?
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -10,7 +10,7 @@ module "server" {
   base_configuration = "${module.base.configuration}"
 
   name = "server"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
 }
 ```
 

--- a/main.tf.aws.example
+++ b/main.tf.aws.example
@@ -97,7 +97,7 @@ module "aws_suma31pg" {
   private_security_group_id = "${module.aws_network.private_security_group_id}"
   name_prefix = "${local.name_prefix}"
 
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   role = "suse_manager_server"
   cc_username = "${local.cc_username}"
   cc_password = "${local.cc_password}"

--- a/main.tf.aws.example
+++ b/main.tf.aws.example
@@ -82,9 +82,9 @@ module "aws_mirror" {
   name_prefix = "${local.name_prefix}"
 }
 
-module "aws_suma31pg" {
+module "aws_server" {
   source = "./modules/aws/host"
-  name = "suma31pg"
+  name = "server"
   region = "us-east-1"
   availability_zone = "us-east-1e"
   ami = "ami-febcf8e9" // change if appropriate (non-SUSE employees or non-us-east-1 region)
@@ -120,7 +120,7 @@ module "aws_minion" {
   private_security_group_id = "${module.aws_network.private_security_group_id}"
   name_prefix = "sumaform"
 
-  server = "${module.aws_suma3pg.private_names[0]}"
+  server = "${module.aws_server.private_names[0]}"
   role = "minion"
   mirror_public_name = "${module.aws_mirror.public_name}"
   mirror_private_name = "${module.aws_mirror.private_name}"
@@ -134,8 +134,8 @@ output "mirror_public_name" {
   value = "${module.aws_mirror.public_name}"
 }
 
-output "aws_suma3pg_private_name" {
-  value = "${module.aws_suma3pg.private_names[0]}"
+output "aws_server_private_name" {
+  value = "${module.aws_server.private_names[0]}"
 }
 
 output "aws_minion_private_names" {

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -42,7 +42,7 @@ module "ctl" {
 module "srv" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   name = "srv"
   image = "sles12sp3"
   auto_accept = false
@@ -62,7 +62,7 @@ module "srv" {
 module "cli-sles12sp3" {
   source = "./modules/libvirt/client"
   base_configuration = "${module.base.configuration}"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   name = "cli-sles12sp3"
   image = "sles12sp3"
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
@@ -73,7 +73,7 @@ module "cli-sles12sp3" {
 module "min-sles12sp3" {
   source = "./modules/libvirt/minion"
   base_configuration = "${module.base.configuration}"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   name = "min-sles12sp3"
   image = "sles12sp3"
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
@@ -96,7 +96,7 @@ module "minssh-sles12sp3" {
 module "min-centos7" {
   source = "./modules/libvirt/minion"
   base_configuration = "${module.base.configuration}"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   name = "min-centos7"
   image = "centos7"
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
@@ -108,7 +108,7 @@ module "min-centos7" {
 module "min-ubuntu" {
   source = "./modules/libvirt/minion"
   base_configuration = "${module.base.configuration}"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   name = "min-ubuntu"
   image = "ubuntu1804"
   memory = 1024

--- a/main.tf.libvirt.example
+++ b/main.tf.libvirt.example
@@ -23,7 +23,7 @@ module "server" {
   base_configuration = "${module.base.configuration}"
 
   name = "server"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   // see modules/libvirt/suse_manager/variables.tf for possible values
 
   // connect_to_additional_network = true

--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -48,7 +48,7 @@ module "ctl" {
 module "srv" {
   source = "./modules/openstack/suse_manager"
   base_configuration = "${module.base.configuration}"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   name = "srv"
   image = "sles12sp3"
   auto_accept = false
@@ -68,7 +68,7 @@ module "srv" {
 module "cli-sles12sp3" {
   source = "./modules/openstack/client"
   base_configuration = "${module.base.configuration}"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   name = "cli-sles12sp3"
   image = "sles12sp3"
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
@@ -79,7 +79,7 @@ module "cli-sles12sp3" {
 module "min-sles12sp3" {
   source = "./modules/openstack/minion"
   base_configuration = "${module.base.configuration}"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   name = "min-sles12sp3"
   image = "sles12sp3"
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
@@ -102,7 +102,7 @@ module "minssh-sles12sp3" {
 module "min-centos7" {
   source = "./modules/openstack/minion"
   base_configuration = "${module.base.configuration}"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   name = "min-centos7"
   image = "centos7"
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used

--- a/main.tf.openstack.example
+++ b/main.tf.openstack.example
@@ -32,7 +32,7 @@ module "server" {
   base_configuration = "${module.base.configuration}"
 
   name = "server"
-  product_version = "3.1-nightly"
+  product_version = "3.2-nightly"
   // see modules/openstack/suse_manager/variables.tf for possible values
 }
 

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -1,4 +1,4 @@
-# AWS-specific configuration
+ # AWS-specific configuration
 
 ## Overview
 
@@ -54,6 +54,6 @@ This project provides a utility script, `configure_aws_tunnels.rb`, which will a
 $ terraform apply
 ...
 $ ./configure_aws_tunnels.rb
-$ ssh suma3pg
+$ ssh server
 ip-YYY-YYY-YYY-YYY:~ #
 ```

--- a/modules/aws/evil_minions/main.tf
+++ b/modules/aws/evil_minions/main.tf
@@ -47,7 +47,7 @@ hostname: ${replace("${element(aws_instance.instance.*.private_dns, count.index)
 domain: ${var.region}.compute.internal
 use_avahi: False
 mirror: ${var.mirror_private_name}
-product_version: 3.1-released
+product_version: 3.2-released
 role: evil_minions
 server: ${var.server}
 evil_minion_count: ${var.evil_minion_count}

--- a/modules/aws/host/variables.tf
+++ b/modules/aws/host/variables.tf
@@ -64,7 +64,7 @@ variable "name_prefix" {
 }
 
 variable "product_version" {
-  description = "Main product version (eg. 4.0-released, 4.0-nightly, 3.2-released, 3.2-nightly, 3.1-nightly, head)"
+  description = "Main product version (eg. 4.0-released, 4.0-nightly, 3.2-released, 3.2-nightly, head)"
   default = "null"
 }
 

--- a/modules/aws/minionswarm/main.tf
+++ b/modules/aws/minionswarm/main.tf
@@ -47,7 +47,7 @@ hostname: ${replace("${element(aws_instance.instance.*.private_dns, count.index)
 domain: ${var.region}.compute.internal
 use_avahi: False
 mirror: ${var.mirror_private_name}
-product_version: 3.0-released
+product_version: 3.2-released
 role: minionswarm
 server: ${var.server}
 minion_count: 100

--- a/modules/libvirt/README.md
+++ b/modules/libvirt/README.md
@@ -40,7 +40,7 @@ If you want to use a different SSH key, please check the README_ADVANCED.md file
 If you don't want to use mDNS, or want to forward Avahi between networks, please check that same file, in section "Disabling Avahi and Avahi reflectors".
 If mDNS does not work out of the box, please check TROUBLESHOOTING.md file, under question "How can I work around name resolution problems with `tf.local` mDNS/Zeroconf/Bonjour/Avahi names?".
 
-Web access is on standard ports, so `firefox suma3pg.tf.local` will work as expected. SUSE Manager default user is `admin` with password `admin`.
+Web access is on standard ports, so `firefox server.tf.local` will work as expected. SUSE Manager default user is `admin` with password `admin`.
 
 Finally, the images come with serial console support, so you can use
 

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "A valid SUSE Manager version (eg. 3.0-nightly, head) see README_ADVANCED.md"
+  description = "A valid SUSE Manager version (eg. 3.2-nightly, head) see README_ADVANCED.md"
   default = "released"
 }
 

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -1,9 +1,5 @@
 variable "testsuite-branch" {
   default = {
-    "3.0-released" = "Manager-3.0"
-    "3.0-nightly" = "Manager-3.0"
-    "3.1-released" = "Manager-3.1"
-    "3.1-nightly" = "Manager-3.1"
     "3.2-released" = "Manager-3.2"
     "3.2-nightly" = "Manager-3.2"
     "4.0-released" = "Manager-4.0"

--- a/modules/libvirt/grafana/main.tf
+++ b/modules/libvirt/grafana/main.tf
@@ -10,7 +10,7 @@ module "grafana" {
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
 locust: ${var.locust_configuration["hostname"]}
-product_version: 3.0-nightly
+product_version: 3.2-nightly
 role: grafana
 
 EOF

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "A valid SUSE Manager version (eg. 3.0-nightly, head) see README_ADVANCED.md"
+  description = "A valid SUSE Manager version (eg. 3.2-nightly, head) see README_ADVANCED.md"
   default = "released"
 }
 

--- a/modules/libvirt/minionswarm/main.tf
+++ b/modules/libvirt/minionswarm/main.tf
@@ -10,7 +10,7 @@ module "minionswarm" {
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
-product_version: 3.0-released
+product_version: 3.2-released
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
 role: minionswarm

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -1,9 +1,5 @@
 variable "images" {
   default = {
-    "3.0-released" = "sles12sp1"
-    "3.0-nightly" = "sles12sp1"
-    "3.1-released" = "sles12sp4"
-    "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
     "4.0-released" = "sles15sp1"

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, head, test, uyuni-released"
+  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, head, test, uyuni-released"
   type = "string"
 }
 

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -1,9 +1,5 @@
 variable "images" {
   default = {
-    "3.0-released" = "sles12sp1"
-    "3.0-nightly" = "sles12sp1"
-    "3.1-released" = "sles12sp4"
-    "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
     "4.0-released" = "sles15sp1"

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, head"
+  description = "One of: 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, head"
   type = "string"
 }
 

--- a/modules/libvirt/virthost/variables.tf
+++ b/modules/libvirt/virthost/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "A valid SUSE Manager version (eg. 3.0-nightly, head) see README_ADVANCED.md"
+  description = "A valid SUSE Manager version (eg. 3.2-nightly, head) see README_ADVANCED.md"
   default = "released"
 }
 

--- a/modules/openstack/README.md
+++ b/modules/openstack/README.md
@@ -24,7 +24,7 @@ All machines come with user `root` with password `linux`. They are also accessib
 
 By default, the machines use Avahi (mDNS), and are configured on the `.tf.local` domain. Thus if your host is on the same network segment of the virtual machines you can simply use:
 ```
-ssh root@susemanager-suma31pg.tf.local
+ssh root@susemanager-server.tf.local
 ```
 
 If you use Avahi and are on another network segment, you can only connect using an IP address, because mDNS packets do not cross network boundaries unless using reflectors.

--- a/modules/openstack/client/variables.tf
+++ b/modules/openstack/client/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "A valid SUSE Manager version (eg. 3.0-nightly, head) see README_ADVANCED.md"
+  description = "A valid SUSE Manager version (eg. 3.2-nightly, head) see README_ADVANCED.md"
   default = "released"
 }
 

--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -1,9 +1,5 @@
 variable "testsuite-branch" {
   default = {
-    "3.0-released" = "Manager-3.0"
-    "3.0-nightly" = "Manager-3.0"
-    "3.1-released" = "Manager-3.1"
-    "3.1-nightly" = "Manager-3.1"
     "3.2-released" = "Manager-3.2"
     "3.2-nightly" = "Manager-3.2"
     "4.0-released" = "Manager-4.0"

--- a/modules/openstack/grafana/main.tf
+++ b/modules/openstack/grafana/main.tf
@@ -10,7 +10,7 @@ module "grafana" {
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
 locust: ${var.locust_configuration["hostname"]}
-product_version: 3.0-nightly
+product_version: 3.2-nightly
 role: grafana
 
 EOF

--- a/modules/openstack/minion/variables.tf
+++ b/modules/openstack/minion/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "A valid SUSE Manager version (eg. 3.0-nightly, head) see README_ADVANCED.md"
+  description = "A valid SUSE Manager version (eg. 3.2-nightly, head) see README_ADVANCED.md"
   default = "released"
 }
 

--- a/modules/openstack/minionswarm/main.tf
+++ b/modules/openstack/minionswarm/main.tf
@@ -10,7 +10,7 @@ module "minionswarm" {
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
-product_version: 3.0-released
+product_version: 3.2-released
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
 role: minionswarm

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -1,9 +1,5 @@
 variable "images" {
   default = {
-    "3.0-released" = "sles12sp1"
-    "3.0-nightly" = "sles12sp1"
-    "3.1-released" = "sles12sp4"
-    "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
     "4.0-released" = "sles15sp1"

--- a/modules/openstack/suse_manager/variables.tf
+++ b/modules/openstack/suse_manager/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, head, test"
+  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, head, test"
   type = "string"
 }
 
@@ -218,7 +218,7 @@ variable "pts_system_prefix" {
 // Provider-specific variables
 
 variable "image" {
-  description = "Leave default for automatic selection or specify sles12sp2 only if product_version is 3.0-released or 3.0-nightly"
+  description = "Leave default for automatic selection or specify image name"
   default = "default"
 }
 

--- a/modules/openstack/suse_manager_proxy/main.tf
+++ b/modules/openstack/suse_manager_proxy/main.tf
@@ -1,9 +1,5 @@
 variable "images" {
   default = {
-    "3.0-released" = "sles12sp1"
-    "3.0-nightly" = "sles12sp1"
-    "3.1-released" = "sles12sp4"
-    "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
     "4.0-released" = "sles15sp1"

--- a/modules/openstack/suse_manager_proxy/variables.tf
+++ b/modules/openstack/suse_manager_proxy/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, head"
+  description = "One of: 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, head"
   type = "string"
 }
 

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -50,10 +50,6 @@ scc:
     - SLE-Module-Containers15-SP1-Pool
     - SLE-Module-Containers15-SP1-Updates
     # SUSE Manager Server
-    - SUSE-Manager-Server-3.0-Pool
-    - SUSE-Manager-Server-3.0-Updates
-    - SUSE-Manager-Server-3.1-Pool
-    - SUSE-Manager-Server-3.1-Updates
     - SUSE-Manager-Server-3.2-Pool
     - SUSE-Manager-Server-3.2-Updates
     - SLE-Product-SUSE-Manager-Server-4.0-Pool
@@ -61,10 +57,6 @@ scc:
     - SLE-Module-SUSE-Manager-Server-4.0-Pool
     - SLE-Module-SUSE-Manager-Server-4.0-Updates
     # SUSE Manager Proxy
-    - SUSE-Manager-Proxy-3.0-Pool
-    - SUSE-Manager-Proxy-3.0-Updates
-    - SUSE-Manager-Proxy-3.1-Pool
-    - SUSE-Manager-Proxy-3.1-Updates
     - SUSE-Manager-Proxy-3.2-Pool
     - SUSE-Manager-Proxy-3.2-Updates
     - SLE-Product-SUSE-Manager-Proxy-4.0-Pool
@@ -140,14 +132,6 @@ http:
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1
     archs: [x86_64]
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/ToSLE/SLE_15_SP1/
-    archs: [x86_64]
-
-  # SUSE Manager 3.0 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.0/SLE_12_SP1_Update
-    archs: [x86_64]
-
-  # SUSE Manager 3.1 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2
     archs: [x86_64]
 
   # SUSE Manager 3.2 devel

--- a/salt/repos/minionswarm.sls
+++ b/salt/repos/minionswarm.sls
@@ -2,14 +2,14 @@
 
 suse_manager_pool_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-3.0-x86_64-Pool.repo
-    - source: salt://repos/repos.d/SUSE-Manager-3.0-x86_64-Pool.repo
+    - name: /etc/zypp/repos.d/SUSE-Manager-3.2-x86_64-Pool.repo
+    - source: salt://repos/repos.d/SUSE-Manager-3.2-x86_64-Pool.repo
     - template: jinja
 
 suse_manager_update_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-3.0-x86_64-Update.repo
-    - source: salt://repos/repos.d/SUSE-Manager-3.0-x86_64-Update.repo
+    - name: /etc/zypp/repos.d/SUSE-Manager-3.2-x86_64-Update.repo
+    - source: salt://repos/repos.d/SUSE-Manager-3.2-x86_64-Update.repo
     - template: jinja
 
 {% endif %}

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_3.0.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_3.0.repo
@@ -1,6 +1,0 @@
-[Devel_Galaxy_Manager_3.0]
-name=Devel Project for SUSE Manager 3.0 (SLE_12_SP1)
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/3.0/SLE_12_SP1_Update/
-priority=96

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_3.1.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_3.1.repo
@@ -1,6 +1,0 @@
-[Devel_Galaxy_Manager_3.1]
-name=Devel Project for SUSE Manager 3.1 (SLE_12_SP2)
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2/
-priority=96

--- a/salt/repos/repos.d/SUSE-Manager-3.0-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SUSE-Manager-3.0-x86_64-Pool.repo
@@ -1,6 +1,0 @@
-[SUSE-Manager-3.0-x86_64-Pool]
-name=SUSE-Manager-3.0-x86_64-Pool
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SUSE-Manager-Server/3.0/x86_64/product/
-priority=97

--- a/salt/repos/repos.d/SUSE-Manager-3.0-x86_64-Update.repo
+++ b/salt/repos/repos.d/SUSE-Manager-3.0-x86_64-Update.repo
@@ -1,6 +1,0 @@
-[SUSE-Manager-3.0-x86_64-Update]
-name=SUSE-Manager-3.0-x86_64-Update
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SUSE-Manager-Server/3.0/x86_64/update/
-priority=97

--- a/salt/repos/repos.d/SUSE-Manager-3.1-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SUSE-Manager-3.1-x86_64-Pool.repo
@@ -1,6 +1,0 @@
-[SUSE-Manager-3.1-x86_64-Pool]
-name=SUSE-Manager-3.1-x86_64-Pool
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product
-priority=97

--- a/salt/repos/repos.d/SUSE-Manager-3.1-x86_64-Update.repo
+++ b/salt/repos/repos.d/SUSE-Manager-3.1-x86_64-Update.repo
@@ -1,6 +1,0 @@
-[SUSE-Manager-3.1-x86_64-Update]
-name=SUSE-Manager-3.1-x86_64-Update
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SUSE-Manager-Server/3.1/x86_64/update/
-priority=97

--- a/salt/repos/repos.d/SUSE-Manager-Proxy-3.0-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SUSE-Manager-Proxy-3.0-x86_64-Pool.repo
@@ -1,6 +1,0 @@
-[SUSE-Manager-Proxy-3.0-x86_64-Pool]
-name=SUSE-Manager-Proxy-3.0-x86_64-Pool
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains["mirror"] | default("download.suse.de/ibs", true) }}/SUSE/Products/SUSE-Manager-Proxy/3.0/x86_64/product/
-priority=97

--- a/salt/repos/repos.d/SUSE-Manager-Proxy-3.0-x86_64-Update.repo
+++ b/salt/repos/repos.d/SUSE-Manager-Proxy-3.0-x86_64-Update.repo
@@ -1,6 +1,0 @@
-[SUSE-Manager-Proxy-3.0-x86_64-Update]
-name=SUSE-Manager-Proxy-3.0-x86_64-Update
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains["mirror"] | default("download.suse.de/ibs", true) }}/SUSE/Updates/SUSE-Manager-Proxy/3.0/x86_64/update/
-priority=97

--- a/salt/repos/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Pool.repo
@@ -1,6 +1,0 @@
-[SUSE-Manager-Proxy-3.1-x86_64-Pool]
-name=SUSE-Manager-Proxy-3.1-x86_64-Pool
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains["mirror"] | default("download.suse.de/ibs", true) }}/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product/
-priority=97

--- a/salt/repos/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Update.repo
+++ b/salt/repos/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Update.repo
@@ -1,6 +1,0 @@
-[SUSE-Manager-Proxy-3.1-x86_64-Update]
-name=SUSE-Manager-Proxy-3.1-x86_64-Update
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains["mirror"] | default("download.suse.de/ibs", true) }}/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update/
-priority=97

--- a/salt/repos/suse_manager_proxy.sls
+++ b/salt/repos/suse_manager_proxy.sls
@@ -1,33 +1,5 @@
 {% if grains.get('role') == 'suse_manager_proxy' %}
 
-{% if '3.0' in grains['product_version'] %}
-suse_manager_proxy_pool_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-Proxy-3.0-x86_64-Pool.repo
-    - source: salt://repos/repos.d/SUSE-Manager-Proxy-3.0-x86_64-Pool.repo
-    - template: jinja
-
-suse_manager_proxy_update_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-Proxy-3.0-x86_64-Update.repo
-    - source: salt://repos/repos.d/SUSE-Manager-Proxy-3.0-x86_64-Update.repo
-    - template: jinja
-{% endif %}
-
-{% if '3.1' in grains['product_version'] %}
-suse_manager_proxy_pool_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Pool.repo
-    - source: salt://repos/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Pool.repo
-    - template: jinja
-
-suse_manager_proxy_update_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Update.repo
-    - source: salt://repos/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Update.repo
-    - template: jinja
-{% endif %}
-
 {% if '3.2' in grains['product_version'] %}
 suse_manager_proxy_pool_repo:
   file.managed:
@@ -133,22 +105,6 @@ module_server_applications_update_repo:
     - template: jinja
 
 {% endif %}
-{% endif %}
-
-{% if '3.0-nightly' in grains['product_version'] %}
-suse_manager_devel_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.0.repo
-    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.0.repo
-    - template: jinja
-{% endif %}
-
-{% if '3.1-nightly' in grains['product_version'] %}
-suse_manager_devel_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1.repo
-    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.1.repo
-    - template: jinja
 {% endif %}
 
 {% if '3.2-nightly' in grains['product_version'] %}

--- a/salt/repos/suse_manager_server.sls
+++ b/salt/repos/suse_manager_server.sls
@@ -1,33 +1,5 @@
 {% if grains.get('role') == 'suse_manager_server' %}
 
-{% if '3.0' in grains['product_version'] %}
-suse_manager_pool_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-3.0-x86_64-Pool.repo
-    - source: salt://repos/repos.d/SUSE-Manager-3.0-x86_64-Pool.repo
-    - template: jinja
-
-suse_manager_update_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-3.0-x86_64-Update.repo
-    - source: salt://repos/repos.d/SUSE-Manager-3.0-x86_64-Update.repo
-    - template: jinja
-{% endif %}
-
-{% if '3.1' in grains['product_version'] %}
-suse_manager_pool_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-3.1-x86_64-Pool.repo
-    - source: salt://repos/repos.d/SUSE-Manager-3.1-x86_64-Pool.repo
-    - template: jinja
-
-suse_manager_update_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-3.1-x86_64-Update.repo
-    - source: salt://repos/repos.d/SUSE-Manager-3.1-x86_64-Update.repo
-    - template: jinja
-{% endif %}
-
 {% if '3.2' in grains['product_version'] %}
 suse_manager_pool_repo:
   file.managed:
@@ -180,22 +152,6 @@ module_python2_update_repo:
     - source: salt://repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Update.repo
     - template: jinja
 {% endif %}
-{% endif %}
-
-{% if '3.0-nightly' in grains['product_version'] %}
-suse_manager_devel_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.0.repo
-    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.0.repo
-    - template: jinja
-{% endif %}
-
-{% if '3.1-nightly' in grains['product_version'] %}
-suse_manager_devel_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1.repo
-    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.1.repo
-    - template: jinja
 {% endif %}
 
 {% if '3.2-nightly' in grains['product_version'] %}

--- a/salt/suse_manager_proxy/config-answers.txt
+++ b/salt/suse_manager_proxy/config-answers.txt
@@ -1,10 +1,6 @@
 RHN_PARENT={{grains['server']}}
 HTTP_PROXY=''
-{% if '3.0' in grains['product_version'] %}
-VERSION='3.0'
-{% elif '3.1' in grains['product_version'] %}
-VERSION='3.1'
-{% elif '3.2' in grains['product_version'] %}
+{% if '3.2' in grains['product_version'] %}
 VERSION='3.2
 {% else %}
 VERSION='4.0'

--- a/salt/suse_manager_proxy/init.sls
+++ b/salt/suse_manager_proxy/init.sls
@@ -147,7 +147,7 @@ configure-proxy:
 
 create_bootstrap_script:
   cmd.run:
-    - name: rhn-bootstrap --activation-keys=1-DEFAULT --no-up2date --hostname {{ grains['hostname'] }}.{{ grains['domain'] }} {{ '--traditional' if '3.0' not in grains['product_version'] else '' }}
+    - name: rhn-bootstrap --activation-keys=1-DEFAULT --no-up2date --hostname {{ grains['hostname'] }}.{{ grains['domain'] }} --traditional
     - creates: /srv/www/htdocs/pub/bootstrap/bootstrap.sh
     - require:
       - cmd: configure-proxy

--- a/salt/suse_manager_server/initial_content.sls
+++ b/salt/suse_manager_server/initial_content.sls
@@ -110,7 +110,7 @@ create_empty_activation_key:
 {% if grains.get('create_sample_bootstrap_script') %}
 create_empty_bootstrap_script:
   cmd.run:
-    - name: rhn-bootstrap --activation-keys=1-DEFAULT --no-up2date --hostname {{ grains['hostname'] }}.{{ grains['domain'] }} {{ '--traditional' if '3.0' not in grains['product_version'] else '' }}
+    - name: rhn-bootstrap --activation-keys=1-DEFAULT --no-up2date --hostname {{ grains['hostname'] }}.{{ grains['domain'] }} --traditional
     - creates: /srv/www/htdocs/pub/bootstrap/bootstrap.sh
     - require:
       - cmd: create_empty_activation_key

--- a/salt/suse_manager_server/tomcat.sls
+++ b/salt/suse_manager_server/tomcat.sls
@@ -5,11 +5,7 @@ include:
 
 tomcat_config:
   file.replace:
-    {% if '3.0' in grains['product_version'] %}
-    - name: /etc/tomcat/tomcat.conf
-    {% else %}
     - name: /etc/sysconfig/tomcat
-    {% endif %}
     - pattern: 'JAVA_OPTS="(?!-Xdebug)(.*)"'
     {% if grains['hostname'] and grains['domain'] %}
     - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['hostname'] }}.{{ grains['domain'] }}:8000,server=y,suspend=n -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['hostname'] }}.{{ grains['domain'] }} \1"'


### PR DESCRIPTION
Remove out of support products from syncing: Manager-3.0 and Manager-3.1
Is there a particular reason we keep them mirrored?