### PR TITLE
refactor base module with for_each in volumes

### DIFF
--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -1,91 +1,28 @@
-resource "libvirt_volume" "centos7_volume" {
-  name   = "${var.name_prefix}centos7"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "centos7") ? 1 : 0
-  pool   = var.pool
+locals {
+  images_used =  var.use_shared_resources ? [] : var.images
+  image_urls = {
+    centos7 = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2"
+    opensuse150 = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse150.x86_64.qcow2"
+    opensuse151 = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse151.x86_64.qcow2"
+    sles15 = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15.x86_64.qcow2"
+    sles15sp1 = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp1.x86_64.qcow2"
+    sles15sp2 = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp2.x86_64.qcow2"
+    sles11sp4 = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles11sp4.x86_64.qcow2"
+    sles12  = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12.x86_64.qcow2"
+    sles12sp1 = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64.qcow2"
+    sles12sp2 = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp2.x86_64.qcow2"
+    sles12sp3 = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp3.x86_64.qcow2"
+    sles12sp4 = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp4.x86_64.qcow2"
+    ubuntu1804 = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.4.0/ubuntu1804.qcow2"
+
+  }
 }
 
-resource "libvirt_volume" "opensuse150_volume" {
-  name   = "${var.name_prefix}opensuse150"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse150.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "opensuse150") ? 1 : 0
-  pool   = var.pool
-}
+resource "libvirt_volume" "volumes" {
+  for_each = local.images_used
 
-resource "libvirt_volume" "opensuse151_volume" {
-  name   = "${var.name_prefix}opensuse151"
-  source = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse151.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "opensuse151") ? 1 : 0
-  pool   = var.pool
-}
-
-resource "libvirt_volume" "sles15_volume" {
-  name   = "${var.name_prefix}sles15"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "sles15") ? 1 : 0
-  pool   = var.pool
-}
-
-resource "libvirt_volume" "sles15sp1_volume" {
-  name   = "${var.name_prefix}sles15sp1"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp1.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "sles15sp1") ? 1 : 0
-  pool   = var.pool
-}
-
-resource "libvirt_volume" "sles15sp2_volume" {
-  name   = "${var.name_prefix}sles15sp2"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp2.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "sles15sp2") ? 1 : 0
-  pool   = var.pool
-}
-
-resource "libvirt_volume" "sles11sp4_volume" {
-  name   = "${var.name_prefix}sles11sp4"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles11sp4.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "sles11sp4") ? 1 : 0
-  pool   = var.pool
-}
-
-resource "libvirt_volume" "sles12_volume" {
-  name   = "${var.name_prefix}sles12"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "sles12") ? 1 : 0
-  pool   = var.pool
-}
-
-resource "libvirt_volume" "sles12sp1_volume" {
-  name   = "${var.name_prefix}sles12sp1"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "sles12sp1") ? 1 : 0
-  pool   = var.pool
-}
-
-resource "libvirt_volume" "sles12sp2_volume" {
-  name   = "${var.name_prefix}sles12sp2"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp2.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "sles12sp2") ? 1 : 0
-  pool   = var.pool
-}
-
-resource "libvirt_volume" "sles12sp3_volume" {
-  name   = "${var.name_prefix}sles12sp3"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp3.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "sles12sp3") ? 1 : 0
-  pool   = var.pool
-}
-
-resource "libvirt_volume" "sles12sp4_volume" {
-  name   = "${var.name_prefix}sles12sp4"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp4.x86_64.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "sles12sp4") ? 1 : 0
-  pool   = var.pool
-}
-
-resource "libvirt_volume" "ubuntu1804_volume" {
-  name   = "${var.name_prefix}ubuntu1804"
-  source = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.4.0/ubuntu1804.qcow2"
-  count  = var.use_shared_resources ? 0 : contains(var.images, "ubuntu1804") ? 1 : 0
+  name   = "${var.name_prefix}${each.value}"
+  source = local.image_urls[each.value]
   pool   = var.pool
 }
 
@@ -102,18 +39,7 @@ resource "libvirt_network" "additional_network" {
 
 output "configuration" {
   depends_on = [
-    libvirt_volume.centos7_volume,
-    libvirt_volume.opensuse150_volume,
-    libvirt_volume.opensuse151_volume,
-    libvirt_volume.sles15_volume,
-    libvirt_volume.sles15sp1_volume,
-    libvirt_volume.sles11sp4_volume,
-    libvirt_volume.sles12_volume,
-    libvirt_volume.sles12sp1_volume,
-    libvirt_volume.sles12sp2_volume,
-    libvirt_volume.sles12sp3_volume,
-    libvirt_volume.sles12sp4_volume,
-    libvirt_volume.ubuntu1804_volume,
+    libvirt_volume.volumes,
     libvirt_network.additional_network,
   ]
   value = {

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -78,4 +78,5 @@ variable "bridge" {
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
   default     = ["centos7", "opensuse150", "opensuse151", "sles15", "sles15sp1", "sles15sp2", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
+  type        = set(string)
 }


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

For each volume, we had one resource block. However, all block are very similar so we can abstract them in one single resource block with "for_each".

Added a map with the URL for each base image. Now add support to a new volume we just need to add the volume base URL to the "image_urls" local variable.

Documentation: https://www.terraform.io/docs/configuration/resources.html#for_each-multiple-resource-instances-defined-by-a-map-or-set-of-strings
