### PR TITLE
WIP: Allow to change image for minions

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -25,13 +25,16 @@ module "base" {
 locals {
   server_full_name = "${var.name_prefix}srv.${var.domain}"
   hosts            = keys(var.host_settings)
-  macs = { for host_key in local.hosts :
-  host_key => lookup(var.host_settings[host_key], "mac", null) if var.host_settings[host_key] != null }
+  macs             = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "mac", null) if var.host_settings[host_key] != null }
   additional_repos = { for host_key in local.hosts :
-  host_key => lookup(var.host_settings[host_key], "additional_repos", {}) if var.host_settings[host_key] != null }
-  images = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "additional_repos", {}) if var.host_settings[host_key] != null }
+  images           = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "image", "default")
-  if var.host_settings[host_key] != null ? contains(keys(var.host_settings[host_key]), "image") : false }
+    if var.host_settings[host_key] != null ? contains(keys(var.host_settings[host_key]), "image") : false }
+  names            = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "name", null)
+    if var.host_settings[host_key] != null ? contains(keys(var.host_settings[host_key]), "name") : false }
 }
 
 module "srv" {
@@ -39,7 +42,7 @@ module "srv" {
   base_configuration             = module.base.configuration
   product_version                = var.product_version
   image                          = lookup(local.images, "srv", "default")
-  name                           = "srv"
+  name                           = lookup(local.names, "srv", "srv")
   auto_accept                    = false
   disable_firewall               = false
   allow_postgres_connections     = false
@@ -73,7 +76,7 @@ module "pxy" {
   base_configuration = module.base.configuration
   product_version    = var.product_version
   image              = lookup(local.images, "pxy", "default")
-  name               = "pxy"
+  name               = lookup(local.names, "pxy", "pxy")
 
   server_configuration      = { hostname = local.server_full_name, username = "admin", password = "admin" }
   auto_register             = false
@@ -102,8 +105,8 @@ module "cli-sles12sp4" {
 
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  name               = "cli-sles12sp4"
-  image              = "sles12sp4"
+  image              = lookup(local.images, "cli-sles12sp4", "sles12sp4")
+  name               = lookup(local.names, "cli-sles12sp4", "cli-sles12sp4")
 
   server_configuration = local.minimal_configuration
 
@@ -123,8 +126,8 @@ module "min-sles12sp4" {
 
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  name               = "min-sles12sp4"
-  image              = "sles12sp4"
+  image              = lookup(local.images, "min-sles12sp4", "sles12sp4")
+  name               = lookup(local.names, "min-sles12sp4", "min-sles12sp4")
 
   server_configuration = local.minimal_configuration
 
@@ -145,8 +148,8 @@ module "minssh-sles12sp4" {
 
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  name               = "minssh-sles12sp4"
-  image              = "sles12sp4"
+  image              = lookup(local.images, "minssh-sles12sp4", "sles12sp4")
+  name               = lookup(local.names, "minssh-sles12sp4", "minssh-sles12sp4")
 
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -164,8 +167,8 @@ module "min-centos7" {
 
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  name               = "min-centos7"
-  image              = "centos7"
+  image              = lookup(local.images, "min-centos7", "centos7")
+  name               = lookup(local.names, "min-centos7", "min-centos7")
 
   server_configuration   = local.minimal_configuration
   auto_connect_to_master = false
@@ -181,10 +184,11 @@ module "min-ubuntu1804" {
 
   quantity = contains(local.hosts, "min-ubuntu1804") ? 1 : 0
 
-  base_configuration     = module.base.configuration
-  product_version        = var.product_version
-  name                   = "min-ubuntu1804"
-  image                  = "ubuntu1804"
+  base_configuration = module.base.configuration
+  product_version    = var.product_version
+  image              = lookup(local.images, "min-ubuntu1804", "ubuntu1804")
+  name               = lookup(local.names, "min-ubuntu1804", "min-ubuntu1804")
+
   server_configuration   = local.minimal_configuration
   auto_connect_to_master = false
   ssh_key_path           = "./salt/controller/id_rsa.pub"
@@ -200,8 +204,8 @@ module "min-pxeboot" {
   quantity = contains(local.hosts, "min-pxeboot") ? 1 : 0
 
   base_configuration = module.base.configuration
-  name               = "min-pxeboot"
   image              = lookup(local.images, "min-pxeboot", "sles12sp3")
+  name               = lookup(local.names, "min-pxeboot", "min-pxeboot")
 }
 
 module "min-kvm" {
@@ -209,10 +213,11 @@ module "min-kvm" {
 
   quantity = contains(local.hosts, "min-kvm") ? 1 : 0
 
-  base_configuration   = module.base.configuration
-  product_version      = var.product_version
-  name                 = "min-kvm"
-  image                = lookup(local.images, "min-kvm", "sles15sp1")
+  base_configuration = module.base.configuration
+  product_version    = var.product_version
+  image              = lookup(local.images, "min-kvm", "sles15sp1")
+  name               = lookup(local.names, "min-kvm", "min-kvm")
+
   ssh_key_path         = "./salt/controller/id_rsa.pub"
   server_configuration = local.minimal_configuration
 


### PR DESCRIPTION
## What does this PR change?

This PR enables to change the images for traditional client, normal minion, and other minions.

Example of use:
```
  host_settings = {
    (...)
    min-sles12sp4 = {
      mac = "AA:B2:93:00:00:42"
      image = "sles15sp1"
    }
```

@rjmateus : the names of the clients are not universal enough. We should rename (in a separate PR) :
```
cli-sles12sp4    -->  client
min-sles12sp4    -->  minion
minssh-sles12sp4 -->  sshminion
min-centos7      -->  centos
min-ubuntu1804   -->  ubuntu
```
or something alike.