### PR TITLE
Add config param to pass grains to the minion start event

### DIFF
--- a/salt/minion/init.sls
+++ b/salt/minion/init.sls
@@ -41,6 +41,10 @@ master_configuration:
         server_id_use_crc: adler32
         enable_legacy_startup_events: False
         enable_fqdns_grains: False
+        start_event_grains:
+          - machine_id
+          - saltboot_initrd
+          - susemanager
 {% endif %}
 
 minion_service:


### PR DESCRIPTION
## What does this PR change?
This PR adds `start_event_grains`  config param, in order to pass grains to the minion start event. 
Related PR:https://github.com/uyuni-project/uyuni/pull/1833

