### PR TITLE
New PXEBOOT_IMAGE variable

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -235,7 +235,7 @@ module "ctl" {
   centos_configuration    = contains(local.hosts, "min-centos7") ? module.min-centos7.configuration : { hostnames = [], ids = [] }
   ubuntu_configuration    = contains(local.hosts, "min-ubuntu1804") ? module.min-ubuntu1804.configuration : { hostnames = [], ids = [] }
   sshminion_configuration = contains(local.hosts, "minssh-sles12sp4") ? module.minssh-sles12sp4.configuration : { hostnames = [], ids = [] }
-  pxeboot_configuration   = contains(local.hosts, "min-pxeboot") ? module.min-pxeboot.configuration : { macaddr = null }
+  pxeboot_configuration   = contains(local.hosts, "min-pxeboot") ? module.min-pxeboot.configuration : { macaddr = null, image = null }
   kvmhost_configuration   = contains(local.hosts, "min-kvm") ? module.min-kvm.configuration : { hostnames = [], ids = [] }
 
   branch            = var.branch

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -95,22 +95,22 @@ variable "git_repo" {
 }
 
 variable "git_profiles_repo" {
-  description = "URL of git repository with alternate Docker and Kiwi profiles, see README_ADVANCED.md"
+  description = "URL of git repository with alternate Docker and Kiwi profiles, see README_TESTING.md"
   default     = "default"
 }
 
 variable "portus_uri" {
-  description = "URI of portus server, see README_ADVANCED.md"
+  description = "URI of portus server, see README_TESTING.md"
   default     = null
 }
 
 variable "portus_username" {
-  description = "username on portus server, see README_ADVANCED.md"
+  description = "username on portus server, see README_TESTING.md"
   default     = null
 }
 
 variable "portus_password" {
-  description = "password on portus server, see README_ADVANCED.md"
+  description = "password on portus server, see README_TESTING.md"
   default     = null
 }
 

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -39,14 +39,15 @@ module "controller" {
     centos_minion = length(var.centos_configuration["hostnames"]) > 0 ? var.centos_configuration["hostnames"][0] : null
     ubuntu_minion = length(var.ubuntu_configuration["hostnames"]) > 0 ? var.ubuntu_configuration["hostnames"][0] : null
     ssh_minion    = length(var.sshminion_configuration["hostnames"]) > 0 ? var.sshminion_configuration["hostnames"][0] : null
-    kvm_host      = length(var.kvmhost_configuration["hostnames"]) > 0 ? var.kvmhost_configuration["hostnames"][0] : null
     pxeboot_mac   = var.pxeboot_configuration["macaddr"]
+    kvm_host      = length(var.kvmhost_configuration["hostnames"]) > 0 ? var.kvmhost_configuration["hostnames"][0] : null
 
     git_profiles_repo = var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo
     portus_uri        = var.portus_uri
     portus_username   = var.portus_username
     portus_password   = var.portus_password
     server_http_proxy = var.server_http_proxy
+    pxeboot_image     = var.pxeboot_configuration["image"]
 
     sle11sp4_minion      = length(var.sle11sp4_minion_configuration["hostnames"]) > 0 ? var.sle11sp4_minion_configuration["hostnames"][0] : null
     sle11sp4_sshminion   = length(var.sle11sp4_sshminion_configuration["hostnames"]) > 0 ? var.sle11sp4_sshminion_configuration["hostnames"][0] : null

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -79,6 +79,7 @@ variable "pxeboot_configuration" {
   description = "use module.<PXEBOOT_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
     macaddr = null
+    image = null
   }
 }
 

--- a/modules/libvirt/pxe_boot/main.tf
+++ b/modules/libvirt/pxe_boot/main.tf
@@ -53,5 +53,6 @@ output "configuration" {
     id       = length(libvirt_domain.domain) > 0 ? libvirt_domain.domain[0].id : null
     hostname = "${var.base_configuration["name_prefix"]}${var.name}${var.quantity > 1 ? "-1" : ""}.${var.base_configuration["domain"]}"
     macaddr  = length(libvirt_domain.domain) > 0 ? libvirt_domain.domain[0].network_interface[0].mac : null
+    image    = var.image
   }
 }

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -8,7 +8,7 @@ export SERVER="{{ grains.get('server') }}"
 {% if grains.get('ssh_minion') | default(false, true) %}export SSHMINION="{{ grains.get('ssh_minion') }}" {% else %}# no SSH minion defined {% endif %}
 {% if grains.get('centos_minion') | default(false, true) %}export CENTOSMINION="{{ grains.get('centos_minion') }}" {% else %}# no CentOS minion defined {% endif %}
 {% if grains.get('ubuntu_minion') | default(false, true) %}export UBUNTUMINION="{{ grains.get('ubuntu_minion') }}" {% else %}# no Ubuntu minion defined {% endif %}
-{% if grains.get('pxeboot_mac') | default(false, true) %}export PXEBOOTMAC="{{ grains.get('pxeboot_mac') }}" {% else %}# no JeOS minion defined {% endif %}
+{% if grains.get('pxeboot_mac') | default(false, true) %}export PXEBOOT_MAC="{{ grains.get('pxeboot_mac') }}" {% else %}# no JeOS minion defined {% endif %}
 {% if grains.get('kvm_host') | default(false, true) %}export VIRTHOST_KVM_URL="{{ grains.get('kvm_host') }}"
 export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 
@@ -46,6 +46,7 @@ export SCC_CREDENTIALS="{{ grains.get('cc_username') }}|{{ grains.get('cc_passwo
 export PORTUS_URI="{{ grains.get('portus_uri') }}"
 export PORTUS_CREDENTIALS="{{ grains.get('portus_username') }}|{{ grains.get('portus_password') }}"
 {% if grains.get('server_http_proxy') | default(false, true) %}export SERVER_HTTP_PROXY="{{ grains.get('server_http_proxy') }}" {% else %}# no server HTTP proxy defined {% endif %}
+{% if grains.get('pxeboot_image') | default(false, true) %}export PXEBOOT_IMAGE="{{ grains.get('pxeboot_image') }}" {% else %}# no PXE boot image defined {% endif %}
 
 #### Generate certificates for Google Chrome
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then


### PR DESCRIPTION
## What does this PR change?

This PR:
* renames `PXEBOOTMAC` test suite variable to `PXEBOOT_MAC`
   (that's the way to identify the PXE boot minion as it does not have an IP in main network)
* introduces a new variable `PXEBOOT_IMAGE` that contains the operating system
   we want to install on it via PXE
   (was previously hardcoded)
* determines the latter automatically as identical to the starting operating system
   on that minion, so if eg we have SLE 15 SP1 on the PXE boot minion, we will reinstall
   a SLE 15 SP1 system via PXE.
   (doing so ensures a certain level of idempotency of tests)

## Links

Testsuite: uyuni-project/uyuni#1762
