### PR TITLE
Minion: only add the container module for SLES

### DIFF
--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -1,4 +1,4 @@
-{% if 'minion' in grains.get('roles') and grains.get('testsuite') | default(false, true) and grains['os'] == 'SUSE' %}
+{% if 'minion' in grains.get('roles') and grains.get('testsuite') | default(false, true) and grains['osfullname'] == 'SLES' %}
 
 {% if '12' in grains['osrelease'] %}
 containers_pool_repo:


### PR DESCRIPTION
## What does this PR change?

Since openSUSE minions have no modules, keep those for SLES minions only.
