### PR TITLE
Change role to check for new module sshminion

### DIFF
--- a/salt/default/testsuite.sls
+++ b/salt/default/testsuite.sls
@@ -1,5 +1,5 @@
 {% if grains.get('testsuite') | default(false, true) %}
-{% if grains.get('role') in ['client', 'minion', None] %}
+{% if grains.get('role') in ['client', 'minion', 'minionssh'] %}
 
 include:
   - repos

--- a/salt/repos/testsuite.sls
+++ b/salt/repos/testsuite.sls
@@ -1,5 +1,5 @@
 {% if grains.get('testsuite') | default(false, true) %}
-{% if grains.get('role') in ['client', 'minion', None] %}
+{% if grains.get('role') in ['client', 'minion', 'minionssh'] %}
 
 {% if grains['os'] == 'SUSE' %}
 


### PR DESCRIPTION
# What does this PR change?

It adds repos to ssh minion that don't get applied because the jinja if statement doesn't expand anymore. The new module minionssh has role:sshminion and this role wasn't in the list that was checked before now.