### PR TITLE
Forgot the openstack module when upgrading the controller

### DIFF
--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -64,7 +64,7 @@ ubuntu1804_sshminion: ${var.ubuntu1804_sshminion_configuration["hostname"]}
 EOF
 
   // Provider-specific variables
-  image = "opensuse423"
+  image = "opensuse150"
   flavor = "m1.small"
   floating_ips = "${var.floating_ips}"
 }


### PR DESCRIPTION
As discussed by email.

My bad, I forgot the openstack module when upgrading the controler from 42.3 to 15.0.
