### PR TITLE
Allow outputs at the cucumber_testsuite module

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -34,6 +34,21 @@ The example will have to be completed with SCC credentials and GitHub credential
 
 `product_version` determines the version under test, see [README_ADVANCED.md](README_ADVANCED.md) for the list of options.
 
+## Getting outputs
+
+By default, the `cucumber_testsuite` module will not produce any outputs for the resources (for example the hostname for the instances).
+
+If you want them, add:
+
+```hcl
+output "configuration" {
+  value = module.cucumber_testsuite.configuration
+}
+```
+At the end of your `main.tf` file.
+
+That will generate the outputs on-screen and will store them at the `terraform.tfstate`.
+
 ## Running the testsuite
 
 To start the testsuite, use:

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -77,3 +77,11 @@ module "controller" {
   image   = "opensuse150"
   provider_settings = var.provider_settings
 }
+
+output "configuration" {
+  value = {
+    id       = length(module.controller.configuration["ids"]) > 0 ? module.controller.configuration["ids"][0] : null
+    hostname = length(module.controller.configuration["hostnames"]) > 0 ? module.controller.configuration["hostnames"][0] : null
+    branch   = var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch
+  }
+}

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -237,3 +237,18 @@ module "ctl" {
   additional_repos  = lookup(local.additional_repos, "ctl", {})
   provider_settings = lookup(local.provider_settings_by_host, "ctl", {})
 }
+
+output "configuration" {
+  value = {
+    srv = module.srv.configuration
+    pxy = module.pxy.configuration
+    cli-sles12sp4 = module.cli-sles12sp4.configuration
+    min-sles12sp4 = module.min-sles12sp4.configuration
+    minssh-sles12sp4 = module.minssh-sles12sp4.configuration
+    min-centos7 = module.min-centos7.configuration
+    min-ubuntu1804 = module.min-ubuntu1804.configuration
+    min-pxeboot = module.min-pxeboot.configuration
+    min-kvm = module.min-kvm.configuration
+    ctl = module.ctl.configuration
+  }
+}


### PR DESCRIPTION
## What does this PR change?

Allow outputs at the cucumber_testsuite module.

So we can get the hostnames from the `terraform.tfstate` as it was the case in the past.

Ugly thing: unlike with the old sumaform and terraform 0.11, this prints the outputs on-screen. Not sure if it can be avoided.
