### PR TITLE
Update AWS templates

### DIFF
--- a/github_deploy_key
+++ b/github_deploy_key
@@ -1,0 +1,1 @@
+put private github deploy key here

--- a/main.tf.aws-create-mirror-snapshot.example
+++ b/main.tf.aws-create-mirror-snapshot.example
@@ -1,0 +1,82 @@
+// This template can be used to create a mirror hosts data snapshot.
+// To do so, copy this template to main.tf, fill in your SCC and AWS
+// credentials and the regions and AMI information.
+
+// Create a mirror instance using 'terraform apply', and if successful,
+// run 'modules/aws/create_aws_mirror_snapshot' to sync
+// channels and create a snapshot from the resulting data volume.
+
+// If you want to base the snapshot on an existing snapshot, either set
+// data_volume_snapshot_id to the ID of the snapshot to use, or set it
+// to "${data.aws_ebs_snapshot.data_disk_snapshot.id}" to look up the
+// latest snapshot that uses the same $name_prefix.
+
+locals {
+  cc_username       = "" // SCC or NCC username
+  cc_password       = "" // SCC password
+  key_name          = "" // SSH key name
+  key_file          = "" // SSH key file
+  name_prefix       = "mirrorsnap"  // change to a prefix if you do not have an exclusive VPC
+  region            = "eu-west-2"
+  availability_zone = "${local.region}a"
+}
+
+provider "aws" {
+  region     = "${local.region}"
+  access_key = "" // add access key as a string here
+  secret_key = "" // add secret key as a string here
+}
+
+module "aws_network" {
+  source            = "./modules/aws/network"
+  region            = "${local.region}"
+  availability_zone = "${local.availability_zone}"
+
+  ssh_allowed_ips = [
+    "1.2.3.4",
+  ]
+
+  name_prefix = "${local.name_prefix}"
+}
+
+data "aws_ebs_snapshot" "data_disk_snapshot" {
+  most_recent = true
+
+  filter {
+    name   = "tag:Name"
+    values = ["${local.name_prefix}-mirror-data-volume-snapshot"]
+  }
+}
+
+module "aws_mirror" {
+  source                   = "./modules/aws/mirror"
+  region                   = "${local.region}"
+  availability_zone        = "${local.availability_zone}"
+  ami                      = "ami-00aa3f926488064bf"
+  key_name                 = "${local.key_name}"
+  key_file                 = "${local.key_file}"
+  public_subnet_id         = "${module.aws_network.public_subnet_id}"
+  public_security_group_id = "${module.aws_network.public_security_group_id}"
+  cc_username              = "${local.cc_username}"
+  cc_password              = "${local.cc_password}"
+  name_prefix              = "${local.name_prefix}"
+  minima_config            = "minima-small.yaml"
+  data_volume_snapshot_id  = "" // use existing snapshot as starting point
+                                // leave empty to create from scratch
+}
+
+output "mirror_host_name" {
+  value = "${module.aws_mirror.public_name}"
+}
+
+output "ebs_volume_id" {
+  value = "${module.aws_mirror.data_volume_id}"
+}
+
+output "region" {
+  value = "${local.region}"
+}
+
+output "snapshot_name" {
+  value = "${local.name_prefix}-mirror-data-volume-snapshot"
+}

--- a/main.tf.aws-testsuite.example
+++ b/main.tf.aws-testsuite.example
@@ -212,11 +212,23 @@ resource "null_resource" "update_server_conf" {
   }
 }
 
