### PR TITLE
Refactoring: use new features in Terraform 0.12 to remove hacks

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -148,8 +148,11 @@ Setting the `wait_for_reposync` variable to `true` will result into sumaform wai
 
 Channels specified via the `channels` variable above can be automatically cloned by date at deploy time. This operation is typically time-intensive, thus it is disabled by default. In order to clone channels specified via the `channels` variable, you need to specify the cloning details in a `cloned_channels` variable according to the following syntax:
 
-```yaml
-[{ channels: [<PARENT_CHANNEL_NAME>, <CHILD_CHANNEL_1_NAME>, ...], prefix: <CLONE_PREFIX>, date: <YYYY-MM-DD> } ...]
+```hcl
+[{ channels = ["<PARENT_CHANNEL_NAME>", "<CHILD_CHANNEL_1_NAME>", ...],
+  prefix   = "<CLONE_PREFIX>",
+  date     = "<YYYY-MM-DD>"
+}]
 ```
 
 A libvirt example follows:
@@ -163,7 +166,12 @@ module "server" {
   product_version = "3.2-nightly"
   channels = ["sles12-sp3-pool-x86_64", "sles12-sp3-updates-x86_64"]
   wait_for_reposync = true
-  cloned_channels = "[{ channels: [sles12-sp3-pool-x86_64, sles12-sp3-updates-x86_64], prefix: cloned-2017-q1, date: 2017-03-31 }]"
+  cloned_channels = [
+    { channels = ["sles12-sp3-pool-x86_64", "sles12-sp3-updates-x86_64"],
+      prefix   = "cloned-2017-q3",
+      date     = "2017-09-30"
+    }
+  ]
 }
 ```
 

