### PR TITLE
cucumber_testsuite: add git_repo variable

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -235,6 +235,7 @@ module "ctl" {
   branch            = var.branch
   git_username      = var.git_username
   git_password      = var.git_password
+  git_repo          = var.git_repo
   server_http_proxy = var.server_http_proxy
 
   additional_repos = lookup(local.additional_repos, "ctl", {})

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -89,6 +89,11 @@ variable "git_password" {
   type        = string
 }
 
+variable "git_repo" {
+  description = "Git repo clone URL for testsuite code"
+  default     = "default"
+}
+
 variable "server_http_proxy" {
   description = "Hostname and port used by the Server as the http proxy to reach the outside network"
   default     = ""


### PR DESCRIPTION
## What does this PR change?

Adds the controller's `git_repo` variable to `cucumber_testsuite`
