### PR TITLE
Install the GPG key of download.opensuse.org

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -217,13 +217,13 @@ http:
     archs: [x86_64]
 
   # Testsuite dummy packages for testing repo
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_rpm
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/standard_deb
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/standard_rpm
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/rpm
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/standard_deb
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb
     archs: [x86_64]
 
   # Software for sumaformed Virtual Machines

--- a/salt/repos/testsuite.sls
+++ b/salt/repos/testsuite.sls
@@ -3,6 +3,15 @@
 
 {% if grains['os'] == 'SUSE' %}
 
+uyuni_key_for_fake_packages:
+  file.managed:
+    - name: /tmp/uyuni.key
+    - source: salt://default/gpg_keys/uyuni.key
+  cmd.wait:
+    - name: rpm --import /tmp/uyuni.key
+    - watch:
+      - file: uyuni_key_for_fake_packages
+
 test_repo_rpm_pool:
   file.managed:
     - name: /etc/zypp/repos.d/Test-Packages_Pool.repo
@@ -10,6 +19,15 @@ test_repo_rpm_pool:
     - template: jinja
 
 {% elif grains['os_family'] == 'RedHat' %}
+
+uyuni_key_for_fake_packages:
+  file.managed:
+    - name: /tmp/uyuni.key
+    - source: salt://default/gpg_keys/uyuni.key
+  cmd.wait:
+    - name: rpm --import /tmp/uyuni.key
+    - watch:
+      - file: uyuni_key_for_fake_packages
 
 test_repo_rpm_pool:
   file.managed:


### PR DESCRIPTION
This PR installs the GPG key of download.opensuse.org when we run the test suite.

If we are running the testsuite, we need the fake packages,
and those are now on download.opensuse.org.

Note: This key is also installed during completly different circumstances (on RedHat client, when we are running uyuni)
