### PR TITLE
Fix some fixes when applying "repos" state

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -379,9 +379,9 @@ http:
   # Uyuni Stable
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_15.1/
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
     archs: [x86_64]

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -329,7 +329,7 @@ galaxy_key:
     - name: rpm --import /tmp/galaxy.key
     - watch:
       - file: galaxy_key
-{% if 'uyuni-master' in grains.get('product_version') or 'uyuni-released' in grains.get('product_version') %}
+{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-released' in grains.get('product_version', '') %}
 uyuni_key:
   file.managed:
     - name: /tmp/uyuni.key

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -99,7 +99,7 @@ module_python2_update_repo:
 {% if 'uyuni-released' in grains['product_version'] %}
 server_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
     - priority: 97
 {% endif %}
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes two issues I've found on the `repos` state:

- Fix Uyuni Stable POOL repository url after 202001 release (the URL changed)
- Do not break "repos" state when system is "rhel/centos" and `product_version` is undefined. 

