### PR TITLE
Device name for additional disk passed via grains

### DIFF
--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -79,6 +79,7 @@ from_email: ${var.from_email}
 traceback_email: ${var.traceback_email}
 saltapi_tcpdump: ${var.saltapi_tcpdump}
 repository_disk_size: ${var.repository_disk_size}
+repository_disk_device: vdb
 
 EOF
 

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -50,6 +50,7 @@ generate_bootstrap_script: ${var.generate_bootstrap_script}
 publish_private_ssl_key: ${var.publish_private_ssl_key}
 apparmor: ${var.apparmor}
 repository_disk_size: ${var.repository_disk_size}
+repository_disk_device: vdb
 
 EOF
 

--- a/salt/suse_manager_proxy/additional_disk.sls
+++ b/salt/suse_manager_proxy/additional_disk.sls
@@ -8,8 +8,8 @@ parted:
 
 spacewalk_partition:
   cmd.run:
-    - name: /usr/sbin/parted -s /dev/vdb mklabel gpt && /usr/sbin/parted -s /dev/vdb mkpart primary 0% 100% && sleep 1 && /sbin/mkfs.ext4 /dev/vdb1
-    - unless: ls /dev/vdb1
+    - name: /usr/sbin/parted -s /dev/{{grains['repository_disk_device']}} mklabel gpt && /usr/sbin/parted -s /dev/{{grains['repository_disk_device']}} mkpart primary 0% 100% && sleep 1 && /sbin/mkfs.ext4 /dev/{{grains['repository_disk_device']}}1
+    - unless: ls /dev/{{grains['repository_disk_device']}}1
     - require:
       - pkg: parted
 
@@ -19,7 +19,7 @@ spacewalk_directory:
     - makedirs: True
   mount.mounted:
     - name: /var/spacewalk
-    - device: /dev/vdb1
+    - device: /dev/{{grains['repository_disk_device']}}1
     - fstype: ext4
     - mkmnt: True
     - persist: True

--- a/salt/suse_manager_server/additional_disk.sls
+++ b/salt/suse_manager_server/additional_disk.sls
@@ -8,8 +8,8 @@ parted:
 
 spacewalk_partition:
   cmd.run:
-    - name: /usr/sbin/parted -s /dev/vdb mklabel gpt && /usr/sbin/parted -s /dev/vdb mkpart primary 0% 100% && sleep 1 && /sbin/mkfs.ext4 /dev/vdb1
-    - unless: ls /dev/vdb1
+    - name: /usr/sbin/parted -s /dev/{{grains['repository_disk_device']}} mklabel gpt && /usr/sbin/parted -s /dev/{{grains['repository_disk_device']}} mkpart primary 0% 100% && sleep 1 && /sbin/mkfs.ext4 /dev/{{grains['repository_disk_device']}}1
+    - unless: ls /dev/{{grains['repository_disk_device']}}1
     - require:
       - pkg: parted
 
@@ -19,7 +19,7 @@ spacewalk_directory:
     - makedirs: True
   mount.mounted:
     - name: /var/spacewalk
-    - device: /dev/vdb1
+    - device: /dev/{{grains['repository_disk_device']}}1
     - fstype: ext4
     - mkmnt: True
     - persist: True


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/uyuni-project/sumaform/pull/615/files#r345705770

To make the port to other backends, at that moment only AWS, we pass via grains the device name.
