### PR TITLE
Use new Uyuni POOL repositories

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -244,9 +244,9 @@ http:
   # Uyuni Master
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.1/
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/
     archs: [x86_64]

--- a/salt/repos/suse_manager_proxy.sls
+++ b/salt/repos/suse_manager_proxy.sls
@@ -49,7 +49,7 @@ suse_manager_proxy_pool_repo:
 {% if grains['osfullname'] == 'Leap' %}
 suse_manager_proxy_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
     - priority: 97
 {% else %}
 suse_manager_proxy_pool_repo:

--- a/salt/repos/suse_manager_server.sls
+++ b/salt/repos/suse_manager_server.sls
@@ -65,7 +65,7 @@ suse_manager_pool_repo:
 {% if grains['osfullname'] == 'Leap' %}
 suse_manager_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.1/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/
     - priority: 97
 {% else %}
 suse_manager_pool_repo:


### PR DESCRIPTION
## What does this PR change?

As part of the new Uyuni product definitions, we are removing the version from the POOL repositories. And we decided to remove the distribution name from the URL as well (so it's now `images` so we don't need to change it when we change the base OS.

This means than in the future no sumaform changes will be needed for new Uyuni versions or base OS changes (also good for development)

Requires https://github.com/uyuni-project/uyuni/pull/1535