### PR TITLE
[WIP] configure loglevel for salt and python

### DIFF
--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -52,6 +52,8 @@ disable_firewall: ${var.disable_firewall}
 allow_postgres_connections: ${var.allow_postgres_connections}
 unsafe_postgres: ${var.unsafe_postgres}
 java_debugging: ${var.java_debugging}
+salt_logging: ${var.salt_logging}
+python_logging: ${var.python_logging}
 skip_changelog_import: ${var.skip_changelog_import}
 browser_side_less: ${var.browser_side_less}
 create_first_user: ${var.create_first_user}

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -79,6 +79,16 @@ variable "java_debugging" {
   default = true
 }
 
+variable "salt_logging" {
+  description = "set all salt logging to 'info', 'debug' or 'trace'"
+  default = "info"
+}
+
+variable "python_logging" {
+  description = "set python backend to loglevel 0 - 10"
+  default = 0
+}
+
 variable "skip_changelog_import" {
   description = "import RPMs without changelog data, this speeds up spacewalk-repo-sync"
   default = true

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -46,6 +46,8 @@ disable_firewall: ${var.disable_firewall}
 allow_postgres_connections: ${var.allow_postgres_connections}
 unsafe_postgres: ${var.unsafe_postgres}
 java_debugging: ${var.java_debugging}
+salt_logging: ${var.salt_logging}
+python_logging: ${var.python_logging}
 skip_changelog_import: ${var.skip_changelog_import}
 browser_side_less: ${var.browser_side_less}
 create_first_user: ${var.create_first_user}

--- a/modules/openstack/suse_manager/variables.tf
+++ b/modules/openstack/suse_manager/variables.tf
@@ -79,6 +79,16 @@ variable "java_debugging" {
   default = true
 }
 
+variable "salt_logging" {
+  description = "set all salt logging to 'info', 'debug' or 'trace'"
+  default = "info"
+}
+
+variable "python_logging" {
+  description = "set python backend to loglevel 0 - 10"
+  default = 0
+}
+
 variable "skip_changelog_import" {
   description = "import RPMs without changelog data, this speeds up spacewalk-repo-sync"
   default = true

--- a/salt/suse_manager_server/master-custom.conf
+++ b/salt/suse_manager_server/master-custom.conf
@@ -3,4 +3,6 @@ auto_accept: True
 {% endif %}
 ssh_minion_opts:
     log_file: ../../../../../var/log/salt-ssh.log
-    log_level: debug
+    log_level: {{ grains.get('salt_logging') | default('info', true) }}
+
+log_level: {{ grains.get('salt_logging') | default('info', true) }}

--- a/salt/suse_manager_server/rhn.sls
+++ b/salt/suse_manager_server/rhn.sls
@@ -89,6 +89,13 @@ rhn_conf_prometheus:
 
 {% endif %}
 
+rhn_conf_debug:
+  file.append:
+    - name: /etc/rhn/rhn.conf
+    - text: debug = {{ grains.get('python_logging') | default(0, true) }}
+    - require:
+      - sls: suse_manager_server
+
 # catch-all to ensure we always have at least one state covering /etc/rhn/rhn.conf
 rhn_conf_present:
   file.touch:


### PR DESCRIPTION
## Warning

In most cases, it is not enough if you modify the terraform modules at `modules/libvirt`. Check if you also need changes at `modules/openstack` and `modules/aws`.

## What does this PR change?

Configure logging and loglevel via main.tf .

As of now for salt and python backend.
