### PR TITLE
Multiple hostnames in host module

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -201,11 +201,11 @@ module "ctl" {
   server_configuration    = module.srv.configuration
   client_configuration    = module.cli-sles12sp4.configuration
   minion_configuration    = module.min-sles12sp4.configuration
-  centos_configuration    = contains(var.optional_clients, "min-centos7") ? module.min-centos7.configuration : {hostname = "null", ids=null}
-  ubuntu_configuration    = contains(var.optional_clients, "min-ubuntu1804") ? module.min-ubuntu1804.configuration : {hostname = "null", ids=null}
-  minionssh_configuration = contains(var.optional_clients, "min-minssh-sles12sp4") ? module.minssh-sles12sp4.configuration : {hostname = "null", ids=null}
-  pxeboot_configuration   = contains(var.optional_clients, "min-pxeboot") ? module.min-pxeboot.configuration : {hostname = "null",ids=null}
-  kvmhost_configuration   = contains(var.optional_clients, "min-kvm") ? module.min-kvm.configuration : {hostname = "null",ids=null}
+  centos_configuration    = contains(var.optional_clients, "min-centos7") ? module.min-centos7.configuration : {hostnames = null, ids=null}
+  ubuntu_configuration    = contains(var.optional_clients, "min-ubuntu1804") ? module.min-ubuntu1804.configuration : {hostnames = null, ids=null}
+  minionssh_configuration = contains(var.optional_clients, "min-minssh-sles12sp4") ? module.minssh-sles12sp4.configuration : {hostnames = null , ids=null}
+  pxeboot_configuration   = contains(var.optional_clients, "min-pxeboot") ? module.min-pxeboot.configuration : {hostnames = null,ids=null}
+  kvmhost_configuration   = contains(var.optional_clients, "min-kvm") ? module.min-kvm.configuration : {hostnames = null, ids=null}
 
   git_username      = var.git_username
   git_password      = var.git_password

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -32,12 +32,12 @@ git_repo: ${var.git_repo}
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
 proxy: ${var.proxy_configuration["hostname"]}
-client: ${var.client_configuration["hostname"]}
-minion: ${var.minion_configuration["hostname"]}
-centos_minion: ${var.centos_configuration["hostname"]}
-ubuntu_minion:  ${var.ubuntu_configuration["hostname"]}
-ssh_minion: ${var.minionssh_configuration["hostname"]}
-kvm_host: ${var.kvmhost_configuration["hostname"]}
+client: ${var.client_configuration["hostnames"][0]}
+minion: ${var.minion_configuration["hostnames"][0]}
+centos_minion: ${var.centos_configuration["hostnames"] != null ? var.centos_configuration["hostnames"][0] : ""}
+ubuntu_minion:  ${var.ubuntu_configuration["hostnames"] != null ? var.ubuntu_configuration["hostnames"][0] : ""}
+ssh_minion: ${var.minionssh_configuration["hostnames"] != null ? var.minionssh_configuration["hostnames"][0] : ""}
+kvm_host: ${var.kvmhost_configuration["hostnames"] != null ? var.kvmhost_configuration["hostnames"][0] : ""}
 pxeboot_mac: ${var.pxeboot_configuration["macaddr"]}
 branch: ${var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch}
 git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo}

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -44,16 +44,16 @@ variable "proxy_configuration" {
 variable "client_configuration" {
   description = "use module.<CLIENT_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   type        = object({
-    ids = list(string)
-    hostname = string
+    ids       = list(string)
+    hostnames = list(string)
   })
 }
 
 variable "minion_configuration" {
   description = "use module.<MINION_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   type        = object({
-    ids = list(string)
-    hostname = string
+    ids       = list(string)
+    hostnames = list(string)
   })
 }
 

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -164,6 +164,6 @@ xml {
 output "configuration" {
   value = {
     ids      = libvirt_domain.domain[*].id
-    hostname = "${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-1" : ""}.${var.base_configuration["domain"]}"
+    hostnames = [for value_used in libvirt_domain.domain : "${value_used.name}.${var.base_configuration["domain"]}"]
   }
 }

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -99,7 +99,7 @@ EOF
 output "configuration" {
   value = {
     id              = module.suse_manager.configuration["ids"][0]
-    hostname        = module.suse_manager.configuration["hostname"]
+    hostname        = module.suse_manager.configuration["hostnames"][0]
     product_version = var.product_version
     username        = var.server_username
     password        = var.server_password

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -65,8 +65,8 @@ EOF
 
 output "configuration" {
   value = {
-    ids              = module.suse_manager_proxy.configuration["ids"]
-    hostname        = module.suse_manager_proxy.configuration["hostname"]
+    id              = module.suse_manager_proxy.configuration["ids"][0]
+    hostname        = module.suse_manager_proxy.configuration["hostnames"][0]
     product_version = var.product_version
     username        = var.server_configuration["username"]
     password        = var.server_configuration["password"]


### PR DESCRIPTION
## What does this PR change?

Refactor in the host module to return a list of hostnames instead of the hostname of the first domain created.
Adapt modules that use this field to behave according.