### PR TITLE
Temporarily don't use mirrors for fake packages

### DIFF
--- a/salt/repos/repos.d/Test-Packages_Pool.list
+++ b/salt/repos/repos.d/Test-Packages_Pool.list
@@ -1,1 +1,1 @@
-deb [trusted=yes] http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_deb/ /
+deb [trusted=yes] http://ftp2.nluug.nl/os/Linux/distr/opensuse/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_deb/ /

--- a/salt/repos/repos.d/Test-Packages_Pool.repo
+++ b/salt/repos/repos.d/Test-Packages_Pool.repo
@@ -2,6 +2,6 @@
 name=Testsuite Test Packages - Pool (SLE_12_SP4)
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_rpm/
+baseurl=http://ftp2.nluug.nl/os/Linux/distr/opensuse/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_rpm/
 gpgcheck=1
-gpgkey=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_rpm/repodata/repomd.xml.key
+gpgkey=http://ftp2.nluug.nl/os/Linux/distr/opensuse/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_rpm/repodata/repomd.xml.key


### PR DESCRIPTION
## What does this PR change?

Temporary workaround, `testsuite-stable-with-new-fake-repos` branch only.

Don't use arbitrary mirrors for fake packages. Use the one in the Netherlands.

Reason: we had to keep same version and release numbers when redoing the fake packages, and this puzzles some mirrors, and others not.

Long term solution is to fix problem at mirrors.
