### PR TITLE
Support for additional disk in server & proxy mounting in /var/spacewalk

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -797,3 +797,19 @@ module "minion" {
 ```
 
 To disable the swap file, set its size to 0.
+
+# Additional disk on SUSE Manager server or proxy
+
+In case the default disk size for those machines is not enough for the amount of products you want to synchronize. You can add an additional disk which will mount the first volume in /var/spacewalk with size `repository_disk_size`. This additional disk will be created in the pool specified by `data_pool`
+
+A libvirt example is:
+
+```hcl
+module "server" {
+  source = "sumaform/modules/libvirt/suse_manager"
+  base_configuration = "${module.base.configuration}"
+  product_version = "4.0-nightly"
+  name = "server"
+  repository_disk_size = 536870912000
+  data_pool = "default"
+```

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -261,9 +261,14 @@ variable "mac" {
   default = ""
 }
 
-variable "additional_disk" {
-  description = "disk block definition(s) to be added to this host"
-  default = []
+variable "repository_disk_size" {
+  description = "Size of an aditional disk for /var/spacewalk partition"
+  default = 0
+}
+
+variable "data_pool" {
+  description = "libvirt storage pool name for this host's data disk"
+  default = "default"
 }
 
 variable "cpu_model" {

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -10,6 +10,13 @@ variable "images" {
   }
 }
 
+resource "libvirt_volume" "server_data_disk" {
+  name = "${var.base_configuration["name_prefix"]}${var.name}-server-data-disk"
+  size = "${var.repository_disk_size}"
+  pool = "${var.data_pool}"
+  count = "${var.repository_disk_size > 0 ? 1 : 0}"
+}
+
 module "suse_manager_proxy" {
   source = "../host"
 
@@ -42,6 +49,7 @@ server_password: ${var.server_configuration["password"]}
 generate_bootstrap_script: ${var.generate_bootstrap_script}
 publish_private_ssl_key: ${var.publish_private_ssl_key}
 apparmor: ${var.apparmor}
+repository_disk_size: ${var.repository_disk_size}
 
 EOF
 
@@ -51,6 +59,15 @@ EOF
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
+
+  // HACK: Terraform 0.11 ternary operator is not short-circuiting
+  // https://github.com/hashicorp/terraform/issues/11566
+  // example by https://github.com/coreos/tectonic-installer/commit/0f209b31b169ce129ba457096b23792f6601d66e#diff-17708827fa84c637698cd840c01710c9R16
+  additional_disk = "${slice(
+    list(map("volume_id", join("",libvirt_volume.server_data_disk.*.id))),
+    0,
+    var.repository_disk_size > 0 ? 1 : 0
+  )}"
 }
 
 output "configuration" {

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -135,6 +135,16 @@ variable "mac" {
   default = ""
 }
 
+variable "repository_disk_size" {
+  description = "Size of an aditional disk for /var/spacewalk partition"
+  default = 0
+}
+
+variable "data_pool" {
+  description = "libvirt storage pool name for this host's data disk"
+  default = "default"
+}
+
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default = ""

--- a/salt/suse_manager_proxy/additional_disk.sls
+++ b/salt/suse_manager_proxy/additional_disk.sls
@@ -1,0 +1,31 @@
+include:
+  - default
+
+{% if grains.get('repository_disk_size') > 0 %}
+
+parted:
+  pkg.installed
+
+spacewalk_partition:
+  cmd.run:
+    - name: /usr/sbin/parted -s /dev/vdb mklabel gpt && /usr/sbin/parted -s /dev/vdb mkpart primary 0% 100% && sleep 1 && /sbin/mkfs.ext4 /dev/vdb1
+    - unless: ls /dev/vdb1
+    - require:
+      - pkg: parted
+
+spacewalk_directory:
+  file.directory:
+    - name: /var/spacewalk
+    - makedirs: True
+  mount.mounted:
+    - name: /var/spacewalk
+    - device: /dev/vdb1
+    - fstype: ext4
+    - mkmnt: True
+    - persist: True
+    - opts:
+      - defaults
+    - require:
+      - cmd: spacewalk_partition
+
+{% endif %}

--- a/salt/suse_manager_proxy/init.sls
+++ b/salt/suse_manager_proxy/init.sls
@@ -1,5 +1,6 @@
 include:
   - repos
+  - suse_manager_proxy.additional_disk
   - suse_manager_proxy.apparmor
 {% if grains['minion'] %}
   - minion

--- a/salt/suse_manager_server/additional_disk.sls
+++ b/salt/suse_manager_server/additional_disk.sls
@@ -1,0 +1,31 @@
+include:
+  - default
+
+{% if grains.get('repository_disk_size') > 0 %}
+
+parted:
+  pkg.installed
+
+spacewalk_partition:
+  cmd.run:
+    - name: /usr/sbin/parted -s /dev/vdb mklabel gpt && /usr/sbin/parted -s /dev/vdb mkpart primary 0% 100% && sleep 1 && /sbin/mkfs.ext4 /dev/vdb1
+    - unless: ls /dev/vdb1
+    - require:
+      - pkg: parted
+
+spacewalk_directory:
+  file.directory:
+    - name: /var/spacewalk
+    - makedirs: True
+  mount.mounted:
+    - name: /var/spacewalk
+    - device: /dev/vdb1
+    - fstype: ext4
+    - mkmnt: True
+    - persist: True
+    - opts:
+      - defaults
+    - require:
+      - cmd: spacewalk_partition
+
+{% endif %}

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -1,5 +1,6 @@
 include:
   - repos
+  - suse_manager_server.additional_disk
   - suse_manager_server.firewall
   - suse_manager_server.postgres
   - suse_manager_server.tomcat


### PR DESCRIPTION
Related task: https://github.com/SUSE/spacewalk/issues/9486

> Note: I had issues testing from master, so my only choice was to move to this temporal branch, where I succeded with the contribution. 

Adding support for an additional disk mounting in /var/spacewalk
On susemanager_server and susemanager_proxy on libvirt provider.

Example main.tf
```
provider "libvirt" {
  uri = "qemu:///system"
}

module "base" {
  source = "sumaform/modules/libvirt/base"

  cc_username = "xxxxx"
  cc_password = "xxxxx"

  pool = "obarrios_disks"
  additional_network = "192.168.6.0/24"
  name_prefix = "oba-"
  images = ["sles15sp1"]
}

module "server" {
  source = "sumaform/modules/libvirt/suse_manager"
  base_configuration = "${module.base.configuration}"
  product_version = "4.0-nightly"
  name = "server"  
  repository_disk_size = 109951162777

  auto_accept = false
  disable_firewall = false
  allow_postgres_connections = false
  skip_changelog_import = false
  browser_side_less = false
  create_first_user = false
  mgr_sync_autologin = false
  create_sample_channel = false
  create_sample_activation_key = false
  create_sample_bootstrap_script = false
  publish_private_ssl_key = false

  ssh_key_path = "./salt/controller/id_rsa.pub"

}
```