### PR TITLE
Adaptations for SLE 15 SP1 clients - batch 1

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -37,6 +37,8 @@ scc:
     - SLE-Module-Server-Applications15-SP1-Updates
     - SLE-Module-Web-Scripting15-SP1-Pool
     - SLE-Module-Web-Scripting15-SP1-Updates
+    - SLE-Module-DevTools15-SP1-Pool
+    - SLE-Module-DevTools15-SP1-Updates
     - SLE-Module-Python2-15-SP1-Pool
     - SLE-Module-Python2-15-SP1-Update
     # SLE 15-SP2 Products
@@ -49,6 +51,8 @@ scc:
     - SLE-Module-Server-Applications15-SP2-Updates
     - SLE-Module-Web-Scripting15-SP2-Pool
     - SLE-Module-Web-Scripting15-SP2-Updates
+    - SLE-Module-DevTools15-SP2-Pool
+    - SLE-Module-DevTools15-SP2-Updates
     - SLE-Module-Python2-15-SP2-Pool
     - SLE-Module-Python2-15-SP2-Update
     # SLE Legacy Module
@@ -145,6 +149,8 @@ http:
   # SLES 15 SP1 Test
   - url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Basesystem:/15-SP1:/x86_64/update
     archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Development-Tools:/15-SP1:/x86_64/update
+    archs: [x86_64]
   - url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Python2:/15-SP1:/x86_64/update
     archs: [x86_64]
   - url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Server-Applications:/15-SP1:/x86_64/update
@@ -155,6 +161,8 @@ http:
   # SLES 15 SP2 Test (not available until GM)
   #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Basesystem:/15-SP2:/x86_64/update
   #  archs: [x86_64]
+  #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Development-Tools:/15-SP2:/x86_64/update
+  #  archs: [x86_64]
   #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Python2:/15-SP2:/x86_64/update
   #  archs: [x86_64]
   #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Server-Applications:/15-SP2:/x86_64/update
@@ -164,6 +172,8 @@ http:
 
   # SLE 15 SP2 moving target (valid until GM)
   - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Basesystem-POOL-x86_64-Media1/
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Development-Tools-POOL-x86_64-Media1/
     archs: [x86_64]
   - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Python2-POOL-x86_64-Media1/
     archs: [x86_64]

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -28,6 +28,16 @@ devel_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/
 
+{% if '3.2-nightly' in grains.get('product_version') or '4.0-nightly' in grains.get('product_version') %}
+python2_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/
+
+python2_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/
+{% endif %}
+
 {% endif %}
 
 

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -19,6 +19,15 @@ containers_pool_repo:
 containers_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15/x86_64/update/
+
+devel_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/
+
+devel_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/
+
 {% endif %}
 
 

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -14,11 +14,11 @@ containers_updates_repo:
 {% if '15' in grains['osrelease'] %}
 containers_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15/x86_64/product/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/
 
 containers_updates_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/
 
 devel_pool_repo:
   pkgrepo.managed:


### PR DESCRIPTION
## What does this PR change?

It prepares for testing with SLE 15 SP1 clients

* SLE 15 SP1 development tools repos are needed for Kiwi
* SLE 15 SP1 Python2 repos are needed for Docker
   (3.2 and 4.0 only; one can build containers with Python3 on 4.1)
* Using SLE 15 SP1 for containers too
* Mirror developement tools in minima
  (Python 2 and Containers seem OK already)

See also uyuni-project/uyuni#1721 for the cucumber side