-output "mirror host public name" {
+output "mirror_host_name" {
   value = "${module.aws_mirror.public_name}"
 }
 
-output "controller host public name" {
+output "ebs_volume_id" {
+  value = "${module.aws_mirror.data_volume_id}"
+}
+
+output "region" {
+  value = "${local.region}"
+}
+
+output "snapshot_name" {
+  value = "${local.name_prefix}-mirror-data-volume-snapshot"
+}
+
+output "controller_host_public_name" {
   value = "${module.testcontroller.public_name}"
 }
 

--- a/main.tf.aws-testsuite.example
+++ b/main.tf.aws-testsuite.example
@@ -1,0 +1,222 @@
+locals {
+  cc_username = "CC_USER" // SCC or NCC username
+  cc_password = "CC_PASS"   //SCC or NCC password
+  key_name = "AWS_KEY"      // SSH key name
+  key_file = "/path/to/priave_ssh_key"      // SSH key file
+  name_prefix = "sumatest"   // change to a prefix if you do not have an exclusive VPC
+  prod_version = "4.0"
+  region = "eu-central-1"
+  availability_zone = "${local.region}a"
+}
+
+provider "aws" {
+  region = "${local.region}"
+  access_key = "MY_AWS_ACCESS_KEY" // add access key as a string here
+  secret_key = "MY_AWS_SECRET_KEY" // add secret key as a string here
+}
+
+
+module "aws_network" {
+  source = "./modules/aws/network"
+  region = "${local.region}"
+  availability_zone = "${local.availability_zone}"
+  ssh_allowed_ips = [
+    "1.2.3.4"
+  ]
+  name_prefix = "${local.name_prefix}"
+}
+
+data "aws_ebs_snapshot" "data_disk_snapshot" {
+  most_recent = true
+
+  filter {
+    name   = "tag:Name"
+    values = ["${local.name_prefix}-mirror-data-volume-snapshot"]
+  }
+}
+
+module "aws_mirror" {
+  source = "./modules/aws/mirror"
+  region = "${local.region}"
+  availability_zone = "${local.availability_zone}"
+  ami = "" // AMI ID of image to use as mirror. openSUSE Leap works fine. Image needs to have salt-minion installed.
+  key_name = "${local.key_name}"
+  key_file = "${local.key_file}"
+  data_volume_snapshot_id = "${data.aws_ebs_snapshot.data_disk_snapshot.id}" // see top comment in modules/aws/mirror/main.tf
+  public_subnet_id = "${module.aws_network.public_subnet_id}"
+  public_security_group_id = "${module.aws_network.public_security_group_id}"
+  cc_username = "${local.cc_username}"
+  cc_password = "${local.cc_password}"
+  name_prefix = "${local.name_prefix}"
+  additional_repos {
+    tools_repo = "http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.0/"
+  }
+}
+
+module "aws_server" {
+  dependencies = [
+    "${module.aws_mirror.depended_on}"
+  ]
+  source = "./modules/aws/host"
+  roles = ["suse_manager_server"]
+  name = "server"
+  region = "${local.region}"
+  availability_zone = "${local.availability_zone}"
+  ami = "" // look up ID with 'pint amazon images --active --region my-region --filter name~manager-4-0-server'
+  instance_type = "t2.large"
+  volume_size = 100 // GiB
+  key_name = "${local.key_name}"
+  key_file = "${local.key_file}"
+  monitored = false
+  private_subnet_id = "${module.aws_network.private_subnet_id}"
+  private_security_group_id = "${module.aws_network.private_security_group_id}"
+  name_prefix = "${local.name_prefix}"
+  authorized_keys = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDOSLK0kJAulwO9Qwm/DVKLsGzv8Fh+ZcGe5x5d+VzO4/+xKnxjOPvGVngm9Hki8N436bCCvIRqwzstDUyJnTHhEe3qzsl02QGqIIfVjzK3BEp4sA8XcmByBy3pxqbTjAjrW8a+n43DBRMx4J86LgywX3fFt8ceEym3rFer/IzQD9QvKRocycNCwhpmGKEDh4zdl9PdyU5RcUpiA01AD/8rdJMNYnUxIsaNElcgP2LSzROjNdyu11cq9h3/cb3b7oRRef718GOkIkzqL/szo4Mm/j4KfyG0SBWyPxlJktFADD3lcQIRrGakFhiZOFbg2HZci26q+l/hUfLMbzcBrWlc+gzY4z4LMF8YBy1x/x+yR4j1SzZuqempSRu7rDKevcIGBF/fALPyiXH2EzYKsVcN9nv5mFCjmwVK7WTjw1SFzufKwdmnvOYgyeYuMaOJv3LEBY1jJg8r4xqzuQx32KNK/iJz1E+njptV3ZhOYDiHBmieykP08nWxdS79N1DbljxRzS54T7CArfGo23nYTNlMewPeKFx7ZqtUVv03g8i1Hn8WdArz2TYciWWrPErBEALBpXsu7Oq5AT97wAhcAIf3B3dV5p/bXgnhALA/SodNBf/wr0U2f5VzTDyJ9eNZURt16jSxDgXkuKKY/rimLqqt2FC1SeicmTql1nVyHG3j9Q== root@controller"]
+
+  mirror_public_name = "${module.aws_mirror.public_name}"
+  mirror_private_name = "${module.aws_mirror.private_name}"
+  product_version = "${local.prod_version}"
+  cc_username = "${local.cc_username}"
+  cc_password = "${local.cc_password}"
+  testsuite = true
+  no_install = true
+}
+
+module "aws_minion" {
+  dependencies = [
+    "${module.aws_mirror.depended_on}"
+  ]
+  source = "./modules/aws/host"
+  roles = ["minion"]
+  name = "sle-minion"
+  count = 1
+  region = "${local.region}"
+  availability_zone = "${local.availability_zone}"
+  ami = "ami-014799f67e8f28c77" // SLES12 SP4 image (SLES12 minion currently required for testsuite)
+                                // look up with 'pint amazon images --active --region my-region --filter name~sles-12-sp4-byos'
+  instance_type = "t2.nano"
+  volume_size = 10 // GiB
+  key_name = "${local.key_name}"
+  key_file = "${local.key_file}"
+  private_subnet_id = "${module.aws_network.private_subnet_id}"
+  private_security_group_id = "${module.aws_network.private_security_group_id}"
+  name_prefix = "${local.name_prefix}"
+  authorized_keys = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDOSLK0kJAulwO9Qwm/DVKLsGzv8Fh+ZcGe5x5d+VzO4/+xKnxjOPvGVngm9Hki8N436bCCvIRqwzstDUyJnTHhEe3qzsl02QGqIIfVjzK3BEp4sA8XcmByBy3pxqbTjAjrW8a+n43DBRMx4J86LgywX3fFt8ceEym3rFer/IzQD9QvKRocycNCwhpmGKEDh4zdl9PdyU5RcUpiA01AD/8rdJMNYnUxIsaNElcgP2LSzROjNdyu11cq9h3/cb3b7oRRef718GOkIkzqL/szo4Mm/j4KfyG0SBWyPxlJktFADD3lcQIRrGakFhiZOFbg2HZci26q+l/hUfLMbzcBrWlc+gzY4z4LMF8YBy1x/x+yR4j1SzZuqempSRu7rDKevcIGBF/fALPyiXH2EzYKsVcN9nv5mFCjmwVK7WTjw1SFzufKwdmnvOYgyeYuMaOJv3LEBY1jJg8r4xqzuQx32KNK/iJz1E+njptV3ZhOYDiHBmieykP08nWxdS79N1DbljxRzS54T7CArfGo23nYTNlMewPeKFx7ZqtUVv03g8i1Hn8WdArz2TYciWWrPErBEALBpXsu7Oq5AT97wAhcAIf3B3dV5p/bXgnhALA/SodNBf/wr0U2f5VzTDyJ9eNZURt16jSxDgXkuKKY/rimLqqt2FC1SeicmTql1nVyHG3j9Q== root@controller"]
+  server = "${module.aws_server.private_names[0]}"
+  mirror_public_name = "${module.aws_mirror.public_name}"
+  mirror_private_name = "${module.aws_mirror.private_name}"
+  testsuite = true
+}
+
+module "aws_client" {
+  dependencies = [
+    "${module.aws_mirror.depended_on}"
+  ]
+  source = "./modules/aws/host"
+  roles = ["client"]
+  name = "sle-client"
+  count = 1
+  region = "${local.region}"
+  availability_zone = "${local.availability_zone}"
+  ami = "ami-014799f67e8f28c77" // see comment in module 'aws_minion' above
+  instance_type = "t2.nano"
+  volume_size = 10 // GiB
+  key_name = "${local.key_name}"
+  key_file = "${local.key_file}"
+  private_subnet_id = "${module.aws_network.private_subnet_id}"
+  private_security_group_id = "${module.aws_network.private_security_group_id}"
+  name_prefix = "${local.name_prefix}"
+  authorized_keys = ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDOSLK0kJAulwO9Qwm/DVKLsGzv8Fh+ZcGe5x5d+VzO4/+xKnxjOPvGVngm9Hki8N436bCCvIRqwzstDUyJnTHhEe3qzsl02QGqIIfVjzK3BEp4sA8XcmByBy3pxqbTjAjrW8a+n43DBRMx4J86LgywX3fFt8ceEym3rFer/IzQD9QvKRocycNCwhpmGKEDh4zdl9PdyU5RcUpiA01AD/8rdJMNYnUxIsaNElcgP2LSzROjNdyu11cq9h3/cb3b7oRRef718GOkIkzqL/szo4Mm/j4KfyG0SBWyPxlJktFADD3lcQIRrGakFhiZOFbg2HZci26q+l/hUfLMbzcBrWlc+gzY4z4LMF8YBy1x/x+yR4j1SzZuqempSRu7rDKevcIGBF/fALPyiXH2EzYKsVcN9nv5mFCjmwVK7WTjw1SFzufKwdmnvOYgyeYuMaOJv3LEBY1jJg8r4xqzuQx32KNK/iJz1E+njptV3ZhOYDiHBmieykP08nWxdS79N1DbljxRzS54T7CArfGo23nYTNlMewPeKFx7ZqtUVv03g8i1Hn8WdArz2TYciWWrPErBEALBpXsu7Oq5AT97wAhcAIf3B3dV5p/bXgnhALA/SodNBf/wr0U2f5VzTDyJ9eNZURt16jSxDgXkuKKY/rimLqqt2FC1SeicmTql1nVyHG3j9Q== root@controller"]
+
+  server = "${module.aws_server.private_names[0]}"
+  mirror_public_name = "${module.aws_mirror.public_name}"
+  mirror_private_name = "${module.aws_mirror.private_name}"
+  testsuite = true
+}
+
+module "testcontroller" {
+  source = "./modules/aws/controller"
+  region = "${local.region}"
+  availability_zone = "${local.availability_zone}"
+  ami = "" // works best with openSUSE Leap 15.0 with chromium installed from https://build.opensuse.org/project/show/openSUSE:Maintenance:9813
+  public_subnet_id = "${module.aws_network.public_subnet_id}"
+  public_security_group_id = "${module.aws_network.public_security_group_id}"
+  key_name = "${local.key_name}"
+  key_file = "${local.key_file}"
+  server = "${module.aws_server.private_names[0]}"
+  client = "${module.aws_client.private_names[0]}"
+  minion = "${module.aws_minion.private_names[0]}"
+  git_username = "" // put github credentials here if necessary
+  git_password = "" // alternatively store a private deploy key in 'github_deploy_key' file
+  git_repo = "ssh://git@github.com/SUSE/spacewalk"
+  git_branch = "Manager-${local.prod_version}"
+  repos_to_sync = "sles12-sp4-pool-x86_64 sles12-sp4-updates-x86_64 sle-manager-tools12-pool-x86_64-sp4 sle-manager-tools12-updates-x86_64-sp4" // repos required for testsuite 'init_clients' set
+}
+
+// testsuite expects to be able to log in with password 'linux'
+resource "null_resource" "update_client_conf" {
+  depends_on = [ "module.aws_client" ]
+  connection {
+    host = "${module.aws_client.private_names[0]}"
+    private_key = "${file(local.key_file)}"
+    bastion_host = "${module.aws_mirror.public_name}"
+    user = "ec2-user"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo sed -i -e 's/.*PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config",
+      "sudo systemctl reload sshd.service",
+      "echo root:linux | sudo chpasswd"
+     ]
+  }
+}
+
+resource "null_resource" "update_minion_conf" {
+  depends_on = [ "module.aws_minion" ]
+  connection {
+    host = "${module.aws_minion.private_names[0]}"
+    private_key = "${file(local.key_file)}"
+    bastion_host = "${module.aws_mirror.public_name}"
+    user = "ec2-user"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo sed -i -e 's/.*PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config",
+      "sudo systemctl reload sshd.service",
+      "echo root:linux | sudo chpasswd"
+     ]
+  }
+}
+
+// testsuite expects admin password to be 'admin'
+// also make sure channels are sync'd
+resource "null_resource" "update_server_conf" {
+  depends_on = [ "module.aws_server" ]
+
+  connection {
+    host = "${module.aws_server.private_names[0]}"
+    private_key = "${file(local.key_file)}"
+    bastion_host = "${module.aws_mirror.public_name}"
+    user = "ec2-user"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo -e 'admin\nadmin' | sudo satpasswd -s admin",
+      "sudo sh -c \"echo 'mgrsync.user = admin' > /root/.mgr-sync\"",
+      "sudo sh -c \"echo 'mgrsync.password = admin' >> /root/.mgr-sync\"",
+      "sudo mgr-sync refresh"
+     ]
+  }
+}
+
+output "mirror host public name" {
+  value = "${module.aws_mirror.public_name}"
+}
+
+output "controller host public name" {
+  value = "${module.testcontroller.public_name}"
+}
+

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -25,9 +25,11 @@ SUSE employees using openbare already have AMI images uploaded and data snapshot
 
 ## mirror
 
