### PR TITLE
Update taint wiki according to the new command interface

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -183,10 +183,10 @@ A: you can use [Terraform's taint command](https://www.terraform.io/docs/command
 ```
 $ terraform state list
 ...
-module.server.module.suse_manager.libvirt_volume.main_disk
+module.server.module.suse_manager.libvirt_volume.main_disk[0]
 
-$ terraform taint -module=server.suse_manager libvirt_volume.main_disk
-The resource libvirt_volume.main_disk in the module root.server.suse_manager has been marked as tainted!
+$ terraform taint module.server.module.suse_manager.libvirt_volume.main_disk[0]
+Resource instance module.server.module.suse_manager.libvirt_volume.main_disk[0] has been marked as tainted.
 ```
 ## Q: how to force the re-download of an image?
 
@@ -197,8 +197,8 @@ $ terraform state list
 ...
 module.base.libvirt_volume.volumes[2]
 
-$ terraform taint -module=base libvirt_volume.volumes.2
-The resource libvirt_volume.volumes.2 in the module root.base has been marked as tainted!
+$ terraform taint module.base.libvirt_volume.volumes[2]
+Resource instance module.base.libvirt_volume.volumes[2] has been marked as tainted.
 ```
 
 Please note that any dependent volume and module should be tainted as well before applying (eg. if you are tainting the `sles12sp2` image, make sure you either have no VMs based on that OS or that they are all tainted).


### PR DESCRIPTION
## What does this PR change?

Update `taint` wiki according to the new command interface

Using the previous command with the `-module` parameter I get the error message:
```
The -module option is no longer used. Instead, include the module path in the main resource address, like "module.foo.module.bar.null_resource.baz".
```