### PR TITLE
enable debug for salt master and api

### DIFF
--- a/salt/suse_manager_server/master-custom.conf
+++ b/salt/suse_manager_server/master-custom.conf
@@ -4,3 +4,4 @@ auto_accept: True
 ssh_minion_opts:
     log_file: ../../../../../var/log/salt-ssh.log
     log_level: debug
+log_level: debug


### PR DESCRIPTION
## Warning

In most cases, it is not enough if you modify the terraform modules at `modules/libvirt`. Check if you also need changes at `modules/openstack` and `modules/aws`.

## What does this PR change?

Enable debug for salt master and api to debug connection problems when bootstrapping clients
