### PR TITLE
Renamed fake repositories to standard_rpm and standard_deb

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -217,13 +217,13 @@ http:
     archs: [x86_64]
 
   # Testsuite dummy packages for testing repo
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/SLE_12_SP4
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_rpm
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/xUbuntu_18.04
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_deb
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/SLE_12_SP4
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/standard_rpm
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/xUbuntu_18.04
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/standard_deb
     archs: [x86_64]
 
   # Software for sumaformed Virtual Machines

--- a/salt/repos/repos.d/Test-Packages_Pool.list
+++ b/salt/repos/repos.d/Test-Packages_Pool.list
@@ -1,1 +1,1 @@
-deb [trusted=yes] http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/xUbuntu_18.04/ /
+deb [trusted=yes] http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_deb/ /

--- a/salt/repos/repos.d/Test-Packages_Pool.repo
+++ b/salt/repos/repos.d/Test-Packages_Pool.repo
@@ -2,6 +2,6 @@
 name=Testsuite Test Packages - Pool (SLE_12_SP4)
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/SLE_12_SP4/
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_rpm/
 gpgcheck=1
-gpgkey=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/SLE_12_SP4/repodata/repomd.xml.key
+gpgkey=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_rpm/repodata/repomd.xml.key

--- a/salt/repos/testsuite.sls
+++ b/salt/repos/testsuite.sls
@@ -1,19 +1,11 @@
 {% if grains.get('testsuite') | default(false, true) %}
 {% if grains.get('role') in ['client', 'minion', 'minionssh'] %}
 
-{% if grains['os'] == 'SUSE' %}
+{% if (grains['os'] == 'SUSE') or (grains['os_family'] == 'RedHat') %}
 
 test_repo_rpm_pool:
   file.managed:
     - name: /etc/zypp/repos.d/Test-Packages_Pool.repo
-    - source: salt://repos/repos.d/Test-Packages_Pool.repo
-    - template: jinja
-
-{% elif grains['os_family'] == 'RedHat' %}
-
-test_repo_rpm_pool:
-  file.managed:
-    - name: /etc/yum.repos.d/Test-Packages_Pool.repo
     - source: salt://repos/repos.d/Test-Packages_Pool.repo
     - template: jinja
 

--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -62,7 +62,7 @@ test_repo_rpm_updates:
     - name: minima sync
     - env:
       - MINIMA_CONFIG: |
-          - url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/SLE_12_SP4
+          - url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/standard_rpm
             path: /srv/www/htdocs/pub/TestRepoRpmUpdates
     - require:
       - archive: minima
@@ -77,7 +77,7 @@ another_test_repo:
 test_repo_debian_updates:
   cmd.script:
     - name: salt://suse_manager_server/download_ubuntu_repo.sh
-    - args: "TestRepoDebUpdates {{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/xUbuntu_18.04/"
+    - args: "TestRepoDebUpdates {{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/standard_deb/"
     - creates: /srv/www/htdocs/pub/TestRepoDebUpdates/Release
     - require:
       - pkg: testsuite_packages


### PR DESCRIPTION
## What does this PR change?

This PR adopts the new fake packages project layout as discussed by email.

## Links

master: #613