### PR TITLE
Fix mirror config

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -209,13 +209,9 @@ http:
 
   # Testsuite dummy packages for testing repo
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm
-    archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb
-    archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/rpm
-    archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb
-    archs: [x86_64]
 
   # Software for sumaformed Virtual Machines
   - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_11_SP4

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -176,6 +176,10 @@ http:
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
     archs: [x86_64]
 
+  # Ubuntu 18.04 Manager Tools 4.0 devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04
+    archs: [amd64]
+
   # SUSE Manager Head devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/SLE_15_SP1
     archs: [x86_64]
@@ -195,6 +199,10 @@ http:
   # RES 7 Manager Tools Head devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
     archs: [x86_64]
+
+  # Ubuntu 18.04 Manager Tools Head devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04
+    archs: [amd64]
 
   # openSUSE Leap
   - url: http://download.opensuse.org/distribution/leap/15.0/repo/oss


### PR DESCRIPTION
## Warning

In most cases, it is not enough if you modify the terraform modules at `modules/libvirt`. Check if you also need changes at `modules/openstack` and `modules/aws`.

## What does this PR change?

Fixes 2 issues:

1. testsuite repos must be synced with all archs incl. source packages
2. add Ubuntu devel repos
