### PR TITLE
Allow hosts to have more than one role

### DIFF
--- a/.ci-travis/salt-client-validation
+++ b/.ci-travis/salt-client-validation
@@ -14,7 +14,7 @@ authorized_keys: [ssh-rsa 1233= root@travis.git]
 reset_ids: true
 product_version: head
 server: travis.tf.local
-role: client
+roles: [client]
 mirror: null
 auto_register: false
 testsuite: true

--- a/.ci-travis/salt-ctl-validation
+++ b/.ci-travis/salt-ctl-validation
@@ -19,7 +19,7 @@ client: cli-travis.tf.local
 minion: min-travis.tf.local
 centos_minion: 100-travis.tf.local
 ssh_minion: ssh-travis.tf.local
-role: controller
+roles: [controller]
 mirror: null
 testsuite: true
 EOF

--- a/.ci-travis/salt-minion-validation
+++ b/.ci-travis/salt-minion-validation
@@ -14,7 +14,7 @@ authorized_keys: [ssh-rsa 1233= root@travis.git]
 reset_ids: true
 product_version: head
 server: travis.tf.local
-role: client
+roles: [client]
 mirror: null
 auto_connect_to_master: false
 testsuite: true

--- a/.ci-travis/salt-server-validation
+++ b/.ci-travis/salt-server-validation
@@ -19,7 +19,7 @@ mirror: null
 iss_master: null
 iss_slave: null
 smt: null
-role: suse_manager_server
+roles: [suse_manager_server]
 disable_firewall: 0
 allow_postgres_connections: 0
 unsafe_postgres: 1