-In addition to acting as a bastion host for all other instances, the `mirror` host serves all repos and packages used by other instances. It works similarly to the one for the libvirt backend, allowing instances in the private subnet to be completely disconnected from the Internet.
+In addition to acting as a bastion host for all other instances, the `mirror` host serves all repos and packages used by other instances. It works similarly to the one for the libvirt backend, allowing instances in the private subnet to be completely disconnected from the Internet. The `mirror` host's data volume can be created from a prepopulated snapshot, which allows it to be operational without lengthy channel synchronization.
 
-Please note that content in `mirror` must be refreshed manually at this time, see comments in [modules/aws/mirror/main.tf](modules/aws/mirror/main.tf).
+For instructions on how to refresh content in `mirror`, see comments in [modules/aws/mirror/main.tf](modules/aws/mirror/main.tf).
+
+For instructions on how to set up a mirror data snapshot from scratch, see comments in [main.tf.aws-create-mirror-snapshot.example](main.tf.aws-create-mirror-snapshot.example).
 
 ## Accessing instances
 

--- a/modules/aws/controller/main.tf
+++ b/modules/aws/controller/main.tf
@@ -1,0 +1,108 @@
+/*
+  This module sets up a controller host that executes the spacewalk testsuite
+  against the manager server.
+*/
+
+terraform {
+    required_version = "~> 0.11.7"
+}
+
+resource "aws_instance" "instance" {
+  ami = "${var.ami}"
+  availability_zone = "${var.availability_zone}"
+  instance_type = "t2.small"
+  key_name = "${var.key_name}"
+  monitoring = "${var.monitoring}"
+  subnet_id = "${var.public_subnet_id}"
+  vpc_security_group_ids = ["${var.public_security_group_id}"]
+
+  tags {
+    Name = "${var.name_prefix}-controller"
+  }
+}
+
+resource "null_resource" "controller_salt_configuration" {
+  triggers {
+    instance_id = "${aws_instance.instance.id}"
+  }
+
+  connection {
+    host = "${aws_instance.instance.public_dns}"
+    private_key = "${file(var.key_file)}"
+    user = "${var.ssh_user}"
+  }
+
+  provisioner "file" {
+    source = "salt"
+    destination = "/tmp"
+  }
+
+  provisioner "file" {
+    content = <<EOF
+
+hostname: ${replace("${aws_instance.instance.private_dns}", ".${var.region == "us-east-1" ? "ec2.internal" : "${var.region}.compute.internal"}", "")}
+domain: ${var.region == "us-east-1" ? "ec2.internal" : "${var.region}.compute.internal"}
+use_avahi: False
+roles: [controller]
+authorized_keys: null
+additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
+additional_repos_only: ${var.additional_repos_only}
+additional_certs: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_certs), values(var.additional_certs)))}}
+additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
+gpg_keys:  [${join(", ", formatlist("'%s'", var.gpg_keys))}]
+reset_ids: true
+timezone: ${var.timezone}
+git_username: ${var.git_username}
+git_password: ${var.git_password}
+git_repo: "${var.git_repo}"
+branch: "${var.git_branch}"
+server: "${var.server}"
+client: "${var.client}"
+minion: "${var.minion}"
+repos_to_sync: "${var.repos_to_sync}"
+EOF
+
+    destination = "/tmp/grains"
+  }
+
+  provisioner "file" {
+    source = "github_deploy_key"
+    destination = "/tmp/github_deploy_key"
+  }
+
+  provisioner "file" {
+    destination = "/tmp/ssh_config"
+    content = <<EOF
+host github.com
+ HostName github.com
+ IdentityFile ~/.ssh/github_deploy_key
+ User git
+ StrictHostKeyChecking no
+EOF
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/grains /etc/salt/grains",
+      "sudo mv /tmp/salt /root/salt",
+      "sudo mv /tmp/github_deploy_key /root/.ssh/",
+      "sudo chown root:root /root/.ssh/github_deploy_key",
+      "sudo chmod 400 /root/.ssh/github_deploy_key",
+      "sudo mv /tmp/ssh_config /root/.ssh/config",
+      "sudo chown root:root /root/.ssh/config",
+      "sudo chmod 400 /root/.ssh/config",
+      "sudo bash /root/salt/first_deployment_highstate.sh",
+      "sudo gem install parallel parallel_tests minitest",
+      "sudo zypper in -y npm8",
+      "sudo npm install cucumber-html-reporter"
+    ]
+  }
+}
+
+output "public_name" {
+  value = "${aws_instance.instance.public_dns}"
+}
+
+output "private_name" {
+  value = "${aws_instance.instance.private_dns}"
+}

