### PR TITLE
Forgot the GPG keys for the new repos

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -324,7 +324,7 @@ galaxy_key:
     - name: rpm --import /tmp/galaxy.key
     - watch:
       - file: galaxy_key
-{% if 'uyuni-master' in grains.get('product_version') or 'uyuni-stable' in grains.get('product_version') %}
+{% if 'uyuni-master' in grains.get('product_version') or 'uyuni-released' in grains.get('product_version') %}
 uyuni_key:
   file.managed:
     - name: /tmp/uyuni.key

--- a/salt/repos/testsuite.sls
+++ b/salt/repos/testsuite.sls
@@ -6,19 +6,24 @@
 test_repo_rpm_pool:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/SLE_12_SP4/
+    - gpgcheck: 1
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/SLE_12_SP4/repodata/repomd.xml.key
 
 {% elif grains['os_family'] == 'RedHat' %}
 
 test_repo_rpm_pool:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/SLE_12_SP4/
+    - gpgcheck: 1
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/SLE_12_SP4/repodata/repomd.xml.key
 
 {% elif grains['os_family'] == 'Debian' %}
 
 test_repo_deb_pool:
   pkgrepo.managed:
-    - name: deb [trusted=yes] {{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/xUbuntu_18.04/
-    - file: /etc/apt/sources.list.d/Devel_Uyuni_BuildRepo.list
+    - name: deb http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/xUbuntu_18.04/ /
+    - file: /etc/apt/sources.list.d/Test-Packages_Pool.list
+    - key_url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/xUbuntu_18.04/Release.key
 
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

dummy packages are currently failing because of missing GPG key. This PR adds it.

it also fixes an error of `uyuni-stable` that should be `uyuni-released`.
