### PR TITLE
Move testsuite test repos to OBS

### DIFF
--- a/salt/default/testsuite.sls
+++ b/salt/default/testsuite.sls
@@ -24,7 +24,7 @@ default_cucumber_requisites:
       - milkyway-dummy
       - virgo-dummy
     - require:
-      - pkgrepo: testsuite_build_repo
+      - pkgrepo: test_repo_rpm_pool
 
 {% endif %}
 {% endif %}

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -217,7 +217,13 @@ http:
     archs: [x86_64]
 
   # Testsuite dummy packages for testing repo
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP4
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/SLE_12_SP4
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/xUbuntu_18.04
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/SLE_12_SP4
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/xUbuntu_18.04
     archs: [x86_64]
 
   # Software for sumaformed Virtual Machines

--- a/salt/repos/testsuite.sls
+++ b/salt/repos/testsuite.sls
@@ -3,21 +3,21 @@
 
 {% if grains['os'] == 'SUSE' %}
 
-testsuite_build_repo:
+test_repo_rpm_pool:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP4/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/SLE_12_SP4/
 
 {% elif grains['os_family'] == 'RedHat' %}
 
-testsuite_build_repo:
+test_repo_rpm_pool:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP4/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/SLE_12_SP4/
 
 {% elif grains['os_family'] == 'Debian' %}
 
-testsuite_build_repo:
+test_repo_deb_pool:
   pkgrepo.managed:
-    - name: deb [trusted=yes] https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Ubuntu-Test/xUbuntu_18.04 /
+    - name: deb [trusted=yes] {{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/xUbuntu_18.04/
     - file: /etc/apt/sources.list.d/Devel_Uyuni_BuildRepo.list
 
 {% endif %}

--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -57,35 +57,27 @@ minima:
     - keep: True
     - overwrite: True
 
-test_repo:
+test_repo_rpm_updates:
   cmd.run:
     - name: minima sync
     - env:
       - MINIMA_CONFIG: |
-          - url: http://download.suse.de/ibs/Devel:/Galaxy:/TestsuiteRepo/SLE_12_SP4
-            path: /srv/www/htdocs/pub/TestRepo
+          - url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/SLE_12_SP4
+            path: /srv/www/htdocs/pub/TestRepoRpmUpdates
     - require:
       - archive: minima
 
 another_test_repo:
   file.symlink:
     - name: /srv/www/htdocs/pub/AnotherRepo
-    - target: TestRepo
+    - target: TestRepoRpmUpdates
     - require:
-      - cmd: test_repo
-
-test_repo_debian:
-  cmd.script:
-    - name: salt://suse_manager_server/download_ubuntu_repo.sh
-    - args: "TestRepoDeb download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Ubuntu-Test/xUbuntu_18.04/"
-    - creates: /srv/www/htdocs/pub/TestRepoDeb/Release
-    - require:
-      - pkg: testsuite_packages
+      - cmd: test_repo_rpm_updates
 
 test_repo_debian_updates:
   cmd.script:
     - name: salt://suse_manager_server/download_ubuntu_repo.sh
-    - args: "TestRepoDebUpdates download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Ubuntu-Test-Updates/xUbuntu_18.04/"
+    - args: "TestRepoDebUpdates {{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/xUbuntu_18.04/"
     - creates: /srv/www/htdocs/pub/TestRepoDebUpdates/Release
     - require:
       - pkg: testsuite_packages


### PR DESCRIPTION
## What does this PR change?

In prevision for Uyuni, move RPM test packages to OBS, and merge with DEB repositories that are already there.

See SUSE/spacewalk#9392.

@mateiw, `/srv/www/htdocs/pub/TestRepoDeb` is simply removed: it does not look like you're using it.

** DO NOT MERGE BEFORE THE TEST SUITE PR CAN BE MERGED IN ALL 3 BRANCHES **