--- a/modules/aws/controller/variables.tf
+++ b/modules/aws/controller/variables.tf
@@ -38,19 +38,9 @@ variable "public_security_group_id" {
   type = "string"
 }
 
-variable "data_volume_snapshot_id" {
-  description = "ID of a snapshot of the data volume, leave default to start with a blank volume"
-  default = ""
-}
-
-variable "cc_username" {
-  description = "Username for the Customer Center"
-  type = "string"
-}
-
-variable "cc_password" {
-  description = "Password for the Customer Center"
-  type = "string"
+variable "name_prefix" {
+  description = "A prefix for names of objects created by this module"
+  default = "sumaform"
 }
 
 variable "timezone" {
@@ -78,13 +68,8 @@ variable "additional_packages" {
   default = []
 }
 
-variable "name_prefix" {
-  description = "A prefix for names of objects created by this module"
-  default = "sumaform"
-}
-
-variable "ubuntu_distros" {
-  description = "List of Ubuntu versions to mirror among 16.04, 18.04, xenial, bionic"
+variable "gpg_keys" {
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
   default = []
 }
 
@@ -94,8 +79,47 @@ variable "ssh_user" {
   default = "ec2-user"
 }
 
-variable "minima_config" {
-  description = "minima config file to copy onto mirror host"
+variable "server" {
+  description = "address of Manager server"
   type = "string"
-  default = "minima.yaml"
+}
+
+variable "client" {
+  description = "address of client host"
+  type = "string"
+}
+
+variable "minion" {
+  description = "address of minion host"
+  type = "string"
+}
+
+variable "git_username" {
+  description = "username for GitHub"
+  type = "string"
+  default = ""
+}
+
+variable "git_password" {
+  description = "password for GitHub"
+  type = "string"
+  default = ""
+}
+
+variable "git_repo" {
+  description = "git repo to use when checking out testsuite"
+  type = "string"
+  default = "https://github.com/uyuni-project/uyuni.git"
+}
+
+variable "git_branch" {
+  description = "git branch to use when checking out testsuite"
+  type = "string"
+  default = "4.0-rc1"
+}
+
+variable "repos_to_sync" {
+  description = "list of repositories needed to be synced on the server for init_client test set"
+  type = "string"
+  default = ""
 }

--- a/modules/aws/create_aws_mirror_snapshot
+++ b/modules/aws/create_aws_mirror_snapshot
@@ -1,0 +1,134 @@
+#!/usr/bin/python3
+
+# Copyright 2019 SUSE Linux Solutions GmbH
+#
+# create_aws_mirror_snapshot is free software: you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation, either version 3 of the License,
+# or (at your option) any later version.
+#
+# create_aws_mirror_snapshot is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# create_aws_mirror_snapshot. If not, see <http://www.gnu.org/licenses/>.
+
+# This script is meant to be used in conjunction with sumaform AWS templates,
+# either main.tf.aws-testsuite.example which creates a full test cluster or
+# main.tf.aws-create-mirror-snapshot.example which only creates a mirror host
+# to be used for creating the snapshot. This script will parse main.tf (which
+# should be based on one of those two templates) and the output of 'terraform
+# output'. It will log into the mirror host, run /root/mirror.sh, and create a
+# snapshot of the data storage volume.
+
+import json
+import boto3
+import subprocess
+import pprint
+import paramiko.client
+
+tf_params = ["mirror_host_name", "ebs_volume_id", "region", "snapshot_name"]
+
+
+def get_creds(tf_file):
+    creds = {}
+    with open(tf_file, 'r') as fh:
+        for line in fh:
+            lstr = line.split()
+            if len(lstr) > 2:
+                if lstr[0].strip() == "access_key":
+                    creds["access_key"] = lstr[2].strip('"\'')
+                elif lstr[0].strip() == "secret_key":
+                    creds["secret_key"] = lstr[2].strip('"\'')
+                elif lstr[0].strip() == "key_file":
+                    creds["key_file"] = lstr[2].strip('"\'')
+            if (len(creds) > 2):
+                break
+    if len(creds) < 3:
+        raise Exception("Could not parse credentials from {}".format(tf_file))
+    return creds
+
+
+def get_terraform_output():
+    p = subprocess.Popen(["terraform", "output", "--json"],
+                         stdout=subprocess.PIPE)
+    stdout, ignored = p.communicate()
+    if (p.returncode != 0):
+        raise Exception("Could not get terraform output")
+    tf_out = json.loads(stdout.decode())
+    for param in tf_params:
+        if not tf_out.get(param):
+            raise Exception("Expected value for '{}' not in terraform output")
+    return tf_out
+
+
+class SSHConnection:
+    def __init__(self, host_name, user_name, key_file):
+        self.host_name = host_name
+        self.user_name = user_name
+        self.key_file = key_file
+        self.ssh_client = paramiko.client.SSHClient()
+        self.ssh_client.set_missing_host_key_policy(paramiko.WarningPolicy())
+
+    def __enter__(self):
+        self._reconnect()
+      return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        self.ssh_client.close()
+
+    def _reconnect(self):
+        self.ssh_client.connect(
+            key_filename=self.key_file,
+            username=self.user_name,
+            hostname=self.host_name
+        )
+
+    def exec_command(self, cmd):
+      if not self.ssh_client.get_transport().is_active():
+          self._reconnect()
+          stdin, stdout, stderr = self.ssh_client.exec_command(cmd)
+      for line in iter(stdout.readline, ""):
+          print(line, end="")
+          err_msg = stderr.read()
+      if (err_msg):
+        raise Exception("Command {} failed with following error\n{}".format(
+            cmd, err_msg))
+
+creds = get_creds("main.tf")
+params = get_terraform_output()
+
+mirror_host = params["mirror_host_name"]["value"]
+print("Connecting to mirror host '{}'".format(mirror_host))
+  with SSHConnection(mirror_host, "ec2-user", creds["key_file"]) as conn:
+      print("Starting mirror sync (this will take a while)")
+      conn.exec_command("sudo bash /root/mirror.sh")
+      conn.exec_command("sudo systemctl stop nfs-server")
+      conn.exec_command("sudo systemctl stop apache2")
+      conn.exec_command("sudo umount /srv/mirror")
+
+print("Creating snapshot")
+ec2 = boto3.client(
+    service_name="ec2",
+    aws_access_key_id=creds["access_key"],
+    aws_secret_access_key=creds["secret_key"],
+    region_name=params["region"]["value"]
+)
+resp = ec2.create_snapshot(
+    VolumeId=params["ebs_volume_id"]["value"],
+    Description="Sumaform mirror host data snapshot",
+    TagSpecifications=[
+        {
+            "ResourceType": "snapshot",
+            "Tags": [
+                {
+                    "Key": "Name",
+                    "Value": "{}".format(params["snapshot_name"]["value"])
+                }
+            ]
+        }
+    ])
+pprint.pprint(resp)
+

--- a/modules/aws/evil_minions/main.tf
+++ b/modules/aws/evil_minions/main.tf
@@ -66,7 +66,7 @@ EOF
 
   provisioner "remote-exec" {
     inline = [
-      "sh /root/salt/first_deployment_highstate.sh"
+      "bash /root/salt/first_deployment_highstate.sh"
     ]
   }
 }

--- a/modules/aws/host/main.tf
+++ b/modules/aws/host/main.tf
@@ -2,7 +2,16 @@ terraform {
     required_version = "~> 0.11.7"
 }
 
+resource "null_resource" "dependency_getter" {
+  provisioner "local-exec" {
+    command = "echo ${length(var.dependencies)}"
+  }
+}
+
 resource "aws_instance" "instance" {
+  depends_on = [
+    "null_resource.dependency_getter",
+  ]
   ami = "${var.ami}"
   instance_type = "${var.instance_type}"
   count = "${var.count}"
@@ -39,11 +48,12 @@ resource "null_resource" "host_salt_configuration" {
     host = "${element(aws_instance.instance.*.private_dns, count.index)}"
     private_key = "${file(var.key_file)}"
     bastion_host = "${var.mirror_public_name}"
+    user = "${var.ssh_user}"
   }
 
   provisioner "file" {
     source = "salt"
-    destination = "/root"
+    destination = "/tmp"
   }
 
   provisioner "file" {
@@ -66,27 +76,43 @@ auto_accept: ${var.auto_accept}
 monitored: ${var.monitored}
 apparmor: ${var.apparmor}
 timezone: ${var.timezone}
-authorized_keys: null
+authorized_keys: [${join(", ", formatlist("'%s'", var.authorized_keys))}]
 additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
+additional_repos_only: ${var.additional_repos_only}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
+additional_certs: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_certs), values(var.additional_certs)))}}
 gpg_keys:  [${join(", ", formatlist("'%s'", var.gpg_keys))}]
 reset_ids: true
