### PR TITLE
Bugfix: virthost would not deploy correctly

### DIFF
--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -7,6 +7,7 @@ virthost_packages:
         {% if '15' in grains['osrelease'] %}
         - patterns-server-kvm_server
         - python3-six  # Workaround missing virt-manager-common dependency
+        - libvirt
         {% elif grains['osfullname'] == 'Leap' %}
         - patterns-openSUSE-kvm_server
         {% else %}
@@ -83,7 +84,7 @@ default-net.xml:
 default-net_destroyed:
   cmd.run:
     - name: 'virsh net-destroy default'
-    - onlyif: 'virsh net-dumpxml default'
+    - onlyif: 'virsh net-info default | grep Active | grep yes'
     - require:
       - service: libvirtd_service
       - file: default-net.xml

--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -7,7 +7,7 @@ virthost_packages:
         {% if '15' in grains['osrelease'] %}
         - patterns-server-kvm_server
         - python3-six  # Workaround missing virt-manager-common dependency
-        - libvirt
+        - libvirt-daemon-qemu
         {% elif grains['osfullname'] == 'Leap' %}
         - patterns-openSUSE-kvm_server
         {% else %}


### PR DESCRIPTION
## What does this PR change?

Prevent deploy errors of `min-kvm` as per the default testsuite example file for libvirt.

Specifically, the libvirt daemon would not start:

```
----------
          ID: libvirtd_service
    Function: service.running
        Name: libvirtd
      Result: False
     Comment: The named service libvirtd is not available
```

Moreover, `default-net_destroyed` would fail if the network is there but not active.