--- a/main.tf.libvirt.example
+++ b/main.tf.libvirt.example
@@ -20,7 +20,7 @@ module "base" {
 
 module "server" {
   source = "./modules/libvirt/suse_manager"
-  base_configuration = "${module.base.configuration}"
+  base_configuration = module.base.configuration
 
   name = "server"
   product_version = "3.2-nightly"
@@ -32,20 +32,20 @@ module "server" {
 
 module "client" {
   source = "./modules/libvirt/client"
-  base_configuration = "${module.base.configuration}"
+  base_configuration = module.base.configuration
 
   name = "client"
   image = "sles12sp3"
-  server_configuration = "${module.server.configuration}"
+  server_configuration = module.server.configuration
   // see modules/libvirt/client/variables.tf for possible values
 }
 
 module "minion" {
   source = "./modules/libvirt/minion"
-  base_configuration = "${module.base.configuration}"
+  base_configuration = module.base.configuration
 
   name = "minion"
   image = "sles12sp3"
-  server_configuration = "${module.server.configuration}"
+  server_configuration = module.server.configuration
   // see modules/libvirt/minion/variables.tf for possible values
 }

--- a/main.tf.uyuni.example
+++ b/main.tf.uyuni.example
@@ -23,7 +23,7 @@ module "base" {
 
 module "srv" {
   source = "./modules/libvirt/suse_manager"
-  base_configuration = "${module.base.configuration}"
+  base_configuration = module.base.configuration
   product_version = "uyuni-master"
   name = "srv"
   image = "opensuse151"
@@ -38,32 +38,32 @@ module "srv" {
 
 module "min-centos7" {
   source = "./modules/libvirt/minion"
-  base_configuration = "${module.base.configuration}"
+  base_configuration = module.base.configuration
   product_version = "uyuni-master"
   name = "min-centos7"
   image = "centos7"
   memory = 1024
-  server_configuration = "${module.server.configuration}"
+  server_configuration = module.server.configuration
   // see modules/libvirt/minion/variables.tf for possible values
 }
 
 module "min-ubuntu1804" {
   source = "./modules/libvirt/minion"
-  base_configuration = "${module.base.configuration}"
+  base_configuration = module.base.configuration
   product_version = "uyuni-master"
   name = "min-ubuntu1804"
   image = "ubuntu1804"
   memory = 1024
-  server_configuration = "${module.server.configuration}"
+  server_configuration = module.server.configuration
   // see modules/libvirt/minion/variables.tf for possible values
 }
 
 module "min-kvm" {
   source = "./modules/libvirt/virthost"
-  base_configuration = "${module.base.configuration}"
+  base_configuration = module.base.configuration
   product_version = "uyuni-master"
   name = "min-kvm"
   image = "opensuse151"
-  server_configuration = "${module.server.configuration}"
+  server_configuration = module.server.configuration
   // see modules/libvirt/minion/variables.tf for possible values
 }

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -30,8 +30,8 @@ locals {
   additional_repos = { for host_key in local.hosts :
   host_key => lookup(var.host_settings[host_key], "additional_repos", {}) if var.host_settings[host_key] != null }
   images = { for host_key in local.hosts :
-  host_key => lookup(var.host_settings[host_key], "image", "default")
-  if var.host_settings[host_key] != null? contains(keys(var.host_settings[host_key]), "image"): false }
+    host_key => lookup(var.host_settings[host_key], "image", "default")
+  if var.host_settings[host_key] != null ? contains(keys(var.host_settings[host_key]), "image") : false }
 }
 
 module "srv" {
@@ -58,7 +58,7 @@ module "srv" {
   from_email                     = var.from_email
   additional_repos               = lookup(local.additional_repos, "srv", {})
 
-  saltapi_tcpdump                = var.saltapi_tcpdump
+  saltapi_tcpdump = var.saltapi_tcpdump
 
   mac    = lookup(local.macs, "srv", "")
   memory = 8192
@@ -223,13 +223,13 @@ module "ctl" {
 
   base_configuration      = module.base.configuration
   server_configuration    = module.srv.configuration
-  proxy_configuration     = contains(local.hosts, "pxy") ? module.pxy.configuration : { hostname = "null", id = "null" }
+  proxy_configuration     = contains(local.hosts, "pxy") ? module.pxy.configuration : { hostname = null }
   client_configuration    = module.cli-sles12sp4.configuration
   minion_configuration    = module.min-sles12sp4.configuration
   centos_configuration    = contains(local.hosts, "min-centos7") ? module.min-centos7.configuration : { hostnames = null, ids = null }
   ubuntu_configuration    = contains(local.hosts, "min-ubuntu1804") ? module.min-ubuntu1804.configuration : { hostnames = null, ids = null }
   minionssh_configuration = contains(local.hosts, "minssh-sles12sp4") ? module.minssh-sles12sp4.configuration : { hostnames = null, ids = null }
-  pxeboot_configuration   = contains(local.hosts, "min-pxeboot") ? module.min-pxeboot.configuration : { hostname = "null", id = "null", macaddr = "null" }
+  pxeboot_configuration   = contains(local.hosts, "min-pxeboot") ? module.min-pxeboot.configuration : { macaddr = null }
   kvmhost_configuration   = contains(local.hosts, "min-kvm") ? module.min-kvm.configuration : { hostnames = null, ids = null }
 
   branch            = var.branch

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -60,7 +60,7 @@ module "srv" {
 
   saltapi_tcpdump = var.saltapi_tcpdump
 
-  mac    = lookup(local.macs, "srv", "")
+  mac    = lookup(local.macs, "srv", null)
   memory = 8192
   vcpu   = 4
 }

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -18,8 +18,8 @@ module "base" {
 
   pool               = lookup(var.provider_settings["libvirt"], "pool", "default")
   network_name       = lookup(var.provider_settings["libvirt"], "network_name", "default")
-  bridge             = lookup(var.provider_settings["libvirt"], "bridge", "")
-  additional_network = lookup(var.provider_settings["libvirt"], "additional_network", "")
+  bridge             = lookup(var.provider_settings["libvirt"], "bridge", null)
+  additional_network = lookup(var.provider_settings["libvirt"], "additional_network", null)
 }
 
 locals {

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -108,8 +108,8 @@ variable "provider_settings" {
       // base
       pool               = "default"
       network_name       = "default"
-      bridge             = ""
-      additional_network = ""
+      bridge             = null
+      additional_network = null
     }
   }
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -89,7 +89,7 @@ variable "git_repo" {
 
 variable "server_http_proxy" {
   description = "Hostname and port used by the Server as the http proxy to reach the outside network"
-  default     = ""
+  default     = null
 }
 
 variable "saltapi_tcpdump" {

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -36,7 +36,7 @@ variable "images" {
 
 variable "mirror" {
   description = "hostname of the mirror host or leave the default for no mirror"
-  default     = "null"
+  default     = null
 }
 
 variable "use_mirror_images" {
@@ -63,7 +63,7 @@ variable "product_version" {
 
 variable "from_email" {
   description = "email address used as sender for emails"
-  default     = "null"
+  default     = null
 }
 
 // ctl

--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -90,7 +90,7 @@ resource "libvirt_volume" "ubuntu1804_volume" {
 }
 
 resource "libvirt_network" "additional_network" {
-  count     = var.additional_network == "" ? 0 : 1
+  count     = var.additional_network == null ? 0 : 1
   name      = "${var.name_prefix}private"
   mode      = "none"
   addresses = [var.additional_network]
@@ -133,7 +133,7 @@ output "configuration" {
 
     // Provider-specific variables
     pool         = var.pool
-    network_name = var.bridge == "" ? var.network_name : ""
+    network_name = var.bridge == null ? var.network_name : null
     bridge       = var.bridge
   }
 }

--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -121,7 +121,7 @@ output "configuration" {
     cc_password           = var.cc_password
     timezone              = var.timezone
     ssh_key_path          = var.ssh_key_path
-    mirror                = var.mirror == "" ? "null" : var.mirror
+    mirror                = var.mirror
     use_mirror_images     = var.use_mirror_images
     use_avahi             = var.use_avahi
     domain                = var.domain

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -20,7 +20,7 @@ variable "ssh_key_path" {
 
 variable "mirror" {
   description = "hostname of the mirror host or leave the default for no mirror"
-  default     = "null"
+  default     = null
 }
 
 variable "use_mirror_images" {

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -66,13 +66,13 @@ variable "pool" {
 }
 
 variable "network_name" {
-  description = "libvirt NAT network name for VMs, use empty string for bridged networking"
+  description = "libvirt NAT network name for VMs, use null for bridged networking"
   default     = "default"
 }
 
 variable "bridge" {
   description = "a bridge device name available on the libvirt host, leave default for NAT"
-  default     = ""
+  default     = null
 }
 
 variable "images" {

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -55,7 +55,7 @@ variable "testsuite" {
 
 variable "additional_network" {
   description = "additional network in CIDR notation, leave empty if none"
-  default     = ""
+  default     = null
 }
 
 // Provider-specific variables

--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -15,14 +15,12 @@ module "client" {
   connect_to_base_network       = true
   connect_to_additional_network = true
   roles                         = ["client"]
-  grains                        = <<EOF
-
-product_version: ${var.product_version}
-mirror: ${var.base_configuration["mirror"]}
-server: ${var.server_configuration["hostname"]}
-auto_register: ${var.auto_register}
-
-EOF
+  grains = {
+    product_version = var.product_version
+    mirror          = var.base_configuration["mirror"]
+    server          = var.server_configuration["hostname"]
+    auto_register   = var.auto_register
+  }
 
 
   // Provider-specific variables

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -98,5 +98,5 @@ variable "mac" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -53,8 +53,7 @@ variable "swap_file_size" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 variable "gpg_keys" {

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -93,7 +93,7 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "cpu_model" {

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {
@@ -15,7 +14,6 @@ variable "product_version" {
 
 variable "server_configuration" {
   description = "use module.<SERVER_NAME>.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "auto_register" {

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -32,37 +32,37 @@ module "controller" {
     proxy         = var.proxy_configuration["hostname"]
     client        = var.client_configuration["hostnames"][0]
     minion        = var.minion_configuration["hostnames"][0]
-    centos_minion = var.centos_configuration["hostnames"] != null ? var.centos_configuration["hostnames"][0] : ""
-    ubuntu_minion = var.ubuntu_configuration["hostnames"] != null ? var.ubuntu_configuration["hostnames"][0] : ""
-    ssh_minion        = var.minionssh_configuration["hostnames"] != null ? var.minionssh_configuration["hostnames"][0] : ""
-    kvm_host          = var.kvmhost_configuration["hostnames"] != null ? var.kvmhost_configuration["hostnames"][0] : ""
+    centos_minion = var.centos_configuration["hostnames"] != null ? var.centos_configuration["hostnames"][0] : null
+    ubuntu_minion = var.ubuntu_configuration["hostnames"] != null ? var.ubuntu_configuration["hostnames"][0] : null
+    ssh_minion        = var.minionssh_configuration["hostnames"] != null ? var.minionssh_configuration["hostnames"][0] : null
+    kvm_host          = var.kvmhost_configuration["hostnames"] != null ? var.kvmhost_configuration["hostnames"][0] : null
     pxeboot_mac       = var.pxeboot_configuration["macaddr"]
     branch            = var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch
     git_profiles_repo = var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo
     server_http_proxy = var.server_http_proxy
 
-    sle11sp4_minion      = var.sle11sp4_minion_configuration["hostnames"] != null ? var.sle11sp4_minion_configuration["hostnames"][0] : ""
-    sle11sp4_sshminion   = var.sle11sp4_sshminion_configuration["hostnames"] != null ? var.sle11sp4_sshminion_configuration["hostnames"][0] : ""
-    sle11sp4_client      = var.sle11sp4_client_configuration["hostnames"] != null ? var.sle11sp4_client_configuration["hostnames"][0] : ""
-    sle12sp4_minion      = var.sle12sp4_minion_configuration["hostnames"] != null ? var.sle12sp4_minion_configuration["hostnames"][0] : ""
-    sle12sp4_sshminion   = var.sle12sp4_sshminion_configuration["hostnames"] != null ? var.sle12sp4_sshminion_configuration["hostnames"][0] : ""
-    sle12sp4_client      = var.sle12sp4_client_configuration["hostnames"] != null ? var.sle12sp4_client_configuration["hostnames"][0] : ""
-    sle15_minion         = var.sle15_minion_configuration["hostnames"] != null ? var.sle15_minion_configuration["hostnames"][0] : ""
-    sle15_sshminion      = var.sle15_sshminion_configuration["hostnames"] != null ? var.sle15_sshminion_configuration["hostnames"][0] : ""
-    sle15_client         = var.sle15_client_configuration["hostnames"] != null ? var.sle15_client_configuration["hostnames"][0] : ""
-    sle15sp1_minion      = var.sle15sp1_minion_configuration["hostnames"] != null ? var.sle15sp1_minion_configuration["hostnames"][0] : ""
-    sle15sp1_sshminion   = var.sle15sp1_sshminion_configuration["hostnames"] != null ? var.sle15sp1_sshminion_configuration["hostnames"][0] : ""
-    sle15sp1_client      = var.sle15sp1_client_configuration["hostnames"] != null ? var.sle15sp1_client_configuration["hostnames"][0] : ""
-    centos6_minion       = var.centos6_minion_configuration["hostnames"] != null ? var.centos6_minion_configuration["hostnames"][0] : ""
-    centos6_sshminion    = var.centos6_sshminion_configuration["hostnames"] != null ? var.centos6_sshminion_configuration["hostnames"][0] : ""
-    centos6_client       = var.centos6_client_configuration["hostnames"] != null ? var.centos6_client_configuration["hostnames"][0] : ""
-    centos7_minion       = var.centos7_minion_configuration["hostnames"] != null ? var.centos7_minion_configuration["hostnames"][0] : ""
-    centos7_sshminion    = var.centos7_sshminion_configuration["hostnames"] != null ? var.centos7_sshminion_configuration["hostnames"][0] : ""
-    centos7_client       = var.centos7_client_configuration["hostnames"] != null ? var.centos7_client_configuration["hostnames"][0] : ""
-    ubuntu1604_minion    = var.ubuntu1604_minion_configuration["hostnames"] != null ? var.ubuntu1604_minion_configuration["hostnames"][0] : ""
-    ubuntu1604_sshminion = var.ubuntu1604_sshminion_configuration["hostnames"] != null ? var.ubuntu1604_sshminion_configuration["hostnames"][0] : ""
-    ubuntu1804_minion    = var.ubuntu1804_minion_configuration["hostnames"] != null ? var.ubuntu1804_minion_configuration["hostnames"][0] : ""
-    ubuntu1804_sshminion = var.ubuntu1804_sshminion_configuration["hostnames"] != null ? var.ubuntu1804_sshminion_configuration["hostnames"][0] : ""
+    sle11sp4_minion      = var.sle11sp4_minion_configuration["hostnames"] != null ? var.sle11sp4_minion_configuration["hostnames"][0] : null
+    sle11sp4_sshminion   = var.sle11sp4_sshminion_configuration["hostnames"] != null ? var.sle11sp4_sshminion_configuration["hostnames"][0] : null
+    sle11sp4_client      = var.sle11sp4_client_configuration["hostnames"] != null ? var.sle11sp4_client_configuration["hostnames"][0] : null
+    sle12sp4_minion      = var.sle12sp4_minion_configuration["hostnames"] != null ? var.sle12sp4_minion_configuration["hostnames"][0] : null
+    sle12sp4_sshminion   = var.sle12sp4_sshminion_configuration["hostnames"] != null ? var.sle12sp4_sshminion_configuration["hostnames"][0] : null
+    sle12sp4_client      = var.sle12sp4_client_configuration["hostnames"] != null ? var.sle12sp4_client_configuration["hostnames"][0] : null
+    sle15_minion         = var.sle15_minion_configuration["hostnames"] != null ? var.sle15_minion_configuration["hostnames"][0] : null
+    sle15_sshminion      = var.sle15_sshminion_configuration["hostnames"] != null ? var.sle15_sshminion_configuration["hostnames"][0] : null
+    sle15_client         = var.sle15_client_configuration["hostnames"] != null ? var.sle15_client_configuration["hostnames"][0] : null
+    sle15sp1_minion      = var.sle15sp1_minion_configuration["hostnames"] != null ? var.sle15sp1_minion_configuration["hostnames"][0] : null
+    sle15sp1_sshminion   = var.sle15sp1_sshminion_configuration["hostnames"] != null ? var.sle15sp1_sshminion_configuration["hostnames"][0] : null
+    sle15sp1_client      = var.sle15sp1_client_configuration["hostnames"] != null ? var.sle15sp1_client_configuration["hostnames"][0] : null
+    centos6_minion       = var.centos6_minion_configuration["hostnames"] != null ? var.centos6_minion_configuration["hostnames"][0] : null
+    centos6_sshminion    = var.centos6_sshminion_configuration["hostnames"] != null ? var.centos6_sshminion_configuration["hostnames"][0] : null
+    centos6_client       = var.centos6_client_configuration["hostnames"] != null ? var.centos6_client_configuration["hostnames"][0] : null
+    centos7_minion       = var.centos7_minion_configuration["hostnames"] != null ? var.centos7_minion_configuration["hostnames"][0] : null
+    centos7_sshminion    = var.centos7_sshminion_configuration["hostnames"] != null ? var.centos7_sshminion_configuration["hostnames"][0] : null
+    centos7_client       = var.centos7_client_configuration["hostnames"] != null ? var.centos7_client_configuration["hostnames"][0] : null
+    ubuntu1604_minion    = var.ubuntu1604_minion_configuration["hostnames"] != null ? var.ubuntu1604_minion_configuration["hostnames"][0] : null
+    ubuntu1604_sshminion = var.ubuntu1604_sshminion_configuration["hostnames"] != null ? var.ubuntu1604_sshminion_configuration["hostnames"][0] : null
+    ubuntu1804_minion    = var.ubuntu1804_minion_configuration["hostnames"] != null ? var.ubuntu1804_minion_configuration["hostnames"][0] : null
+    ubuntu1804_sshminion = var.ubuntu1804_sshminion_configuration["hostnames"] != null ? var.ubuntu1804_sshminion_configuration["hostnames"][0] : null
   }
 
 

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -23,49 +23,47 @@ module "controller" {
   connect_to_base_network       = true
   connect_to_additional_network = false
   roles                         = ["controller"]
-  grains                        = <<EOF
+  grains = {
+    git_username  = var.git_username
+    git_password  = var.git_password
+    git_repo      = var.git_repo
+    mirror        = var.base_configuration["mirror"]
+    server        = var.server_configuration["hostname"]
+    proxy         = var.proxy_configuration["hostname"]
+    client        = var.client_configuration["hostnames"][0]
+    minion        = var.minion_configuration["hostnames"][0]
+    centos_minion = var.centos_configuration["hostnames"] != null ? var.centos_configuration["hostnames"][0] : ""
+    ubuntu_minion = var.ubuntu_configuration["hostnames"] != null ? var.ubuntu_configuration["hostnames"][0] : ""
+    ssh_minion        = var.minionssh_configuration["hostnames"] != null ? var.minionssh_configuration["hostnames"][0] : ""
+    kvm_host          = var.kvmhost_configuration["hostnames"] != null ? var.kvmhost_configuration["hostnames"][0] : ""
+    pxeboot_mac       = var.pxeboot_configuration["macaddr"]
+    branch            = var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch
+    git_profiles_repo = var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo
+    server_http_proxy = var.server_http_proxy
 
-git_username: ${var.git_username}
-git_password: ${var.git_password}
-git_repo: ${var.git_repo}
-mirror: ${var.base_configuration["mirror"]}
-server: ${var.server_configuration["hostname"]}
-proxy: ${var.proxy_configuration["hostname"]}
-client: ${var.client_configuration["hostnames"][0]}
-minion: ${var.minion_configuration["hostnames"][0]}
-centos_minion: ${var.centos_configuration["hostnames"] != null ? var.centos_configuration["hostnames"][0] : ""}
-ubuntu_minion:  ${var.ubuntu_configuration["hostnames"] != null ? var.ubuntu_configuration["hostnames"][0] : ""}
-ssh_minion: ${var.minionssh_configuration["hostnames"] != null ? var.minionssh_configuration["hostnames"][0] : ""}
-kvm_host: ${var.kvmhost_configuration["hostnames"] != null ? var.kvmhost_configuration["hostnames"][0] : ""}
-pxeboot_mac: ${var.pxeboot_configuration["macaddr"]}
-branch: ${var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch}
-git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo}
-server_http_proxy: ${var.server_http_proxy}
-
-sle11sp4_minion: ${var.sle11sp4_minion_configuration["hostnames"] != null ? var.sle11sp4_minion_configuration["hostnames"][0] : ""}
-sle11sp4_sshminion: ${var.sle11sp4_sshminion_configuration["hostnames"] != null ? var.sle11sp4_sshminion_configuration["hostnames"][0] : ""}
-sle11sp4_client: ${var.sle11sp4_client_configuration["hostnames"] != null ? var.sle11sp4_client_configuration["hostnames"][0] : ""}
-sle12sp4_minion: ${var.sle12sp4_minion_configuration["hostnames"] != null ? var.sle12sp4_minion_configuration["hostnames"][0] : ""}
-sle12sp4_sshminion: ${var.sle12sp4_sshminion_configuration["hostnames"] != null ? var.sle12sp4_sshminion_configuration["hostnames"][0] : ""}
-sle12sp4_client: ${var.sle12sp4_client_configuration["hostnames"] != null ? var.sle12sp4_client_configuration["hostnames"][0] : ""}
-sle15_minion: ${var.sle15_minion_configuration["hostnames"] != null ? var.sle15_minion_configuration["hostnames"][0] : ""}
-sle15_sshminion: ${var.sle15_sshminion_configuration["hostnames"] != null ? var.sle15_sshminion_configuration["hostnames"][0] : ""}
-sle15_client: ${var.sle15_client_configuration["hostnames"] != null ? var.sle15_client_configuration["hostnames"][0] : ""}
-sle15sp1_minion: ${var.sle15sp1_minion_configuration["hostnames"] != null ? var.sle15sp1_minion_configuration["hostnames"][0] : ""}
-sle15sp1_sshminion: ${var.sle15sp1_sshminion_configuration["hostnames"] != null ? var.sle15sp1_sshminion_configuration["hostnames"][0] : ""}
-sle15sp1_client: ${var.sle15sp1_client_configuration["hostnames"] != null ? var.sle15sp1_client_configuration["hostnames"][0] : ""}
-centos6_minion: ${var.centos6_minion_configuration["hostnames"] != null ? var.centos6_minion_configuration["hostnames"][0] : ""}
-centos6_sshminion: ${var.centos6_sshminion_configuration["hostnames"] != null ? var.centos6_sshminion_configuration["hostnames"][0] : ""}
-centos6_client: ${var.centos6_client_configuration["hostnames"] != null ? var.centos6_client_configuration["hostnames"][0] : ""}
-centos7_minion: ${var.centos7_minion_configuration["hostnames"] != null ? var.centos7_minion_configuration["hostnames"][0] : ""}
-centos7_sshminion: ${var.centos7_sshminion_configuration["hostnames"] != null ? var.centos7_sshminion_configuration["hostnames"][0] : ""}
-centos7_client: ${var.centos7_client_configuration["hostnames"] != null ? var.centos7_client_configuration["hostnames"][0] : ""}
-ubuntu1604_minion: ${var.ubuntu1604_minion_configuration["hostnames"] != null ? var.ubuntu1604_minion_configuration["hostnames"][0] : ""}
-ubuntu1604_sshminion: ${var.ubuntu1604_sshminion_configuration["hostnames"] != null ? var.ubuntu1604_sshminion_configuration["hostnames"][0] : ""}
-ubuntu1804_minion: ${var.ubuntu1804_minion_configuration["hostnames"] != null ? var.ubuntu1804_minion_configuration["hostnames"][0] : ""}
-ubuntu1804_sshminion: ${var.ubuntu1804_sshminion_configuration["hostnames"] != null ? var.ubuntu1804_sshminion_configuration["hostnames"][0] : ""}
-
-EOF
+    sle11sp4_minion      = var.sle11sp4_minion_configuration["hostnames"] != null ? var.sle11sp4_minion_configuration["hostnames"][0] : ""
+    sle11sp4_sshminion   = var.sle11sp4_sshminion_configuration["hostnames"] != null ? var.sle11sp4_sshminion_configuration["hostnames"][0] : ""
+    sle11sp4_client      = var.sle11sp4_client_configuration["hostnames"] != null ? var.sle11sp4_client_configuration["hostnames"][0] : ""
+    sle12sp4_minion      = var.sle12sp4_minion_configuration["hostnames"] != null ? var.sle12sp4_minion_configuration["hostnames"][0] : ""
+    sle12sp4_sshminion   = var.sle12sp4_sshminion_configuration["hostnames"] != null ? var.sle12sp4_sshminion_configuration["hostnames"][0] : ""
+    sle12sp4_client      = var.sle12sp4_client_configuration["hostnames"] != null ? var.sle12sp4_client_configuration["hostnames"][0] : ""
+    sle15_minion         = var.sle15_minion_configuration["hostnames"] != null ? var.sle15_minion_configuration["hostnames"][0] : ""
+    sle15_sshminion      = var.sle15_sshminion_configuration["hostnames"] != null ? var.sle15_sshminion_configuration["hostnames"][0] : ""
+    sle15_client         = var.sle15_client_configuration["hostnames"] != null ? var.sle15_client_configuration["hostnames"][0] : ""
+    sle15sp1_minion      = var.sle15sp1_minion_configuration["hostnames"] != null ? var.sle15sp1_minion_configuration["hostnames"][0] : ""
+    sle15sp1_sshminion   = var.sle15sp1_sshminion_configuration["hostnames"] != null ? var.sle15sp1_sshminion_configuration["hostnames"][0] : ""
+    sle15sp1_client      = var.sle15sp1_client_configuration["hostnames"] != null ? var.sle15sp1_client_configuration["hostnames"][0] : ""
+    centos6_minion       = var.centos6_minion_configuration["hostnames"] != null ? var.centos6_minion_configuration["hostnames"][0] : ""
+    centos6_sshminion    = var.centos6_sshminion_configuration["hostnames"] != null ? var.centos6_sshminion_configuration["hostnames"][0] : ""
+    centos6_client       = var.centos6_client_configuration["hostnames"] != null ? var.centos6_client_configuration["hostnames"][0] : ""
+    centos7_minion       = var.centos7_minion_configuration["hostnames"] != null ? var.centos7_minion_configuration["hostnames"][0] : ""
+    centos7_sshminion    = var.centos7_sshminion_configuration["hostnames"] != null ? var.centos7_sshminion_configuration["hostnames"][0] : ""
+    centos7_client       = var.centos7_client_configuration["hostnames"] != null ? var.centos7_client_configuration["hostnames"][0] : ""
+    ubuntu1604_minion    = var.ubuntu1604_minion_configuration["hostnames"] != null ? var.ubuntu1604_minion_configuration["hostnames"][0] : ""
+    ubuntu1604_sshminion = var.ubuntu1604_sshminion_configuration["hostnames"] != null ? var.ubuntu1604_sshminion_configuration["hostnames"][0] : ""
+    ubuntu1804_minion    = var.ubuntu1804_minion_configuration["hostnames"] != null ? var.ubuntu1804_minion_configuration["hostnames"][0] : ""
+    ubuntu1804_sshminion = var.ubuntu1804_sshminion_configuration["hostnames"] != null ? var.ubuntu1804_sshminion_configuration["hostnames"][0] : ""
+  }
 
 
   // Provider-specific variables

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -278,7 +278,7 @@ variable "git_profiles_repo" {
 
 variable "server_http_proxy" {
   description = "Hostname and port used by SUSE Manager http proxy"
-  default     = ""
+  default     = null
 }
 
 // Provider-specific variables

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -305,5 +305,5 @@ variable "mac" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {
@@ -30,20 +29,18 @@ variable "branch" {
 
 variable "server_configuration" {
   description = "use module.<SERVER_NAME>.configuration, see main.tf.libvirt-testsuite.example"
-  type        = map(string)
 }
 
 variable "proxy_configuration" {
   description = "use module.<PROXY_NAME>.configuration, see main.tf.libvirt-testsuite.example"
-  type        = map(string)
   default = {
-    hostname = "null"
+    hostname = null
   }
 }
 
 variable "client_configuration" {
   description = "use module.<CLIENT_NAME>.configuration, see main.tf.libvirt-testsuite.example"
-  type        = object({
+  type = object({
     ids       = list(string)
     hostnames = list(string)
   })
@@ -51,7 +48,7 @@ variable "client_configuration" {
 
 variable "minion_configuration" {
   description = "use module.<MINION_NAME>.configuration, see main.tf.libvirt-testsuite.example"
-  type        = object({
+  type = object({
     ids       = list(string)
     hostnames = list(string)
   })
@@ -81,7 +78,7 @@ variable "ubuntu_configuration" {
 variable "pxeboot_configuration" {
   description = "use module.<PXEBOOT_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    macaddr = "null"
+    macaddr = null
   }
 }
 

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -260,8 +260,7 @@ variable "swap_file_size" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 variable "ipv6" {

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -300,7 +300,7 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "cpu_model" {

--- a/modules/libvirt/grafana/main.tf
+++ b/modules/libvirt/grafana/main.tf
@@ -6,14 +6,12 @@ module "grafana" {
   quantity           = var.quantity
   ssh_key_path       = var.ssh_key_path
   roles              = ["grafana"]
-  grains             = <<EOF
-
-mirror: ${var.base_configuration["mirror"]}
-server: ${var.server_configuration["hostname"]}
-locust: ${var.locust_configuration["hostname"]}
-product_version: 3.2-nightly
-
-EOF
+  grains = {
+    mirror          = var.base_configuration["mirror"]
+    server          = var.server_configuration["hostname"]
+    locust          = var.locust_configuration["hostname"]
+    product_version = "3.2-nightly"
+  }
 
 
   // Provider-specific variables

--- a/modules/libvirt/grafana/variables.tf
+++ b/modules/libvirt/grafana/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {
@@ -15,7 +14,6 @@ variable "quantity" {
 
 variable "server_configuration" {
   description = "use module.<SERVER_NAME>.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "locust_configuration" {

--- a/modules/libvirt/grafana/variables.tf
+++ b/modules/libvirt/grafana/variables.tf
@@ -25,8 +25,7 @@ variable "locust_configuration" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 // Provider-specific variables
@@ -45,4 +44,3 @@ variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default     = ""
 }
-

--- a/modules/libvirt/grafana/variables.tf
+++ b/modules/libvirt/grafana/variables.tf
@@ -37,7 +37,7 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "cpu_model" {

--- a/modules/libvirt/grafana/variables.tf
+++ b/modules/libvirt/grafana/variables.tf
@@ -42,5 +42,5 @@ variable "mac" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -1,18 +1,16 @@
-// Names are calculated as follows:
-// ${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-${count.index  + 1}" : ""}
-// This means:
-//   name_prefix + name (if quantity = 1)
-//   name_prefix + name + "-" + index (if quantity > 1)
+locals {
+  resource_name_prefix = "${var.base_configuration["name_prefix"]}${var.name}"
+}
 
 resource "libvirt_volume" "main_disk" {
-  name             = "${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-${count.index + 1}" : ""}-main-disk"
+  name             = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}-main-disk"
   base_volume_name = "${var.base_configuration["use_shared_resources"] ? "" : var.base_configuration["name_prefix"]}${var.image}"
   pool             = var.base_configuration["pool"]
   count            = var.quantity
 }
 
 resource "libvirt_domain" "domain" {
-  name       = "${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
+  name       = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
   memory     = var.memory
   vcpu       = var.vcpu
   running    = var.running
@@ -105,7 +103,7 @@ resource "libvirt_domain" "domain" {
   provisioner "file" {
     content = yamlencode(merge(
       {
-        hostname                  = "${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
+        hostname                  = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
         domain                    = var.base_configuration["domain"]
         use_avahi                 = var.base_configuration["use_avahi"]
         additional_network        = var.base_configuration["additional_network"]

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -76,18 +76,18 @@ resource "libvirt_domain" "domain" {
   }
 
   console {
-    type        = "pty"
-    target_port = "0"
-    target_type = "serial"
-    source_host = null
+    type           = "pty"
+    target_port    = "0"
+    target_type    = "serial"
+    source_host    = null
     source_service = null
   }
 
   console {
-    type        = "pty"
-    target_port = "1"
-    target_type = "virtio"
-    source_host = null
+    type           = "pty"
+    target_port    = "1"
+    target_type    = "virtio"
+    source_host    = null
     source_service = null
   }
 
@@ -103,67 +103,47 @@ resource "libvirt_domain" "domain" {
   }
 
   provisioner "file" {
-    content = <<EOF
+    content = yamlencode(merge(
+      {
+        hostname                      = "${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
+        domain                        = var.base_configuration["domain"]
+        use_avahi                     = var.base_configuration["use_avahi"]
+        additional_network            = var.base_configuration["additional_network"]
+        timezone                      = var.base_configuration["timezone"]
+        testsuite                     = var.base_configuration["testsuite"]
+        roles                         = var.roles
+        use_os_released_updates       = var.use_os_released_updates
+        use_os_unreleased_updates     = var.use_os_unreleased_updates
+        additional_repos              = var.additional_repos
+        additional_repos_only         = var.additional_repos_only
+        additional_certs              = var.additional_certs
+        additional_packages           = var.additional_packages
+        swap_file_size                = var.swap_file_size
+        authorized_keys               = [trimspace(file(var.base_configuration["ssh_key_path"])), trimspace(file(var.ssh_key_path))]
+        gpg_keys                      = var.gpg_keys
+        connect_to_base_network       = var.connect_to_base_network
+        connect_to_additional_network = var.connect_to_additional_network
+        reset_ids                     = true
+        ipv6                          = var.ipv6
+      },
+    var.grains))
+    destination = "/etc/salt/grains"
+  }
 
-hostname: ${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-${count.index + 1}" : ""}
-domain: ${var.base_configuration["domain"]}
-use_avahi: ${var.base_configuration["use_avahi"]}
-additional_network: ${var.base_configuration["additional_network"]}
-timezone: ${var.base_configuration["timezone"]}
-testsuite: ${var.base_configuration["testsuite"]}
-roles: [${join(",", var.roles)}]
-use_os_released_updates: ${var.use_os_released_updates}
-use_os_unreleased_updates: ${var.use_os_unreleased_updates}
-additional_repos: {${join(
-    ", ",
-    formatlist(
-      "'%s': '%s'",
-      keys(var.additional_repos),
-      values(var.additional_repos),
-    ),
-    )}}
-additional_repos_only: ${var.additional_repos_only}
-additional_certs: {${join(
-    ", ",
-    formatlist(
-      "'%s': '%s'",
-      keys(var.additional_certs),
-      values(var.additional_certs),
-    ),
-    )}}
-additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
-swap_file_size: ${var.swap_file_size}
-authorized_keys: [${trimspace(file(var.base_configuration["ssh_key_path"]))},${trimspace(file(var.ssh_key_path))}]
-gpg_keys: [${join(", ", formatlist("'%s'", var.gpg_keys))}]
-connect_to_base_network: ${var.connect_to_base_network}
-connect_to_additional_network: ${var.connect_to_additional_network}
-reset_ids: true
-ipv6: {${join(
-    ", ",
-    formatlist("'%s': %s", keys(var.ipv6), values(var.ipv6)),
-)}}
-${var.grains}
+  provisioner "remote-exec" {
+    inline = [
+      "sh /root/salt/first_deployment_highstate.sh",
+    ]
+  }
 
-EOF
-
-
-destination = "/etc/salt/grains"
-}
-
-provisioner "remote-exec" {
-  inline = [
-    "sh /root/salt/first_deployment_highstate.sh",
-  ]
-}
-
-xml {
-  xslt = var.xslt
-}
+  xml {
+    xslt = var.xslt
+  }
 }
 
 output "configuration" {
   value = {
-    ids      = libvirt_domain.domain[*].id
+    ids       = libvirt_domain.domain[*].id
     hostnames = [for value_used in libvirt_domain.domain : "${value_used.name}.${var.base_configuration["domain"]}"]
   }
 }

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -19,7 +19,7 @@ resource "libvirt_domain" "domain" {
 
   // copy host CPU model to guest to get the vmx flag if present
   cpu = {
-    mode = var.cpu_model != "" ? var.cpu_model : "custom"
+    mode = coalesce(var.cpu_model, "custom")
   }
 
   // base disk + additional disks if any

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -105,21 +105,24 @@ resource "libvirt_domain" "domain" {
   provisioner "file" {
     content = yamlencode(merge(
       {
-        hostname                      = "${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
-        domain                        = var.base_configuration["domain"]
-        use_avahi                     = var.base_configuration["use_avahi"]
-        additional_network            = var.base_configuration["additional_network"]
-        timezone                      = var.base_configuration["timezone"]
-        testsuite                     = var.base_configuration["testsuite"]
-        roles                         = var.roles
-        use_os_released_updates       = var.use_os_released_updates
-        use_os_unreleased_updates     = var.use_os_unreleased_updates
-        additional_repos              = var.additional_repos
-        additional_repos_only         = var.additional_repos_only
-        additional_certs              = var.additional_certs
-        additional_packages           = var.additional_packages
-        swap_file_size                = var.swap_file_size
-        authorized_keys               = [trimspace(file(var.base_configuration["ssh_key_path"])), trimspace(file(var.ssh_key_path))]
+        hostname                  = "${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
+        domain                    = var.base_configuration["domain"]
+        use_avahi                 = var.base_configuration["use_avahi"]
+        additional_network        = var.base_configuration["additional_network"]
+        timezone                  = var.base_configuration["timezone"]
+        testsuite                 = var.base_configuration["testsuite"]
+        roles                     = var.roles
+        use_os_released_updates   = var.use_os_released_updates
+        use_os_unreleased_updates = var.use_os_unreleased_updates
+        additional_repos          = var.additional_repos
+        additional_repos_only     = var.additional_repos_only
+        additional_certs          = var.additional_certs
+        additional_packages       = var.additional_packages
+        swap_file_size            = var.swap_file_size
+        authorized_keys = concat(
+          var.base_configuration["ssh_key_path"] != null ? [trimspace(file(var.base_configuration["ssh_key_path"]))] : [],
+          var.ssh_key_path != null ? [trimspace(file(var.ssh_key_path))] : [],
+        )
         gpg_keys                      = var.gpg_keys
         connect_to_base_network       = var.connect_to_base_network
         connect_to_additional_network = var.connect_to_additional_network

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -48,7 +48,7 @@ variable "quantity" {
 }
 
 variable "grains" {
-  description = "custom grain string to be added to this host's configuration"
+  description = "custom grain map to be added to this host's configuration"
   default     = {}
 }
 

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -59,8 +59,7 @@ variable "swap_file_size" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 variable "gpg_keys" {

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {
@@ -50,7 +49,7 @@ variable "quantity" {
 
 variable "grains" {
   description = "custom grain string to be added to this host's configuration"
-  default     = ""
+  default     = {}
 }
 
 variable "swap_file_size" {

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -123,6 +123,6 @@ variable "cpu_model" {
 }
 
 variable "xslt" {
-  description = "module relative path to an xsl file to apply on the libvirt domain"
-  default     = ""
+  description = "xslt contents to apply on the libvirt domain"
+  default     = null
 }

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -119,7 +119,7 @@ variable "additional_disk" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }
 
 variable "xslt" {

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -109,7 +109,7 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "additional_disk" {

--- a/modules/libvirt/locust/main.tf
+++ b/modules/libvirt/locust/main.tf
@@ -4,17 +4,15 @@ module "locust" {
   name               = var.name
   ssh_key_path       = var.ssh_key_path
   roles              = ["locust"]
-  grains             = <<EOF
-
-mirror: ${var.base_configuration["mirror"]}
-server: ${var.server_configuration["hostname"]}
-locust_file: ${base64encode(file(var.locust_file))}
-server_username: ${var.server_configuration["username"]}
-server_password: ${var.server_configuration["password"]}
-locust_master_host: null
-locust_slave_count: ${var.slave_quantity}
-EOF
-
+  grains = {
+    mirror             = var.base_configuration["mirror"]
+    server             = var.server_configuration["hostname"]
+    locust_file        = base64encode(file(var.locust_file))
+    server_username    = var.server_configuration["username"]
+    server_password    = var.server_configuration["password"]
+    locust_master_host = null
+    locust_slave_count = var.slave_quantity
+  }
 
   // Provider-specific variables
   image   = "opensuse151"
@@ -30,15 +28,14 @@ module "locust-slave" {
   quantity           = var.slave_quantity
   ssh_key_path       = var.ssh_key_path
   roles              = ["locust"]
-  grains             = <<EOF
-
-mirror: ${var.base_configuration["mirror"]}
-server: ${var.server_configuration["hostname"]}
-locust_file: ${base64encode(file(var.locust_file))}
-server_username: ${var.server_configuration["username"]}
-server_password: ${var.server_configuration["password"]}
-locust_master_host: ${module.locust.configuration["hostname"]}
-EOF
+  grains = {
+    mirror             = var.base_configuration["mirror"]
+    server             = var.server_configuration["hostname"]
+    locust_file        = base64encode(file(var.locust_file))
+    server_username    = var.server_configuration["username"]
+    server_password    = var.server_configuration["password"]
+    locust_master_host = module.locust.configuration["hostname"]
+  }
 
 
   // Provider-specific variables

--- a/modules/libvirt/locust/variables.tf
+++ b/modules/libvirt/locust/variables.tf
@@ -1,11 +1,9 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "server_configuration" {
   description = "use module.<SERVER_NAME>.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {

--- a/modules/libvirt/locust/variables.tf
+++ b/modules/libvirt/locust/variables.tf
@@ -13,8 +13,7 @@ variable "name" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 variable "locust_file" {

--- a/modules/libvirt/locust/variables.tf
+++ b/modules/libvirt/locust/variables.tf
@@ -45,5 +45,5 @@ variable "mac" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }

--- a/modules/libvirt/locust/variables.tf
+++ b/modules/libvirt/locust/variables.tf
@@ -40,7 +40,7 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "cpu_model" {

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -15,24 +15,20 @@ module "minion" {
   connect_to_base_network       = true
   connect_to_additional_network = true
   roles                         = var.roles
-  grains                        = <<EOF
 
-product_version: ${var.product_version}
-mirror: ${var.base_configuration["mirror"]}
-server: ${var.server_configuration["hostname"]}
-auto_connect_to_master: ${var.auto_connect_to_master}
-apparmor: ${var.apparmor}
-avahi_reflector: ${var.avahi_reflector}
-
-susemanager:
-  activation_key: ${var.activation_key}
-
-evil_minion_count: ${var.evil_minion_count}
-evil_minion_slowdown_factor: ${var.evil_minion_slowdown_factor}
-
-${var.additional_grains}
-
-EOF
+  grains = merge({
+    product_version        = var.product_version
+    mirror                 = var.base_configuration["mirror"]
+    server                 = var.server_configuration["hostname"]
+    auto_connect_to_master = var.auto_connect_to_master
+    apparmor               = var.apparmor
+    avahi_reflector        = var.avahi_reflector
+    susemanager = {
+      activation_key : var.activation_key
+    }
+    evil_minion_count           = var.evil_minion_count
+    evil_minion_slowdown_factor = var.evil_minion_slowdown_factor
+  }, var.additional_grains)
 
 
   // Provider-specific variables

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -133,7 +133,7 @@ variable "mac" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }
 
 variable "xslt" {

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -128,7 +128,7 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "cpu_model" {

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -137,6 +137,6 @@ variable "cpu_model" {
 }
 
 variable "xslt" {
-  description = "module relative path to an xslt file to apply on the libvirt domain"
-  default     = ""
+  description = "xslt contents to apply on the libvirt domain"
+  default     = null
 }

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -83,8 +83,7 @@ variable "swap_file_size" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 variable "gpg_keys" {

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {
@@ -20,12 +19,11 @@ variable "product_version" {
 
 variable "server_configuration" {
   description = "use module.<SERVER_NAME>.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "activation_key" {
   description = "an Activation Key to be used when onboarding this minion"
-  default     = "null"
+  default     = null
 }
 
 variable "auto_connect_to_master" {
@@ -104,7 +102,7 @@ variable "ipv6" {
 
 variable "additional_grains" {
   description = "custom grain string to be added to this minion's configuration"
-  default     = ""
+  default     = {}
 }
 
 // Provider-specific variables

--- a/modules/libvirt/minionssh/main.tf
+++ b/modules/libvirt/minionssh/main.tf
@@ -15,13 +15,10 @@ module "minionssh" {
   connect_to_base_network       = true
   connect_to_additional_network = true
   roles                         = ["minionssh"]
-  grains                        = <<EOF
-
-product_version: ${var.product_version}
-mirror: ${var.base_configuration["mirror"]}
-
-EOF
-
+  grains = {
+    product_version = var.product_version
+    mirror          = var.base_configuration["mirror"]
+  }
 
   // Provider-specific variables
   image     = var.image

--- a/modules/libvirt/minionssh/variables.tf
+++ b/modules/libvirt/minionssh/variables.tf
@@ -109,7 +109,7 @@ variable "additional_disk" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }
 
 variable "xslt" {

--- a/modules/libvirt/minionssh/variables.tf
+++ b/modules/libvirt/minionssh/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {

--- a/modules/libvirt/minionssh/variables.tf
+++ b/modules/libvirt/minionssh/variables.tf
@@ -113,6 +113,6 @@ variable "cpu_model" {
 }
 
 variable "xslt" {
-  description = "module relative path to an xsl file to apply on the libvirt domain"
-  default     = ""
+  description = "xslt contents to apply on the libvirt domain"
+  default     = null
 }

--- a/modules/libvirt/minionssh/variables.tf
+++ b/modules/libvirt/minionssh/variables.tf
@@ -49,8 +49,7 @@ variable "swap_file_size" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 variable "gpg_keys" {

--- a/modules/libvirt/minionssh/variables.tf
+++ b/modules/libvirt/minionssh/variables.tf
@@ -38,8 +38,8 @@ variable "quantity" {
 }
 
 variable "grains" {
-  description = "custom grain string to be added to this host's configuration"
-  default     = ""
+  description = "custom grain map to be added to this host's configuration"
+  default     = {}
 }
 
 variable "swap_file_size" {

--- a/modules/libvirt/minionssh/variables.tf
+++ b/modules/libvirt/minionssh/variables.tf
@@ -99,7 +99,7 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "additional_disk" {

--- a/modules/libvirt/mirror/main.tf
+++ b/modules/libvirt/mirror/main.tf
@@ -17,15 +17,13 @@ module "mirror" {
   swap_file_size      = var.swap_file_size
   ssh_key_path        = var.ssh_key_path
   roles               = ["mirror"]
-  grains              = <<EOF
-
-cc_username: ${var.base_configuration["cc_username"]}
-cc_password: ${var.base_configuration["cc_password"]}
-data_disk_device: vdb
-ubuntu_distros: [${join(", ", formatlist("'%s'", var.ubuntu_distros))}]
-use_mirror_images: ${var.base_configuration["use_mirror_images"]}
-
-EOF
+  grains = {
+    cc_username       = var.base_configuration["cc_username"]
+    cc_password       = var.base_configuration["cc_password"]
+    data_disk_device  = "vdb"
+    ubuntu_distros    = var.ubuntu_distros
+    use_mirror_images = var.base_configuration["use_mirror_images"]
+  }
 
 
   // Provider-specific variables
@@ -40,4 +38,3 @@ EOF
     },
   ]
 }
-

--- a/modules/libvirt/mirror/variables.tf
+++ b/modules/libvirt/mirror/variables.tf
@@ -46,5 +46,5 @@ variable "mac" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }

--- a/modules/libvirt/mirror/variables.tf
+++ b/modules/libvirt/mirror/variables.tf
@@ -19,8 +19,7 @@ variable "swap_file_size" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 variable "ubuntu_distros" {
@@ -49,4 +48,3 @@ variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default     = ""
 }
-

--- a/modules/libvirt/mirror/variables.tf
+++ b/modules/libvirt/mirror/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "additional_repos" {

--- a/modules/libvirt/mirror/variables.tf
+++ b/modules/libvirt/mirror/variables.tf
@@ -41,7 +41,7 @@ variable "data_pool" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "cpu_model" {

--- a/modules/libvirt/pts/main.tf
+++ b/modules/libvirt/pts/main.tf
@@ -13,7 +13,16 @@ module "server" {
   pts_system_prefix  = "${var.base_configuration["name_prefix"]}${var.minion_name}"
   channels           = ["sles12-sp3-pool-x86_64", "sles12-sp3-updates-x86_64", "sle-manager-tools12-pool-x86_64-sp3", "sle-manager-tools12-updates-x86_64-sp3"]
   wait_for_reposync  = true
-  cloned_channels    = "[{channels: [sles12-sp3-pool-x86_64, sles12-sp3-updates-x86_64, sle-manager-tools12-pool-x86_64-sp3, sle-manager-tools12-updates-x86_64-sp3], prefix: cloned-2017-q3, date: 2017-09-30}, {channels: [sles12-sp3-pool-x86_64, sles12-sp3-updates-x86_64, sle-manager-tools12-pool-x86_64-sp3, sle-manager-tools12-updates-x86_64-sp3], prefix: cloned-2017-q4, date: 2017-12-31}]"
+  cloned_channels = [
+    { channels = ["sles12-sp3-pool-x86_64", "sles12-sp3-updates-x86_64", "sle-manager-tools12-pool-x86_64-sp3", "sle-manager-tools12-updates-x86_64-sp3"],
+      prefix   = "cloned-2017-q3",
+      date     = "2017-09-30"
+    },
+    { channels = ["sles12-sp3-pool-x86_64", "sles12-sp3-updates-x86_64", "sle-manager-tools12-pool-x86_64-sp3", "sle-manager-tools12-updates-x86_64-sp3"],
+      prefix   = "cloned-2017-q4",
+      date     = "2017-12-31"
+    }
+  ]
 
   // Provider-specific variables
   vcpu   = 8
@@ -61,4 +70,3 @@ module "grafana" {
   // Provider-specific variables
   mac = var.grafana_mac
 }
-

--- a/modules/libvirt/pts/variables.tf
+++ b/modules/libvirt/pts/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "grafana" {

--- a/modules/libvirt/pts/variables.tf
+++ b/modules/libvirt/pts/variables.tf
@@ -36,26 +36,25 @@ variable "grafana_name" {
 
 variable "server_mac" {
   description = "a MAC address for the server in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "minion_mac" {
   description = "a MAC address for the minion instance in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "locust_mac" {
   description = "a MAC address for the Locust instance in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "grafana_mac" {
   description = "a MAC address for the Grafana instance in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default     = ""
 }
-

--- a/modules/libvirt/pts/variables.tf
+++ b/modules/libvirt/pts/variables.tf
@@ -56,5 +56,5 @@ variable "grafana_mac" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }

--- a/modules/libvirt/pxe_boot/variables.tf
+++ b/modules/libvirt/pxe_boot/variables.tf
@@ -36,7 +36,7 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "additional_disk" {

--- a/modules/libvirt/pxe_boot/variables.tf
+++ b/modules/libvirt/pxe_boot/variables.tf
@@ -46,6 +46,5 @@ variable "additional_disk" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }
-

--- a/modules/libvirt/pxe_boot/variables.tf
+++ b/modules/libvirt/pxe_boot/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -34,12 +34,8 @@ module "suse_manager" {
   ipv6                          = var.ipv6
   connect_to_base_network       = true
   connect_to_additional_network = false
+  roles = var.register_to_server == null ? ["suse_manager_server"] : ["suse_manager_server", "minion"]
 
-  # HACK: work around "conditional operator cannot be used with list values"
-  roles = split(
-    ",",
-    var.register_to_server == null ? "suse_manager_server" : "suse_manager_server,minion",
-  )
   grains = {
     product_version        = var.product_version
     cc_username            = var.base_configuration["cc_username"]

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -38,54 +38,53 @@ module "suse_manager" {
   # HACK: work around "conditional operator cannot be used with list values"
   roles = split(
     ",",
-    var.register_to_server == "null" ? "suse_manager_server" : "suse_manager_server,minion",
+    var.register_to_server == null ? "suse_manager_server" : "suse_manager_server,minion",
   )
-  grains = <<EOF
-
-product_version: ${var.product_version}
-cc_username: ${var.base_configuration["cc_username"]}
-cc_password: ${var.base_configuration["cc_password"]}
-channels: [${join(",", var.channels)}]
-wait_for_reposync: ${var.wait_for_reposync}
-cloned_channels: ${var.cloned_channels}
-mirror: ${var.base_configuration["mirror"]}
-iss_master: ${var.iss_master}
-iss_slave: ${var.iss_slave}
-server: ${var.register_to_server}
-auto_connect_to_master: ${var.auto_register}
-susemanager:
-  activation_key: ${var.activation_key}
-smt: ${var.smt}
-server_username: ${var.server_username}
-server_password: ${var.server_password}
-disable_firewall: ${var.disable_firewall}
-allow_postgres_connections: ${var.allow_postgres_connections}
-unsafe_postgres: ${var.unsafe_postgres}
-java_debugging: ${var.java_debugging}
-skip_changelog_import: ${var.skip_changelog_import}
-browser_side_less: ${var.browser_side_less}
-create_first_user: ${var.create_first_user}
-mgr_sync_autologin: ${var.mgr_sync_autologin}
-create_sample_channel: ${var.create_sample_channel}
-create_sample_activation_key: ${var.create_sample_activation_key}
-create_sample_bootstrap_script: ${var.create_sample_bootstrap_script}
-publish_private_ssl_key: ${var.publish_private_ssl_key}
-disable_download_tokens: ${var.disable_download_tokens}
-auto_accept: ${var.auto_accept}
-monitored: ${var.monitored}
-pts: ${var.pts}
-pts_minion: ${var.pts_minion}
-pts_locust: ${var.pts_locust}
-pts_system_count: ${var.pts_system_count}
-pts_system_prefix: ${var.pts_system_prefix}
-apparmor: ${var.apparmor}
-from_email: ${var.from_email}
-traceback_email: ${var.traceback_email}
-saltapi_tcpdump: ${var.saltapi_tcpdump}
-repository_disk_size: ${var.repository_disk_size}
-repository_disk_device: vdb
-
-EOF
+  grains = {
+    product_version        = var.product_version
+    cc_username            = var.base_configuration["cc_username"]
+    cc_password            = var.base_configuration["cc_password"]
+    channels               = var.channels
+    wait_for_reposync      = var.wait_for_reposync
+    cloned_channels        = var.cloned_channels
+    mirror                 = var.base_configuration["mirror"]
+    iss_master             = var.iss_master
+    iss_slave              = var.iss_slave
+    server                 = var.register_to_server
+    auto_connect_to_master = var.auto_register
+    susemanager = {
+      activation_key = var.activation_key
+    }
+    smt                            = var.smt
+    server_username                = var.server_username
+    server_password                = var.server_password
+    disable_firewall               = var.disable_firewall
+    allow_postgres_connections     = var.allow_postgres_connections
+    unsafe_postgres                = var.unsafe_postgres
+    java_debugging                 = var.java_debugging
+    skip_changelog_import          = var.skip_changelog_import
+    browser_side_less              = var.browser_side_less
+    create_first_user              = var.create_first_user
+    mgr_sync_autologin             = var.mgr_sync_autologin
+    create_sample_channel          = var.create_sample_channel
+    create_sample_activation_key   = var.create_sample_activation_key
+    create_sample_bootstrap_script = var.create_sample_bootstrap_script
+    publish_private_ssl_key        = var.publish_private_ssl_key
+    disable_download_tokens        = var.disable_download_tokens
+    auto_accept                    = var.auto_accept
+    monitored                      = var.monitored
+    pts                            = var.pts
+    pts_minion                     = var.pts_minion
+    pts_locust                     = var.pts_locust
+    pts_system_count               = var.pts_system_count
+    pts_system_prefix              = var.pts_system_prefix
+    apparmor                       = var.apparmor
+    from_email                     = var.from_email
+    traceback_email                = var.traceback_email
+    saltapi_tcpdump                = var.saltapi_tcpdump
+    repository_disk_size           = var.repository_disk_size
+    repository_disk_device         = "vdb"
+  }
 
 
   // Provider-specific variables

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -25,7 +25,11 @@ variable "wait_for_reposync" {
 variable "cloned_channels" {
   description = "a json formatted string representing a list of dictionaries containing SUSE channels information to clone"
   default     = null
-  type        = string
+  type        = list(object({
+    channels = list(string)
+    prefix = string
+    date = string
+  }))
 }
 
 variable "iss_master" {

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {
@@ -25,23 +24,23 @@ variable "wait_for_reposync" {
 
 variable "cloned_channels" {
   description = "a json formatted string representing a list of dictionaries containing SUSE channels information to clone"
-  default     = "null"
+  default     = null
   type        = string
 }
 
 variable "iss_master" {
   description = "ISS master server, leave the default for no ISS"
-  default     = "null"
+  default     = null
 }
 
 variable "iss_slave" {
   description = "ISS slave server, leave the default for no ISS"
-  default     = "null"
+  default     = null
 }
 
 variable "register_to_server" {
   description = "name of another Server to register to, eg module.<SERVER_NAME>.configuration.hostname"
-  default     = "null"
+  default     = null
 }
 
 variable "auto_register" {
@@ -51,7 +50,7 @@ variable "auto_register" {
 
 variable "activation_key" {
   description = "an Activation Key to be used when registering to another Server"
-  default     = "null"
+  default     = null
 }
 
 variable "server_username" {
@@ -141,12 +140,12 @@ variable "use_os_unreleased_updates" {
 
 variable "from_email" {
   description = "email address used as sender for emails"
-  default     = "null"
+  default     = null
 }
 
 variable "smt" {
   description = "URL to an SMT server to get packages from"
-  default     = "null"
+  default     = null
 }
 
 variable "auto_accept" {
@@ -186,7 +185,7 @@ variable "additional_packages" {
 
 variable "traceback_email" {
   description = "recipient email address that will receive errors during usage"
-  default     = "null"
+  default     = null
 }
 
 variable "swap_file_size" {

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -199,8 +199,7 @@ variable "swap_file_size" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 variable "gpg_keys" {

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -274,7 +274,7 @@ variable "repository_disk_size" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }
 
 variable "saltapi_tcpdump" {

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -264,7 +264,7 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "repository_disk_size" {

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -34,26 +34,23 @@ module "suse_manager_proxy" {
   connect_to_base_network       = true
   connect_to_additional_network = true
   roles                         = ["suse_manager_proxy"]
-  grains                        = <<EOF
-
-product_version: ${var.product_version}
-mirror: ${var.base_configuration["mirror"]}
-server: ${var.server_configuration["hostname"]}
-minion: ${var.minion}
-auto_connect_to_master: ${var.auto_connect_to_master}
-auto_register: ${var.auto_register}
-download_private_ssl_key: ${var.download_private_ssl_key}
-auto_configure: ${var.auto_configure}
-server_username: ${var.server_configuration["username"]}
-server_password: ${var.server_configuration["password"]}
-generate_bootstrap_script: ${var.generate_bootstrap_script}
-publish_private_ssl_key: ${var.publish_private_ssl_key}
-apparmor: ${var.apparmor}
-repository_disk_size: ${var.repository_disk_size}
-repository_disk_device: vdb
-
-EOF
-
+  grains = {
+    product_version           = var.product_version
+    mirror                    = var.base_configuration["mirror"]
+    server                    = var.server_configuration["hostname"]
+    minion                    = var.minion
+    auto_connect_to_master    = var.auto_connect_to_master
+    auto_register             = var.auto_register
+    download_private_ssl_key  = var.download_private_ssl_key
+    auto_configure            = var.auto_configure
+    server_username           = var.server_configuration["username"]
+    server_password           = var.server_configuration["password"]
+    generate_bootstrap_script = var.generate_bootstrap_script
+    publish_private_ssl_key   = var.publish_private_ssl_key
+    apparmor                  = var.apparmor
+    repository_disk_size      = var.repository_disk_size
+    repository_disk_device    = "vdb"
+  }
 
   // Provider-specific variables
   image           = var.image == "default" || var.product_version == "head" ? var.images[var.product_version] : var.image

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -88,8 +88,7 @@ variable "swap_file_size" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 variable "gpg_keys" {

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -128,7 +128,7 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }
 
 variable "cpu_model" {

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {
@@ -15,7 +14,6 @@ variable "product_version" {
 
 variable "server_configuration" {
   description = "use module.<SERVER_NAME>.configuration, see README_ADVANCED.md"
-  type        = map(string)
 }
 
 variable "minion" {

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -133,7 +133,7 @@ variable "mac" {
 
 variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
-  default     = ""
+  default     = null
 }
 
 variable "repository_disk_size" {

--- a/modules/libvirt/virthost/main.tf
+++ b/modules/libvirt/virthost/main.tf
@@ -17,11 +17,10 @@ module "virthost" {
   ssh_key_path              = var.ssh_key_path
   ipv6                      = var.ipv6
   roles                     = ["minion", "virthost"]
-  additional_grains         = <<EOF
-
-hvm_disk_image: "${var.hvm_disk_image}"
-hvm_disk_image_hash: "${var.hvm_disk_image_hash}"
-EOF
+  additional_grains = {
+    hvm_disk_image      = var.hvm_disk_image
+    hvm_disk_image_hash = var.hvm_disk_image_hash
+  }
 
 
   // Provider-specific variables

--- a/modules/libvirt/virthost/variables.tf
+++ b/modules/libvirt/virthost/variables.tf
@@ -1,6 +1,5 @@
 variable "base_configuration" {
   description = "use module.base.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "name" {
@@ -15,12 +14,11 @@ variable "product_version" {
 
 variable "server_configuration" {
   description = "use module.<SERVER_NAME>.configuration, see the main.tf example file"
-  type        = map(string)
 }
 
 variable "activation_key" {
   description = "an Activation Key to be used when onboarding this minion"
-  default     = "null"
+  default     = null
 }
 
 variable "auto_connect_to_master" {

--- a/modules/libvirt/virthost/variables.tf
+++ b/modules/libvirt/virthost/variables.tf
@@ -53,8 +53,7 @@ variable "additional_packages" {
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default     = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+  default     = null
 }
 
 variable "quantity" {

--- a/modules/libvirt/virthost/variables.tf
+++ b/modules/libvirt/virthost/variables.tf
@@ -108,5 +108,5 @@ variable "running" {
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default     = ""
+  default     = null
 }


### PR DESCRIPTION
## What does this PR change?
The main goal of this PR is to use objects to define host grains and serialized them using terraform native methods. 
This allows removing a set of hacks that were needed since we are using string templates to generate the file content.

This rector acts in two action items:
- remove null string as default value in vars
- pass grains as objects instead of strings
- Remove type check for base configuration and server configuration

Jenkins Run: 
- https://ci.suse.de/view/Manager/view/Manager-3.2/job/manager-3.2-cucumber-pipeline-NUE/669
- https://ci.suse.de/view/Manager/view/Manager-3.2/job/manager-3.2-cucumber-pipeline-NUE/677/

I need to remove the type check since it was defined as map and all fields were converted to string. 
To solve this we have two approaches:
1 - Do not specify the variable type and allow any type as input.
2- Define as object, and specify each field in the object. This needs to be propagated in several modules, and if we need to add another field, we should synchronize in all modules

In this case, since it is for internal use only, I think it is safe to not specify the variable type, and use solution 1.

**Some more detailed information from documentation:**
If we specify the base input as map, it should have all the same type and  If we define as map of any, it will be converted to string.
"_The keyword map is a shorthand for map(any), which accepts any element type as long as every element is the same type._ " (https://www.terraform.io/docs/configuration/types.html#collection-types)

We are not obligated to specify the variable type, and in that case, it can have any type:
"_The type argument in a variable block allows you to restrict the type of value that will be accepted as the value for a variable. If no type constraint is set then a value of any type is accepted._

_While type constraints are optional, we recommend specifying them; they serve as easy reminders for users of the module, and allow Terraform to return a helpful error message if the wrong type is used._"  (https://www.terraform.io/docs/configuration/variables.html#type-constraints)



Signed-off-by: Ricardo Mateus <rmateus@suse.com>