### PR TITLE
Disable download token checking by default

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -114,7 +114,7 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
    * `create_sample_activation_key`: whether to create a sample activation key. Requires `create_first_user`
    * `create_sample_bootstrap_script`: whether to create a sample bootstrap script for traditional clients. Requires `create_sample_activation_key`
    * `publish_private_ssl_key`: copies the private SSL key in /pub for Proxies to copy automatically. Set to `false` for manual distribution
-   * `disable_download_tokens`: disable package token download checks. Set to `true` to enable checking
+   * `disable_download_tokens`: disable package token download checks. Set to `false` to enable checking
 
 
 ## Adding channels to SUSE Manager Servers

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -114,6 +114,7 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
    * `create_sample_activation_key`: whether to create a sample activation key. Requires `create_first_user`
    * `create_sample_bootstrap_script`: whether to create a sample bootstrap script for traditional clients. Requires `create_sample_activation_key`
    * `publish_private_ssl_key`: copies the private SSL key in /pub for Proxies to copy automatically. Set to `false` for manual distribution
+   * `disable_download_tokens`: disable package token download checks. Set to `true` to enable checking
 
 
 ## Adding channels to SUSE Manager Servers

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -56,6 +56,7 @@ module "srv" {
   create_sample_activation_key = false
   create_sample_bootstrap_script = false
   publish_private_ssl_key = false
+  disable_download_tokens = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 

--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -62,6 +62,7 @@ module "srv" {
   create_sample_activation_key = false
   create_sample_bootstrap_script = false
   publish_private_ssl_key = false
+  disable_download_tokens = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -53,6 +53,7 @@ create_sample_channel: ${var.create_sample_channel}
 create_sample_activation_key: ${var.create_sample_activation_key}
 create_sample_bootstrap_script: ${var.create_sample_bootstrap_script}
 publish_private_ssl_key: ${var.publish_private_ssl_key}
+disable_download_tokens: ${var.disable_download_tokens}
 auto_accept: ${var.auto_accept}
 monitored: ${var.monitored}
 pts: ${var.pts}

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -104,6 +104,11 @@ variable "publish_private_ssl_key" {
   default = true
 }
 
+variable "disable_download_tokens" {
+  description = "disable package token download checks"
+  default = true
+}
+
 variable "use_os_released_updates" {
   description = "Apply all updates from SUSE Linux Enterprise repos"
   default = false

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -51,6 +51,7 @@ create_sample_channel: ${var.create_sample_channel}
 create_sample_activation_key: ${var.create_sample_activation_key}
 create_sample_bootstrap_script: ${var.create_sample_bootstrap_script}
 publish_private_ssl_key: ${var.publish_private_ssl_key}
+disable_download_tokens: ${var.disable_download_tokens}
 auto_accept: ${var.auto_accept}
 monitored: ${var.monitored}
 pts: ${var.pts}

--- a/modules/openstack/suse_manager/variables.tf
+++ b/modules/openstack/suse_manager/variables.tf
@@ -104,6 +104,11 @@ variable "publish_private_ssl_key" {
   default = true
 }
 
+variable "disable_download_tokens" {
+  description = "disable package token download checks"
+  default = true
+}
+
 variable "use_os_released_updates" {
   description = "Apply all updates from SUSE Linux Enterprise repos"
   default = false

--- a/salt/suse_manager_server/rhn.sls
+++ b/salt/suse_manager_server/rhn.sls
@@ -29,6 +29,15 @@ browser_side_less_configuration:
 
 {% endif %}
 
+{% if grains.get('disable_download_tokens') %}
+disable_download_tokens:
+  file.append:
+    - name: /etc/rhn/rhn.conf
+    - text: java.salt_check_download_tokens = false
+    - require:
+      - sls: suse_manager_server
+{% endif %}
+
 {% if salt["grains.get"]("mirror") %}
 
 nfs_client:


### PR DESCRIPTION
## What does this PR change?

It disables token checking by default on Servers, which is convenient to consume repos from other sumaform hosts.