### PR TITLE
Fix empty lookups

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -226,11 +226,11 @@ module "ctl" {
   proxy_configuration     = contains(local.hosts, "pxy") ? module.pxy.configuration : { hostname = null }
   client_configuration    = module.cli-sles12sp4.configuration
   minion_configuration    = module.min-sles12sp4.configuration
-  centos_configuration    = contains(local.hosts, "min-centos7") ? module.min-centos7.configuration : { hostnames = null, ids = null }
-  ubuntu_configuration    = contains(local.hosts, "min-ubuntu1804") ? module.min-ubuntu1804.configuration : { hostnames = null, ids = null }
-  sshminion_configuration = contains(local.hosts, "minssh-sles12sp4") ? module.minssh-sles12sp4.configuration : { hostnames = null, ids = null }
+  centos_configuration    = contains(local.hosts, "min-centos7") ? module.min-centos7.configuration : { hostnames = [], ids = [] }
+  ubuntu_configuration    = contains(local.hosts, "min-ubuntu1804") ? module.min-ubuntu1804.configuration : { hostnames = [], ids = [] }
+  sshminion_configuration = contains(local.hosts, "minssh-sles12sp4") ? module.minssh-sles12sp4.configuration : { hostnames = [], ids = [] }
   pxeboot_configuration   = contains(local.hosts, "min-pxeboot") ? module.min-pxeboot.configuration : { macaddr = null }
-  kvmhost_configuration   = contains(local.hosts, "min-kvm") ? module.min-kvm.configuration : { hostnames = null, ids = null }
+  kvmhost_configuration   = contains(local.hosts, "min-kvm") ? module.min-kvm.configuration : { hostnames = [], ids = [] }
 
   branch            = var.branch
   git_username      = var.git_username

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -32,37 +32,37 @@ module "controller" {
     proxy         = var.proxy_configuration["hostname"]
     client        = length(var.client_configuration["hostnames"]) > 0 ? var.client_configuration["hostnames"][0] : null
     minion        = length(var.minion_configuration["hostnames"]) > 0 ? var.minion_configuration["hostnames"][0] : null
-    centos_minion = var.centos_configuration["hostnames"] != null ? var.centos_configuration["hostnames"][0] : null
-    ubuntu_minion = var.ubuntu_configuration["hostnames"] != null ? var.ubuntu_configuration["hostnames"][0] : null
-    ssh_minion        = var.sshminion_configuration["hostnames"] != null ? var.sshminion_configuration["hostnames"][0] : null
-    kvm_host          = var.kvmhost_configuration["hostnames"] != null ? var.kvmhost_configuration["hostnames"][0] : null
+    centos_minion = length(var.centos_configuration["hostnames"]) > 0 ? var.centos_configuration["hostnames"][0] : null
+    ubuntu_minion = length(var.ubuntu_configuration["hostnames"]) > 0 ? var.ubuntu_configuration["hostnames"][0] : null
+    ssh_minion        = length(var.sshminion_configuration["hostnames"]) > 0 ? var.sshminion_configuration["hostnames"][0] : null
+    kvm_host          = length(var.kvmhost_configuration["hostnames"]) > 0 ? var.kvmhost_configuration["hostnames"][0] : null
     pxeboot_mac       = var.pxeboot_configuration["macaddr"]
     branch            = var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch
     git_profiles_repo = var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo
     server_http_proxy = var.server_http_proxy
 
-    sle11sp4_minion      = var.sle11sp4_minion_configuration["hostnames"] != null ? var.sle11sp4_minion_configuration["hostnames"][0] : null
-    sle11sp4_sshminion   = var.sle11sp4_sshminion_configuration["hostnames"] != null ? var.sle11sp4_sshminion_configuration["hostnames"][0] : null
-    sle11sp4_client      = var.sle11sp4_client_configuration["hostnames"] != null ? var.sle11sp4_client_configuration["hostnames"][0] : null
-    sle12sp4_minion      = var.sle12sp4_minion_configuration["hostnames"] != null ? var.sle12sp4_minion_configuration["hostnames"][0] : null
-    sle12sp4_sshminion   = var.sle12sp4_sshminion_configuration["hostnames"] != null ? var.sle12sp4_sshminion_configuration["hostnames"][0] : null
-    sle12sp4_client      = var.sle12sp4_client_configuration["hostnames"] != null ? var.sle12sp4_client_configuration["hostnames"][0] : null
-    sle15_minion         = var.sle15_minion_configuration["hostnames"] != null ? var.sle15_minion_configuration["hostnames"][0] : null
-    sle15_sshminion      = var.sle15_sshminion_configuration["hostnames"] != null ? var.sle15_sshminion_configuration["hostnames"][0] : null
-    sle15_client         = var.sle15_client_configuration["hostnames"] != null ? var.sle15_client_configuration["hostnames"][0] : null
-    sle15sp1_minion      = var.sle15sp1_minion_configuration["hostnames"] != null ? var.sle15sp1_minion_configuration["hostnames"][0] : null
-    sle15sp1_sshminion   = var.sle15sp1_sshminion_configuration["hostnames"] != null ? var.sle15sp1_sshminion_configuration["hostnames"][0] : null
-    sle15sp1_client      = var.sle15sp1_client_configuration["hostnames"] != null ? var.sle15sp1_client_configuration["hostnames"][0] : null
-    centos6_minion       = var.centos6_minion_configuration["hostnames"] != null ? var.centos6_minion_configuration["hostnames"][0] : null
-    centos6_sshminion    = var.centos6_sshminion_configuration["hostnames"] != null ? var.centos6_sshminion_configuration["hostnames"][0] : null
-    centos6_client       = var.centos6_client_configuration["hostnames"] != null ? var.centos6_client_configuration["hostnames"][0] : null
-    centos7_minion       = var.centos7_minion_configuration["hostnames"] != null ? var.centos7_minion_configuration["hostnames"][0] : null
-    centos7_sshminion    = var.centos7_sshminion_configuration["hostnames"] != null ? var.centos7_sshminion_configuration["hostnames"][0] : null
-    centos7_client       = var.centos7_client_configuration["hostnames"] != null ? var.centos7_client_configuration["hostnames"][0] : null
-    ubuntu1604_minion    = var.ubuntu1604_minion_configuration["hostnames"] != null ? var.ubuntu1604_minion_configuration["hostnames"][0] : null
-    ubuntu1604_sshminion = var.ubuntu1604_sshminion_configuration["hostnames"] != null ? var.ubuntu1604_sshminion_configuration["hostnames"][0] : null
-    ubuntu1804_minion    = var.ubuntu1804_minion_configuration["hostnames"] != null ? var.ubuntu1804_minion_configuration["hostnames"][0] : null
-    ubuntu1804_sshminion = var.ubuntu1804_sshminion_configuration["hostnames"] != null ? var.ubuntu1804_sshminion_configuration["hostnames"][0] : null
+    sle11sp4_minion      = length(var.sle11sp4_minion_configuration["hostnames"]) > 0 ? var.sle11sp4_minion_configuration["hostnames"][0] : null
+    sle11sp4_sshminion   = length(var.sle11sp4_sshminion_configuration["hostnames"]) > 0 ? var.sle11sp4_sshminion_configuration["hostnames"][0] : null
+    sle11sp4_client      = length(var.sle11sp4_client_configuration["hostnames"]) > 0 ? var.sle11sp4_client_configuration["hostnames"][0] : null
+    sle12sp4_minion      = length(var.sle12sp4_minion_configuration["hostnames"]) > 0 ? var.sle12sp4_minion_configuration["hostnames"][0] : null
+    sle12sp4_sshminion   = length(var.sle12sp4_sshminion_configuration["hostnames"]) > 0 ? var.sle12sp4_sshminion_configuration["hostnames"][0] : null
+    sle12sp4_client      = length(var.sle12sp4_client_configuration["hostnames"]) > 0 ? var.sle12sp4_client_configuration["hostnames"][0] : null
+    sle15_minion         = length(var.sle15_minion_configuration["hostnames"]) > 0 ? var.sle15_minion_configuration["hostnames"][0] : null
+    sle15_sshminion      = length(var.sle15_sshminion_configuration["hostnames"]) > 0 ? var.sle15_sshminion_configuration["hostnames"][0] : null
+    sle15_client         = length(var.sle15_client_configuration["hostnames"]) > 0 ? var.sle15_client_configuration["hostnames"][0] : null
+    sle15sp1_minion      = length(var.sle15sp1_minion_configuration["hostnames"]) > 0 ? var.sle15sp1_minion_configuration["hostnames"][0] : null
+    sle15sp1_sshminion   = length(var.sle15sp1_sshminion_configuration["hostnames"]) > 0 ? var.sle15sp1_sshminion_configuration["hostnames"][0] : null
+    sle15sp1_client      = length(var.sle15sp1_client_configuration["hostnames"]) > 0 ? var.sle15sp1_client_configuration["hostnames"][0] : null
+    centos6_minion       = length(var.centos6_minion_configuration["hostnames"]) > 0 ? var.centos6_minion_configuration["hostnames"][0] : null
+    centos6_sshminion    = length(var.centos6_sshminion_configuration["hostnames"]) > 0 ? var.centos6_sshminion_configuration["hostnames"][0] : null
+    centos6_client       = length(var.centos6_client_configuration["hostnames"]) > 0 ? var.centos6_client_configuration["hostnames"][0] : null
+    centos7_minion       = length(var.centos7_minion_configuration["hostnames"]) > 0 ? var.centos7_minion_configuration["hostnames"][0] : null
+    centos7_sshminion    = length(var.centos7_sshminion_configuration["hostnames"]) > 0 ? var.centos7_sshminion_configuration["hostnames"][0] : null
+    centos7_client       = length(var.centos7_client_configuration["hostnames"]) > 0 ? var.centos7_client_configuration["hostnames"][0] : null
+    ubuntu1604_minion    = length(var.ubuntu1604_minion_configuration["hostnames"]) > 0 ? var.ubuntu1604_minion_configuration["hostnames"][0] : null
+    ubuntu1604_sshminion = length(var.ubuntu1604_sshminion_configuration["hostnames"]) > 0 ? var.ubuntu1604_sshminion_configuration["hostnames"][0] : null
+    ubuntu1804_minion    = length(var.ubuntu1804_minion_configuration["hostnames"]) > 0 ? var.ubuntu1804_minion_configuration["hostnames"][0] : null
+    ubuntu1804_sshminion = length(var.ubuntu1804_sshminion_configuration["hostnames"]) > 0 ? var.ubuntu1804_sshminion_configuration["hostnames"][0] : null
   }
 
 

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -30,8 +30,8 @@ module "controller" {
     mirror        = var.base_configuration["mirror"]
     server        = var.server_configuration["hostname"]
     proxy         = var.proxy_configuration["hostname"]
-    client        = var.client_configuration["hostnames"][0]
-    minion        = var.minion_configuration["hostnames"][0]
+    client        = length(var.client_configuration["hostnames"]) > 0 ? var.client_configuration["hostnames"][0] : null
+    minion        = length(var.minion_configuration["hostnames"]) > 0 ? var.minion_configuration["hostnames"][0] : null
     centos_minion = var.centos_configuration["hostnames"] != null ? var.centos_configuration["hostnames"][0] : null
     ubuntu_minion = var.ubuntu_configuration["hostnames"] != null ? var.ubuntu_configuration["hostnames"][0] : null
     ssh_minion        = var.sshminion_configuration["hostnames"] != null ? var.sshminion_configuration["hostnames"][0] : null

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -57,21 +57,21 @@ variable "minion_configuration" {
 variable "sshminion_configuration" {
   description = "use module.<SSHMINION_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "centos_configuration" {
   description = "use module.<CENTOS_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "ubuntu_configuration" {
   description = "use module.<UBUNTU_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
@@ -85,161 +85,161 @@ variable "pxeboot_configuration" {
 variable "kvmhost_configuration" {
   description = "use module.<VIRTHOST_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle11sp4_minion_configuration" {
   description = "use module.<SLE11SP4_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle11sp4_sshminion_configuration" {
   description = "use module.<SLE11SP4_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle11sp4_client_configuration" {
   description = "use module.<SLE11SP4_CLIENT>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle12sp4_minion_configuration" {
   description = "use module.<SLE12SP4_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle12sp4_sshminion_configuration" {
   description = "use module.<SLE12SP4_SSHMINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle12sp4_client_configuration" {
   description = "use module.<SLE12SP4_CLIENT>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle15_minion_configuration" {
   description = "use module.<SLE15_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle15_sshminion_configuration" {
   description = "use module.<SLE15_SSHMINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle15_client_configuration" {
   description = "use module.<SLE15_CLIENT>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle15sp1_minion_configuration" {
   description = "use module.<SLE15SP1_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle15sp1_sshminion_configuration" {
   description = "use module.<SLE15SP1_SSHMINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "sle15sp1_client_configuration" {
   description = "use module.<SLE15SP1_CLIENT>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "centos6_minion_configuration" {
   description = "use module.<CENTOS6_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "centos6_sshminion_configuration" {
   description = "use module.<CENTOS6_SSHMINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "centos6_client_configuration" {
   description = "use module.<CENTOS6_CLIENT>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "centos7_minion_configuration" {
   description = "use module.<CENTOS7_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "centos7_sshminion_configuration" {
   description = "use module.<CENTOS7_SSHMINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "centos7_client_configuration" {
   description = "use module.<CENTOS7_CLIENT>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "ubuntu1604_minion_configuration" {
   description = "use module.<UBUNTU1604_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "ubuntu1604_sshminion_configuration" {
   description = "use module.<UBUNTU1604_SSHMINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "ubuntu1804_minion_configuration" {
   description = "use module.<UBUNTU1804_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 
 variable "ubuntu1804_sshminion_configuration" {
   description = "use module.<UBUNTU1804_SSHMINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    hostnames = null
+    hostnames = []
   }
 }
 

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -25,11 +25,7 @@ resource "libvirt_domain" "domain" {
   // base disk + additional disks if any
   dynamic "disk" {
     for_each = concat(
-      [
-        {
-          "volume_id" = element(libvirt_volume.main_disk.*.id, count.index)
-        },
-      ],
+      length(libvirt_volume.main_disk) == var.quantity ? [{"volume_id" : libvirt_volume.main_disk[count.index].id}] : [],
       var.additional_disk,
     )
     content {

--- a/modules/libvirt/locust/main.tf
+++ b/modules/libvirt/locust/main.tf
@@ -47,6 +47,6 @@ module "locust-slave" {
 output "configuration" {
   value = {
     id       = length(module.locust.configuration["ids"]) > 0 ? module.locust.configuration["ids"][0] : null
-    hostname = module.locust.configuration["hostname"]
+    hostname = length(module.locust.configuration["hostnames"]) > 0 ? module.locust.configuration["hostnames"][0] : null
   }
 }

--- a/modules/libvirt/locust/main.tf
+++ b/modules/libvirt/locust/main.tf
@@ -46,8 +46,7 @@ module "locust-slave" {
 
 output "configuration" {
   value = {
-    id       = module.locust.configuration["ids"][0]
+    id       = length(module.locust.configuration["ids"]) > 0 ? module.locust.configuration["ids"][0] : null
     hostname = module.locust.configuration["hostname"]
   }
 }
-

--- a/modules/libvirt/pxe_boot/main.tf
+++ b/modules/libvirt/pxe_boot/main.tf
@@ -26,7 +26,7 @@ resource "libvirt_domain" "domain" {
       var.additional_disk,
     )
     content {
-      volume_id = disk.value["volume_id"]
+      volume_id = disk.value.volume_id
     }
   }
 

--- a/modules/libvirt/pxe_boot/main.tf
+++ b/modules/libvirt/pxe_boot/main.tf
@@ -22,11 +22,7 @@ resource "libvirt_domain" "domain" {
   // base disk + additional disks if any
   dynamic "disk" {
     for_each = concat(
-      [
-        {
-          "volume_id" = element(libvirt_volume.main_disk.*.id, count.index)
-        },
-      ],
+      length(libvirt_volume.main_disk) == var.quantity ? [{"volume_id" : libvirt_volume.main_disk[count.index].id}] : [],
       var.additional_disk,
     )
     content {

--- a/modules/libvirt/pxe_boot/main.tf
+++ b/modules/libvirt/pxe_boot/main.tf
@@ -54,8 +54,8 @@ resource "libvirt_domain" "domain" {
 
 output "configuration" {
   value = {
-    id       = var.quantity > 0 ? libvirt_domain.domain[0].id : null
+    id       = length(libvirt_domain.domain) > 0 ? libvirt_domain.domain[0].id : null
     hostname = "${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-1" : ""}.${var.base_configuration["domain"]}"
-    macaddr  = var.quantity > 0 ? libvirt_domain.domain[0].network_interface[0].mac : null
+    macaddr  = length(libvirt_domain.domain) > 0 ? libvirt_domain.domain[0].network_interface[0].mac : null
   }
 }

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -89,7 +89,7 @@ module "suse_manager" {
   vcpu            = var.vcpu
   running         = var.running
   mac             = var.mac
-  additional_disk = var.repository_disk_size > 0 ? [{ volume_id = libvirt_volume.server_data_disk[0].id }] : []
+  additional_disk = length(libvirt_volume.server_data_disk) > 0 ? [{ volume_id = libvirt_volume.server_data_disk[0].id }] : []
 }
 
 output "configuration" {

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -94,8 +94,8 @@ module "suse_manager" {
 
 output "configuration" {
   value = {
-    id              = module.suse_manager.configuration["ids"][0]
-    hostname        = module.suse_manager.configuration["hostnames"][0]
+    id              = length(module.suse_manager.configuration["ids"]) > 0 ? module.suse_manager.configuration["ids"][0] : null
+    hostname        = length(module.suse_manager.configuration["hostnames"]) > 0 ? module.suse_manager.configuration["hostnames"][0] : null
     product_version = var.product_version
     username        = var.server_username
     password        = var.server_password

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -58,13 +58,13 @@ module "suse_manager_proxy" {
   vcpu            = var.vcpu
   running         = var.running
   mac             = var.mac
-  additional_disk = var.repository_disk_size > 0 ? [{ volume_id = libvirt_volume.server_data_disk[0].id }] : []
+  additional_disk = length(libvirt_volume.server_data_disk) > 0 ? [{ volume_id = libvirt_volume.server_data_disk[0].id }] : []
 }
 
 output "configuration" {
   value = {
-    id              = var.quantity > 0 ? module.suse_manager_proxy.configuration["ids"][0] : null
-    hostname        = var.quantity > 0 ? module.suse_manager_proxy.configuration["hostnames"][0] : null
+    id              = length(module.suse_manager_proxy.configuration["ids"]) > 0 ? module.suse_manager_proxy.configuration["ids"][0] : null
+    hostname        = length(module.suse_manager_proxy.configuration["hostnames"]) > 0 ? module.suse_manager_proxy.configuration["hostnames"][0] : null
     product_version = var.product_version
     username        = var.server_configuration["username"]
     password        = var.server_configuration["password"]


### PR DESCRIPTION
## What does this PR change?

Purpose of this PR is to avoid the following error and similar circumstances:

```
Error: Error in function call
  on modules/libvirt/host/main.tf line 30, in resource "libvirt_domain" "domain":
  30:           "volume_id" = element(libvirt_volume.main_disk.*.id, count.index)
    |----------------
    | count.index is 0
    | libvirt_volume.main_disk is empty tuple
```

Crucial point here is that `libvirt_volume.main_disk.*.id` might be an empty tuple (because of an in-progress destruction, because state is inconsistent or simply because it was so configured), but we might still try to access element 0 (the first).

This PR tries to address the problem comprehensively and is **best reviewed commit-by-commit**.
