### PR TITLE
Fix virthost matching in top.sls

### DIFF
--- a/salt/top.sls
+++ b/salt/top.sls
@@ -34,6 +34,6 @@ base:
     - match: grain
     - locust
 
-  'roles: virthost':
+  'roles:virthost':
     - match: grain
     - virthost


### PR DESCRIPTION
## What does this PR change?

Remove the space that prevented setting up virthosts properly