--- a/main.tf.aws.example
+++ b/main.tf.aws.example
@@ -98,7 +98,7 @@ module "aws_server" {
   name_prefix = "${local.name_prefix}"
 
   product_version = "3.2-nightly"
-  role = "suse_manager_server"
+  roles = ["suse_manager_server"]
   cc_username = "${local.cc_username}"
   cc_password = "${local.cc_password}"
   mirror_public_name = "${module.aws_mirror.public_name}"
@@ -121,7 +121,7 @@ module "aws_minion" {
   name_prefix = "sumaform"
 
   server = "${module.aws_server.private_names[0]}"
-  role = "minion"
+  roles = ["minion"]
   mirror_public_name = "${module.aws_mirror.public_name}"
   mirror_private_name = "${module.aws_mirror.private_name}"
 }

--- a/modules/aws/evil_minions/main.tf
+++ b/modules/aws/evil_minions/main.tf
@@ -48,7 +48,7 @@ domain: ${var.region}.compute.internal
 use_avahi: False
 mirror: ${var.mirror_private_name}
 product_version: 3.2-released
-role: evil_minions
+roles: [evil_minions]
 server: ${var.server}
 evil_minion_count: ${var.evil_minion_count}
 slowdown_factor: ${var.slowdown_factor}

--- a/modules/aws/host/main.tf
+++ b/modules/aws/host/main.tf
@@ -55,7 +55,7 @@ use_avahi: False
 mirror: ${var.mirror_private_name}
 product_version: ${var.product_version}
 channels: [${join(",", var.channels)}]
-role: ${var.role}
+roles: [${join(",", var.roles)}]
 cc_username: ${var.cc_username}
 cc_password: ${var.cc_password}
 server: ${var.server}

--- a/modules/aws/host/variables.tf
+++ b/modules/aws/host/variables.tf
@@ -73,9 +73,9 @@ variable "channels" {
   default = []
 }
 
-variable "role"  {
-  description = "Name of the host role, see the main.tf example file"
-  type = "string"
+variable "roles"  {
+  description = "List of the host roles, see the main.tf example file"
+  default = []
 }
 
 variable "cc_username" {

--- a/modules/aws/mirror/main.tf
+++ b/modules/aws/mirror/main.tf
@@ -72,7 +72,7 @@ resource "null_resource" "mirror_salt_configuration" {
 hostname: ${replace("${aws_instance.instance.private_dns}", ".${var.region == "us-east-1" ? "ec2.internal" : "${var.region}.compute.internal"}", "")}
 domain: ${var.region == "us-east-1" ? "ec2.internal" : "${var.region}.compute.internal"}
 use_avahi: False
-role: mirror
+roles: [mirror]
 cc_username: ${var.cc_username}
 cc_password: ${var.cc_password}
 data_disk_device: xvdf

--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -14,12 +14,12 @@ module "client" {
   ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = true
+  roles = ["client"]
   grains = <<EOF
 
 product_version: ${var.product_version}
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: client
 auto_register: ${var.auto_register}
 
 EOF

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -23,6 +23,7 @@ module "controller" {
   ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = false
+  roles = ["controller"]
   grains = <<EOF
 
 git_username: ${var.git_username}
@@ -38,7 +39,6 @@ ubuntu_minion:  ${var.ubuntu_configuration["hostname"]}
 ssh_minion: ${var.minionssh_configuration["hostname"]}
 kvm_host: ${var.kvmhost_configuration["hostname"]}
 pxeboot_mac: ${var.pxeboot_configuration["macaddr"]}
-role: controller
 branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["product_version"]) : var.branch}
 git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo}
 server_http_proxy: ${var.server_http_proxy}

--- a/modules/libvirt/grafana/main.tf
+++ b/modules/libvirt/grafana/main.tf
@@ -5,13 +5,13 @@ module "grafana" {
   name = "${var.name}"
   count = "${var.count}"
   ssh_key_path = "${var.ssh_key_path}"
+  roles = ["grafana"]
   grains = <<EOF
 
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
 locust: ${var.locust_configuration["hostname"]}
 product_version: 3.2-nightly
-role: grafana
 
 EOF
 

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -88,6 +88,7 @@ use_avahi: ${var.base_configuration["use_avahi"]}
 additional_network: ${var.base_configuration["additional_network"]}
 timezone: ${var.base_configuration["timezone"]}
 testsuite: ${var.base_configuration["testsuite"]}
+roles: [${join(",", var.roles)}]
 use_os_released_updates: ${var.use_os_released_updates}
 use_os_unreleased_updates: ${var.use_os_unreleased_updates}
 additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -8,6 +8,11 @@ variable "name" {
   type = "string"
 }
 
+variable "roles"  {
+  description = "List of the host roles"
+  default = []
+}
+
 variable "use_os_released_updates" {
   description = "Apply all updates from SUSE Linux Enterprise repos"
   default = false

--- a/modules/libvirt/locust/main.tf
+++ b/modules/libvirt/locust/main.tf
@@ -3,11 +3,11 @@ module "locust" {
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
   ssh_key_path = "${var.ssh_key_path}"
+  roles = ["locust"]
   grains = <<EOF
 
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: locust
 locust_file: ${base64encode(file(var.locust_file))}
 server_username: ${var.server_configuration["username"]}
 server_password: ${var.server_configuration["password"]}
@@ -28,11 +28,11 @@ module "locust-slave" {
   name = "${var.name}-slave"
   count = "${var.slave_count}"
   ssh_key_path = "${var.ssh_key_path}"
+  roles = ["locust"]
   grains = <<EOF
 
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: locust
 locust_file: ${base64encode(file(var.locust_file))}
 server_username: ${var.server_configuration["username"]}
 server_password: ${var.server_configuration["password"]}

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -14,12 +14,12 @@ module "minion" {
   ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = true
+  roles = "${var.roles}"
   grains = <<EOF
 
 product_version: ${var.product_version}
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: minion
 auto_connect_to_master: ${var.auto_connect_to_master}
 apparmor: ${var.apparmor}
 avahi_reflector: ${var.avahi_reflector}

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -8,6 +8,11 @@ variable "name" {
   type = "string"
 }
 
+variable "roles"  {
+  description = "List of the host roles"
+  default = ["minion"]
+}
+
 variable "product_version" {
   description = "A valid SUSE Manager version (eg. 3.2-nightly, head) see README_ADVANCED.md"
   default = "released"

--- a/modules/libvirt/minionssh/main.tf
+++ b/modules/libvirt/minionssh/main.tf
@@ -14,10 +14,10 @@ module "minionssh" {
   ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = true
+  roles = ["minionssh"]
   grains = <<EOF
 
 product_version: ${var.product_version}
-role: minionssh
 
 EOF
 

--- a/modules/libvirt/mirror/main.tf
+++ b/modules/libvirt/mirror/main.tf
@@ -16,9 +16,9 @@ module "mirror" {
   additional_packages = "${var.additional_packages}"
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
+  roles = ["mirror"]
   grains = <<EOF
 
-role: mirror
 cc_username: ${var.base_configuration["cc_username"]}
 cc_password: ${var.base_configuration["cc_password"]}
 data_disk_device: vdb

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -27,6 +27,7 @@ module "suse_manager" {
   ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = false
+  roles = ["suse_manager_server"]
   grains = <<EOF
 
 product_version: ${var.product_version}
@@ -38,7 +39,6 @@ mirror: ${var.base_configuration["mirror"]}
 iss_master: ${var.iss_master}
 iss_slave: ${var.iss_slave}
 smt: ${var.smt}
-role: suse_manager_server
 server_username: ${var.server_username}
 server_password: ${var.server_password}
 disable_firewall: ${var.disable_firewall}

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -26,12 +26,12 @@ module "suse_manager_proxy" {
   ipv6 = "${var.ipv6}"
   connect_to_base_network = true
   connect_to_additional_network = true
+  roles = ["suse_manager_proxy"]
   grains = <<EOF
 
 product_version: ${var.product_version}
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: suse_manager_proxy
 minion: ${var.minion}
 auto_connect_to_master: ${var.auto_connect_to_master}
 auto_register: ${var.auto_register}

--- a/modules/libvirt/virthost/main.tf
+++ b/modules/libvirt/virthost/main.tf
@@ -15,11 +15,11 @@ module "virthost" {
   gpg_keys = "${var.gpg_keys}"
   ssh_key_path = "${var.ssh_key_path}"
   ipv6 = "${var.ipv6}"
+  roles = ["minion", "virthost"]
   additional_grains = <<EOF
 
 hvm_disk_image: "${var.hvm_disk_image}"
 hvm_disk_image_hash: "${var.hvm_disk_image_hash}"
-virtual_host: true
 EOF
 
   // Provider-specific variables

--- a/modules/openstack/client/main.tf
+++ b/modules/openstack/client/main.tf
@@ -12,12 +12,12 @@ module "client" {
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   ipv6 = "${var.ipv6}"
+  roles = ["client"]
   grains = <<EOF
 
 product_version: ${var.product_version}
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: client
 auto_register: ${var.auto_register}
 
 EOF

--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -21,6 +21,7 @@ module "controller" {
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   ipv6 = "${var.ipv6}"
+  roles = ["controller"]
   grains = <<EOF
 
 git_username: ${var.git_username}
@@ -34,7 +35,6 @@ minion: ${var.minion_configuration["hostname"]}
 centos_minion: ${var.centos_configuration["hostname"]}
 ubuntu_minion: ${var.ubuntu_configuration["hostname"]}
 ssh_minion: ${var.minionssh_configuration["hostname"]}
-role: controller
 branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["product_version"]) : var.branch}
 git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo}
 server_http_proxy: ${var.server_http_proxy}

--- a/modules/openstack/grafana/main.tf
+++ b/modules/openstack/grafana/main.tf
@@ -5,13 +5,13 @@ module "grafana" {
   name = "${var.name}"
   count = "${var.count}"
   ssh_key_path = "${var.ssh_key_path}"
+  roles = ["grafana"]
   grains = <<EOF
 
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
 locust: ${var.locust_configuration["hostname"]}
 product_version: 3.2-nightly
-role: grafana
 
 EOF
 

--- a/modules/openstack/host/main.tf
+++ b/modules/openstack/host/main.tf
@@ -103,6 +103,7 @@ domain: ${var.base_configuration["domain"]}
 use_avahi: ${var.base_configuration["use_avahi"]}
 timezone: ${var.base_configuration["timezone"]}
 testsuite: ${var.base_configuration["testsuite"]}
+roles: [${join(",", var.roles)}]
 use_os_released_updates: ${var.use_os_released_updates}
 use_os_unreleased_updates: ${var.use_os_unreleased_updates}
 additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}

--- a/modules/openstack/host/variables.tf
+++ b/modules/openstack/host/variables.tf
@@ -8,6 +8,11 @@ variable "name" {
   type = "string"
 }
 
+variable "roles"  {
+  description = "List of the host roles"
+  default = []
+}
+
 variable "use_os_released_updates" {
   description = "Apply all updates from SUSE Linux Enterprise repos"
   default = false

--- a/modules/openstack/locust/main.tf
+++ b/modules/openstack/locust/main.tf
@@ -3,11 +3,11 @@ module "locust" {
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
   ssh_key_path = "${var.ssh_key_path}"
+  roles = ["locust"]
   grains = <<EOF
 
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: locust
 locust_file: ${base64encode(file(var.locust_file))}
 server_username: ${var.server_configuration["username"]}
 server_password: ${var.server_configuration["password"]}
@@ -27,11 +27,11 @@ module "locust-slave" {
   name = "${var.name}-slave"
   count = "${var.slave_count}"
   ssh_key_path = "${var.ssh_key_path}"
+  roles = ["locust"]
   grains = <<EOF
 
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: locust
 locust_file: ${base64encode(file(var.locust_file))}
 server_username: ${var.server_configuration["username"]}
 server_password: ${var.server_configuration["password"]}

--- a/modules/openstack/minion/main.tf
+++ b/modules/openstack/minion/main.tf
@@ -12,12 +12,12 @@ module "minion" {
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   ipv6 = "${var.ipv6}"
+  roles = "${var.roles}"
   grains = <<EOF
 
 product_version: ${var.product_version}
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: minion
 auto_connect_to_master: ${var.auto_connect_to_master}
 apparmor: ${var.apparmor}
 avahi_reflector: ${var.avahi_reflector}

--- a/modules/openstack/minion/variables.tf
+++ b/modules/openstack/minion/variables.tf
@@ -8,6 +8,11 @@ variable "name" {
   type = "string"
 }
 
+variable "roles"  {
+  description = "List of the host roles"
+  default = ["minion"]
+}
+
 variable "product_version" {
   description = "A valid SUSE Manager version (eg. 3.2-nightly, head) see README_ADVANCED.md"
   default = "released"

--- a/modules/openstack/minionssh/main.tf
+++ b/modules/openstack/minionssh/main.tf
@@ -12,10 +12,10 @@ module "minionssh" {
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   ipv6 = "${var.ipv6}"
+  roles = ["minionssh"]
   grains = <<EOF
 
 product_version: ${var.product_version}
-role: minionssh
 
 EOF
 

--- a/modules/openstack/mirror/main.tf
+++ b/modules/openstack/mirror/main.tf
@@ -7,9 +7,9 @@ module "mirror" {
   additional_packages = "${var.additional_packages}"
   swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
+  roles = ["mirror"]
   grains = <<EOF
 
-role: mirror
 cc_username: ${var.base_configuration["cc_username"]}
 cc_password: ${var.base_configuration["cc_password"]}
 data_disk_device: vdb

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -25,6 +25,7 @@ module "suse_manager" {
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
   ipv6 = "${var.ipv6}"
+  roles = ["suse_manager_server"]
   grains = <<EOF
 
 product_version: ${var.product_version}
@@ -36,7 +37,6 @@ mirror: ${var.base_configuration["mirror"]}
 iss_master: ${var.iss_master}
 iss_slave: ${var.iss_slave}
 smt: ${var.smt}
-role: suse_manager_server
 server_username: ${var.server_username}
 server_password: ${var.server_password}
 disable_firewall: ${var.disable_firewall}

--- a/modules/openstack/suse_manager_proxy/main.tf
+++ b/modules/openstack/suse_manager_proxy/main.tf
@@ -24,12 +24,12 @@ module "suse_manager_proxy" {
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
   ipv6 = "${var.ipv6}"
+  roles = ["suse_manager_proxy"]
   grains = <<EOF
 
 product_version: ${var.product_version}
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: suse_manager_proxy
 minion: ${var.minion}
 auto_connect_to_master: ${var.auto_connect_to_master}
 auto_register: ${var.auto_register}

--- a/salt/default/testsuite.sls
+++ b/salt/default/testsuite.sls
@@ -1,5 +1,5 @@
 {% if grains.get('testsuite') | default(false, true) %}
-{% if grains.get('role') in ['client', 'minion', 'minionssh'] %}
+{% if 'client' in grains.get('roles') or 'minion' in grains.get('roles') or 'minionssh' in grains.get('roles') %}
 
 include:
   - repos

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -21,7 +21,7 @@ os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/oss/
 
-{% if not grains.get('role') or not grains.get('role').startswith('suse_manager') %}
+{% if not grains.get('roles') or ('suse_manager_server' not in grains.get('roles') and 'suse_manager_proxy' not in grains.get('roles')) %}
 {% if grains.get('product_version') and grains.get('product_version').startswith('uyuni-') %}
 tools_pool_repo:
   pkgrepo.managed:
@@ -36,7 +36,7 @@ tools_pool_repo_master:
     - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
     - priority: 98
 {% endif %}
-{% endif %}
+{% endif %} {# not grains.get('roles') or ('suse_manager_server' not in grains.get('roles') and 'suse_manager_proxy' not in grains.get('roles')) #}
 
 {% elif grains['osfullname'] == 'SLES' %}
 
@@ -185,7 +185,7 @@ test_update_repo:
 
 {% endif %}
 
-{% if not grains.get('role') or not grains.get('role').startswith('suse_manager') %}
+{% if not grains.get('roles') or ('suse_manager_server' not in grains.get('roles') and 'suse_manager_proxy' not in grains.get('roles')) %}
 {% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %}
 tools_pool_repo:
   pkgrepo.managed:
@@ -219,12 +219,12 @@ tools_additional_repo:
     - priority: 98
 {% endif %}
 
-{% endif %} {# not grains.get('role') or not grains.get('role').startswith('suse_manager') #}
+{% endif %} {# not grains.get('roles') or ('suse_manager_server' not in grains.get('roles') and 'suse_manager_proxy' not in grains.get('roles')) #}
 {% endif %} {# '12' in grains['osrelease'] #}
 
 
 {% if '15' in grains['osrelease'] %}
-{% if not grains.get('role') or not grains.get('role').startswith('suse_manager') %}
+{% if not grains.get('roles') or ('suse_manager_server' not in grains.get('roles') and 'suse_manager_proxy' not in grains.get('roles')) %}
 {% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %}
 tools_pool_repo:
   pkgrepo.managed:
@@ -256,7 +256,7 @@ tools_update_repo:
     - priority: 98
 {% endif %}
 
-{% endif %} {# not grains.get('role') or not grains.get('role').startswith('suse_manager') #}
+{% endif %} {# not grains.get('roles') or ('suse_manager_server' not in grains.get('roles') and 'suse_manager_proxy' not in grains.get('roles')) #}
 {% endif %} {# '15' in grains['osrelease'] #}
 
 {% if '15' == grains['osrelease'] %}

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -1,4 +1,4 @@
-{% if grains.get('role') == 'minion' and grains.get('testsuite') | default(false, true) and grains['os'] == 'SUSE' %}
+{% if 'minion' in grains.get('roles') and grains.get('testsuite') | default(false, true) and grains['os'] == 'SUSE' %}
 
 {% if '12' in grains['osrelease'] %}
 containers_pool_repo:

--- a/salt/repos/suse_manager_proxy.sls
+++ b/salt/repos/suse_manager_proxy.sls
@@ -1,4 +1,4 @@
-{% if grains.get('role') == 'suse_manager_proxy' %}
+{% if 'suse_manager_proxy' in grains.get('roles') %}
 
 {% if '3.2' in grains['product_version'] %}
 suse_manager_proxy_pool_repo:

--- a/salt/repos/suse_manager_server.sls
+++ b/salt/repos/suse_manager_server.sls
@@ -1,4 +1,4 @@
-{% if grains.get('role') == 'suse_manager_server' %}
+{% if 'suse_manager_server' in grains.get('roles') %}
 
 {% if '3.2' in grains['product_version'] %}
 suse_manager_pool_repo:

--- a/salt/repos/testsuite.sls
+++ b/salt/repos/testsuite.sls
@@ -1,5 +1,5 @@
 {% if grains.get('testsuite') | default(false, true) %}
-{% if grains.get('role') in ['client', 'minion', 'minionssh'] %}
+{% if 'client' in grains.get('roles') or 'minion' in grains.get('roles') or 'minionssh' in grains.get('roles') %}
 
 {% if grains['os'] == 'SUSE' %}
 

--- a/salt/repos/tools.sls
+++ b/salt/repos/tools.sls
@@ -1,5 +1,7 @@
 {% if grains['os'] == 'SUSE' and (
-      grains.get('role') in ['controller', 'grafana', 'mirror'] or
+      'controller' in grains.get('roles') or
+      'grafana' in grains.get('roles') or
+      'mirror' in grains.get('roles') or
       grains.get('evil_minion_count') or
       grains.get('monitored') or
       grains.get('pts')

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -2,35 +2,35 @@ base:
   '*':
     - default
 
-  'role:suse_manager_server':
+  'roles:suse_manager_server':
     - match: grain
     - suse_manager_server
 
-  'role:client':
+  'roles:client':
     - match: grain
     - client
 
-  'role:suse_manager_proxy':
+  'roles:suse_manager_proxy':
     - match: grain
     - suse_manager_proxy
 
-  'role:minion':
+  'roles:minion':
     - match: grain
     - minion
 
-  'role:mirror':
+  'roles:mirror':
     - match: grain
     - mirror
 
-  'role:controller':
+  'roles:controller':
     - match: grain
     - controller
 
-  'role:grafana':
+  'roles:grafana':
     - match: grain
     - grafana
 
-  'role:locust':
+  'roles:locust':
     - match: grain
     - locust
 

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -34,6 +34,6 @@ base:
     - match: grain
     - locust
 
-  'virtual_host:true':
+  'roles: virthost':
     - match: grain
     - virthost


### PR DESCRIPTION
This is expected to be an internal-only change.

At the moment all it does is to open the door to overlay roles, which will be needed to implement Servers registering to other Servers.

@cbosdo I took the liberty of using `virthost` as the first example on how this refactoring could be useful.

I am pretty certain more cases will come up later.