### PR TITLE
Change requirement to match state cmd

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -99,7 +99,7 @@ fix_cucumber_html_reporter_style:
             width: 100%;
         }
     - require:
-      - sls: install_cucumber_html_reporter_via_npm
+      - cmd: install_cucumber_html_reporter_via_npm
 
 spacewalk_git_repository:
   cmd.run:


### PR DESCRIPTION
## What does this PR change?

Changes the state fix_cucumber_html_reporter_style to require the install_cucumber_html_reporter_via_npm still but it's a cmd not sls. It will fix the failing deployment on HEAD. Tested locally on m226 already for head