### PR TITLE
Remove DEBUG log_level for salt-master and salt-api

### DIFF
--- a/salt/suse_manager_server/master-custom.conf
+++ b/salt/suse_manager_server/master-custom.conf
@@ -4,4 +4,3 @@ auto_accept: True
 ssh_minion_opts:
     log_file: ../../../../../var/log/salt-ssh.log
     log_level: debug
-log_level: debug


### PR DESCRIPTION
## What does this PR change?

This PR removes the `log_level: debug` for `salt-master` and `salt-api` in order to prevent testsuite failures due unexpected DEBUG output while checking pillar data.