+testsuite: "${var.testsuite}"
+no_install: ${var.no_install}
 
 susemanager:
   activation_key: ${var.activation_key}
 
 EOF
 
-    destination = "/etc/salt/grains"
+    destination = "/tmp/grains"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sh /root/salt/first_deployment_highstate.sh"
+      "sudo mv /tmp/grains /etc/salt/grains",
+      "sudo mv /tmp/salt /root",
+      "sudo bash /root/salt/first_deployment_highstate.sh"
     ]
   }
 }
 
+resource "null_resource" "dependency_setter" {
+  depends_on = [
+    "null_resource.host_salt_configuration"
+  ]
+}
+
 output "private_names" {
   value = "${aws_instance.instance.*.private_dns}"
+}
+
+output "depended_on" {
+  value = "${null_resource.dependency_setter.id}"
 }

--- a/modules/aws/host/variables.tf
+++ b/modules/aws/host/variables.tf
@@ -138,6 +138,16 @@ variable "additional_repos" {
   default = {}
 }
 
+variable "additional_repos_only" {
+  description = "whether to exclusively use additional repos"
+  default = false
+}
+
+variable "additional_certs" {
+  description = "extra SSL certficates in the form {name = url}, see README_ADVANCED.md"
+  default = {}
+}
+
 variable "additional_packages" {
   description = "extra packages to install, see README_ADVANCED.md"
   default = []
@@ -155,5 +165,31 @@ variable "mirror_private_name" {
 
 variable "gpg_keys" {
   description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
+  default = []
+}
+
+variable "ssh_user" {
+  description = "user name to use with ssh connection"
+  type = "string"
+  default = "ec2-user"
+}
+
+variable "authorized_keys" {
+  description = "addtional ssh public keys to authorize access"
+  default = []
+}
+
+variable "no_install" {
+  description = "do not install product packages"
+  default = false
+}
+
+variable "testsuite" {
+  description = "install testsuite packages"
+  default = false
+}
+
+variable "dependencies" {
+  type = "list"
   default = []
 }

--- a/salt/controller/run-testsuite.sh
+++ b/salt/controller/run-testsuite.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+sync_repos()
+{
+  test -z "$SERVER" && { echo "SERVER not set" ; exit 1 ; }
+  repos=`salt-call --out txt --local --file-root=/root/salt grains.get repos_to_sync  | cut -d' ' -f2- 2>/dev/null`
+
+  if [ -n "$repos" ]; then
+    cmd="ssh -o StrictHostKeyChecking=no $SERVER \"spacewalk-repo-sync --latest --type yum"
+    for i in $repos ; do
+      cmd="$cmd --channel $i"
+    done
+    cmd="$cmd\""
+    echo "syncing repos '$repos' on server"
+    eval $cmd
+  fi
+}
+
 set -e
 
 cd /root/spacewalk/testsuite
@@ -7,6 +23,7 @@ cd /root/spacewalk/testsuite
 if [ -z "$1" ]; then
    rake cucumber:core
    rake cucumber:reposync
+   sync_repos
    rake cucumber:init_clients
    rake cucumber:secondary
    rake cucumber:secondary_parallelizable
@@ -32,6 +49,7 @@ fi
 if [[ $1 = "parallel" ]]; then
    rake cucumber:core
    rake cucumber:reposync
+   sync_repos
    rake parallel:init_clients
    rake cucumber:secondary
    rake parallel:secondary_parallelizable

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -1,7 +1,9 @@
 include:
   - default.locale
   - default.minimal
+  {% if not grains.get('no_install') | default(false) %}
   - default.pkgs
+  {% endif %}
   {% if grains.get('reset_ids') | default(false, true) %}
   - default.ids
   {% endif %}

--- a/salt/default/minimal.sls
+++ b/salt/default/minimal.sls
@@ -5,6 +5,7 @@ include:
   {% endif %}
   - default.avahi
 
+{% if not grains.get('no_install') | default(false) %}
 minimal_package_update:
   pkg.latest:
     - pkgs:
@@ -18,3 +19,4 @@ minimal_package_update:
       {% endif %}
 {% endif %}
     - order: last
+{% endif %}

--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -3,6 +3,7 @@
 # Applies the "minimal" state in isolation to set the hostname and update Salt itself
 # then applies the highstate
 
+exec &> >(tee /var/log/highstate.log)
 salt-call --local --file-root=/root/salt/ --log-level=quiet --output=quiet state.sls default.minimal ||:
 salt-call --local --file-root=/root/salt/ --log-level=info --retcode-passthrough --force-color state.highstate || exit 1
 

--- a/salt/mirror/minima-pubcloud.yaml
+++ b/salt/mirror/minima-pubcloud.yaml
@@ -114,11 +114,11 @@ scc:
 http:
   # Testsuite dummy packages for testing repo
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm
-    archs: [x86_64, src]
+    archs: [x86_64, i586, src]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/rpm
-    archs: [x86_64, src]
+    archs: [x86_64, i586, src]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb
     archs: [x86_64]
 

--- a/salt/mirror/minima-pubcloud.yaml
+++ b/salt/mirror/minima-pubcloud.yaml
@@ -1,0 +1,152 @@
+storage:
+  type: file
+  path: /srv/mirror
+
+scc:
+  username: {{ grains.get("cc_username") }}
+  password: {{ grains.get("cc_password") }}
+  repo_names:
+    # SLES
+    - SLES11-SP4-Pool
+    - SLES11-SP4-Updates
+    - SLES12-Pool
+    - SLES12-Updates
+    - SLES12-SP1-Pool
+    - SLES12-SP1-Updates
+    - SLES12-SP2-Pool
+    - SLES12-SP2-Updates
+    - SLES12-SP3-Pool
+    - SLES12-SP3-Updates
+    - SLES12-SP4-Pool
+    - SLES12-SP4-Updates
+    # SLE 15 Products
+    - SLE-Product-SLES15-Pool
+    - SLE-Product-SLES15-Updates
+    # SLE 15 Basic Modules
+    - SLE-Module-Basesystem15-Pool
+    - SLE-Module-Basesystem15-Updates
+    - SLE-Module-Server-Applications15-Pool
+    - SLE-Module-Server-Applications15-Updates
+    # SLE 15-SP1 Products
+    - SLE-Product-SLES15-SP1-Pool
+    - SLE-Product-SLES15-SP1-Updates
+    # SLE 15-SP1 Basic Modules
+    - SLE-Module-Basesystem15-SP1-Pool
+    - SLE-Module-Basesystem15-SP1-Updates
+    - SLE-Module-Server-Applications15-SP1-Pool
+    - SLE-Module-Server-Applications15-SP1-Updates
+    - SLE-Module-Web-Scripting15-SP1-Pool
+    - SLE-Module-Web-Scripting15-SP1-Updates
+    - SLE-Module-Python2-15-SP1-Pool
+    - SLE-Module-Python2-15-SP1-Update
+    # SLE Legacy Module
+    - SLE-Module-Legacy12-Pool
+    - SLE-Module-Legacy12-Updates
+    # SLE Container Module
+    - SLE-Module-Containers12-Pool
+    - SLE-Module-Containers12-Updates
+    - SLE-Module-Containers15-Pool
+    - SLE-Module-Containers15-Updates
+    - SLE-Module-Containers15-SP1-Pool
+    - SLE-Module-Containers15-SP1-Updates
+    # SUSE Manager Server
+    - SUSE-Manager-Server-3.2-Pool
+    - SUSE-Manager-Server-3.2-Updates
+    - SLE-Product-SUSE-Manager-Server-4.0-Pool
+    - SLE-Product-SUSE-Manager-Server-4.0-Updates
+    - SLE-Module-SUSE-Manager-Server-4.0-Pool
+    - SLE-Module-SUSE-Manager-Server-4.0-Updates
+    # SUSE Manager Proxy
+    - SUSE-Manager-Proxy-3.2-Pool
+    - SUSE-Manager-Proxy-3.2-Updates
+    - SLE-Product-SUSE-Manager-Proxy-4.0-Pool
+    - SLE-Product-SUSE-Manager-Proxy-4.0-Updates
+    - SLE-Module-SUSE-Manager-Proxy-4.0-Pool
+    - SLE-Module-SUSE-Manager-Proxy-4.0-Updates
+    # Retail Branch Server
+    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Pool
+    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Updates
+    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-Pool
+    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-Updates
+    # SUSE Manager Tools
+    - SLES11-SP4-SUSE-Manager-Tools
+    - SLE-Manager-Tools12-Pool
+    - SLE-Manager-Tools12-Updates
+    - SLE-Manager-Tools15-Pool
+    - SLE-Manager-Tools15-Updates
+    - RES-7-SUSE-Manager-Tools
+    - Ubuntu-16.04-SUSE-Manager-Tools
+    - Ubuntu-18.04-SUSE-Manager-Tools
+    # Additional products used by testsuite
+    - SLE-Product-SLED15-Pool
+    - SLE-15-GA-Desktop-NVIDIA-Driver
+    - SLE-Module-Desktop-Applications15-Pool
+    - SLE-Module-Desktop-Applications15-Updates
+    - SLE-Product-SLED15-Updates
+    - SLE-Product-WE15-Pool
+    - SLE-Product-WE15-Updates
+    - SLE11-SP2-SAP-Updates
+    - SLE11-HAE-SP2-Pool
+    - SLE11-HAE-SP2-Updates
+    - SLE11-WebYaST-SP2-Pool
+    - SLE11-WebYaST-SP2-Updates
+    - SLES11-SP1-Pool
+    - SLES11-SP1-Updates
+    - SLES11-SP2-Core
+    - SLES11-SP2-SUSE-Manager-Tools
+    - SLES11-SP2-Updates
+    - SLE11-SP4-SAP-Pool
+    - SLE11-HAE-SP4-Pool
+    - SLE11-HAE-SP4-Updates
+    - SLE11-SP2-WebYaST-1.3-Pool
+    - SLE11-SP2-WebYaST-1.3-Updates
+    - SLE11-SP4-SAP-Updates
+    - SLES11-SP4-LTSS-Updates
+    - SUSE-Manager-Proxy-2.1-Pool
+    - SUSE-Manager-Proxy-2.1-Updates
+    - SLE-Module-DevTools15-Pool
+    - SLE-Module-DevTools15-Updates
+    - SLE-HA12-Pool
+    - SLE-HA12-Updates
+    - RES7
+  archs: [x86_64, amd64]
+
+http:
+  # Testsuite dummy packages for testing repo
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm
+    archs: [x86_64, src]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/rpm
+    archs: [x86_64, src]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb
+    archs: [x86_64]
+
+  # Software for sumaformed Virtual Machines
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_11_SP4
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_12
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_12_SP1
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_12_SP2
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_12_SP3
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_12_SP4
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_15_SP1
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.0
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.1
+    archs: [x86_64]
+
+  # NVidia repositories
+  - url: https://download.nvidia.com/suse/sle15
+    archs: [x86_64]
+  - url: https://download.nvidia.com/suse/sle15sp1
+    archs: [x86_64]
+  - url: https://download.nvidia.com/suse/sle12sp4
+    archs: [x86_64]
+

--- a/salt/mirror/mirror.sh
+++ b/salt/mirror/mirror.sh
@@ -8,6 +8,24 @@ minima -c /root/minima.yaml sync 2>&1 | tee /var/log/minima.log
 
 apt-mirror
 
+# check for nvidia repo and create links, if necessary
+if [ -d suse ]; then
+  mkdir -p RPMMD
+  for dir in suse/sle* ; do
+    d=${dir^^}
+    ver=${d#SUSE/SLE}
+    if [[ $ver == ${ver%SP*} ]]; then
+      target="${ver}-GA"
+    else
+      target=${ver/SP/-SP}
+    fi
+    full_path=RPMMD/${target}-Desktop-NVIDIA-Driver
+    if [ ! -e ${full_path} ]; then
+      ln -s ../suse/$dir ${full_path}
+    fi
+  done
+fi
+
 jdupes --linkhard -r -s /srv/mirror/
 
-chmod -R 777 .
+#chmod -R 777 .

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -170,10 +170,12 @@ test_update_repo:
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
+    - name: SLE-12-SP4-x86_64-Pool
 
 os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP4/x86_64/update/
+    - name: SLE-12-SP4-x86_64-Update
 
 {% if grains.get('use_os_unreleased_updates') | default(False, true) %}
 test_update_repo:
@@ -190,10 +192,12 @@ test_update_repo:
 tools_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/
+    - name: SLE-Manager-Tools12-Pool
 
 tools_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/
+    - name: SLE-Manager-Tools12-Update
 {% else %}
 tools_pool_repo:
   pkgrepo.managed:

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -4,10 +4,12 @@
 containers_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/12/x86_64/product/
+    - name: SLE-Module-Containers-12-Pool
 
 containers_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/12/x86_64/update/
+    - name: SLE-Module-Containers-12-Update
 
 {% endif %}
 

--- a/salt/repos/suse_manager_server.sls
+++ b/salt/repos/suse_manager_server.sls
@@ -1,6 +1,6 @@
 {% if 'suse_manager_server' in grains.get('roles') %}
 
-{% if '3.2' in grains['product_version'] %}
+{% if '3.2' in grains['product_version']|string %}
 suse_manager_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SUSE-Manager-Server/3.2/x86_64/product
@@ -12,7 +12,7 @@ suse_manager_update_repo:
     - priority: 97
 {% endif %}
 
-{% if '4.0' in grains['product_version'] %}
+{% if '4.0' in grains['product_version']|string %}
 suse_manager_server_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.0/x86_64/product/
@@ -54,14 +54,14 @@ module_python2_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/
 {% endif %}
 
-{% if 'uyuni-released' in grains['product_version'] %}
+{% if 'uyuni-released' in grains['product_version']|string %}
 suse_manager_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
     - priority: 97
 {% endif %}
 
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version')|string or 'uyuni-master' in grains.get('product_version')|string %}
 {% if grains['osfullname'] == 'Leap' %}
 suse_manager_pool_repo:
   pkgrepo.managed:
@@ -120,14 +120,14 @@ module_python2_update_repo:
 {% endif %}
 {% endif %}
 
-{% if '3.2-nightly' in grains['product_version'] %}
+{% if '3.2-nightly' in grains['product_version']|string %}
 suse_manager_devel_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/3.2/SLE_12_SP3/
     - priority: 96
 {% endif %}
 
-{% if '4.0-nightly' in grains['product_version'] %}
+{% if '4.0-nightly' in grains['product_version']|string %}
 suse_manager_devel_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0/SLE_15_SP1/

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -27,7 +27,7 @@ suse_manager_packages:
       - sls: repos
       - sls: suse_manager_server.firewall
 
-{% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' %}
+{% if '4' in grains['product_version']|string and grains['osfullname'] != 'Leap' %}
 baseproduct_link:
   file.symlink:
     - name: /etc/products.d/baseproduct
@@ -47,7 +47,9 @@ suse_manager_setup:
     - name: /usr/lib/susemanager/bin/migration.sh -l /var/log/susemanager_setup.log -s
     - creates: /root/.MANAGER_SETUP_COMPLETE
     - require:
+      {% if not grains.get('no_install') | default(false) %}
       - pkg: suse_manager_packages
+      {% endif %}
       - file: environment_setup_script
       {% if grains.get('apparmor') %}
       - sls: suse_manager_server.apparmor

--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -50,8 +50,8 @@ test_vcenter_file:
 minima:
   archive.extracted:
     - name: /usr/bin
-    - source: https://github.com/moio/minima/releases/download/v0.4/minima-linux-amd64.tar.gz
-    - source_hash: https://github.com/moio/minima/releases/download/v0.4/minima-linux-amd64.tar.gz.sha512
+    - source: http://{{ grains.get("mirror") | default("github.com/moio/minima/releases/download/v0.4/", true) }}/minima-linux-amd64.tar.gz
+    - source_hash: http://{{ grains.get("mirror") | default("github.com/moio/minima/releases/download/v0.4/", true) }}/minima-linux-amd64.tar.gz.sha512
     - archive_format: tar
     - enforce_toplevel: false
     - keep: True


### PR DESCRIPTION
This is an attempt to bring the AWS templates into a state where they can be used to spin up a cluster using the official released SUSE Manger 4.0 Server image in which the spacewalk test suite can be executed.

It adds a controller resource and makes some adjustments to the other ones, and also makes some changes to the salt templates that were required to make the test suite pass. Those changes should be non intrusive.

It probably needs a bit more polishing but I thought this should work as an initial base for discussion.