### PR TITLE
Pin cucumber-html-reporter to 5.0.2

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -87,7 +87,7 @@ install_npm:
 # https://github.com/gkushang/cucumber-html-reporter
 install_cucumber_html_reporter_via_npm:
   cmd.run:
-    - name: npm install cucumber-html-reporter --save-dev
+    - name: npm install cucumber-html-reporter@5.0.2 --save-dev
     - require:
       - pkg: install_npm
 


### PR DESCRIPTION
https://github.com/gkushang/cucumber-html-reporter/pull/197#discussion_r320247815
https://github.com/gkushang/cucumber-html-reporter/commit/7bb1b440e5262d2f43d4e2acfd5bacfa2d8fb1c4

This way we can update the version when needed, and not automatically.