### PR TITLE
Use custom version of Avahi

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -310,7 +310,7 @@ module "server" {
 }
 ```
 
-If Avahi is enabled and you are running Docker on a minion, you will need an Avahi reflector on the minion to provide Avahi resolution inside of the containers. A typical example is the Cucumber testsuite which uses such a setup. An Avahi reflector can be enabled via:
+If Avahi is enabled and you are running Docker on a minion, you will need an Avahi reflector on the minion to provide multicast domain name resolution inside of the containers. A typical example is the Cucumber testsuite which uses such a setup. An Avahi reflector can be enabled via:
 
 ```hcl
 module "minion" {
@@ -319,8 +319,6 @@ module "minion" {
   ...
 }
 ```
-
-Beware this may trigger [a known Avahi bug](https://github.com/lathiat/avahi/issues/117). This bug causes wrong names to be assigned to hosts (with unexpected `-2`, `-3`, etc. suffixes) in many circumstances, in particular when more than one reflector is in use on the same network.
 
 
 ## Additional network and SUSE Manager for Retail

--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -2,13 +2,39 @@ include:
   - default.hostname
 
 {% if grains['use_avahi'] %}
-avahi_pkg:
-  pkg.installed:
-    {%- if grains['os_family'] == 'Debian' %}
-    - name: avahi-daemon
+
+# TODO: remove the following state when fix to bsc#1163683 is applied to all the SLES versions we use
+{% if grains['osfullname'] == 'SLES' %}
+custom_avahi_repo:
+  pkgrepo.managed:
+    - humanname: custom_avahi
+    {% if grains.get('osmajorrelease', None)|int() == 12 %}
+    - baseurl: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools:/avahi:/0.6.32/SLE_12_SP4/
     {% else %}
-    - name: avahi
+    - baseurl: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools:/avahi:/0.7/SLE_15_SP1/
     {% endif %}
+    - priority: 95
+    - gpgcheck: 0
+{% endif %}
+
+# TODO: replace 'pkg.latest' with 'pkg.installed' when fix to bsc#1163683 is applied to all the SLES versions we use
+avahi_pkg:
+  pkg.latest:
+    - pkgs:
+      {% if grains['os_family'] == 'Debian' %}
+      - avahi-daemon
+      - libavahi-common-data
+      - libavahi-common3
+      - libavahi-core7
+      {% elif grains['os_family'] == 'RedHat' %}
+      - avahi
+      - avahi-libs
+      {% elif grains['os_family'] == 'Suse' %}
+      - avahi
+      - avahi-lang
+      - libavahi-common3
+      - libavahi-core7
+      {% endif %}
 
 avahi_change_domain:
   file.replace:

--- a/salt/minion/reflector.sls
+++ b/salt/minion/reflector.sls
@@ -1,27 +1,5 @@
 {% if grains.get('use_avahi') and grains.get('avahi_reflector') %}
 
-# We upgrade to latest version because of a bug in Avahi:
-#   https://github.com/lathiat/avahi/issues/117
-# It does not remove the problem, but makes it less likely to happen
-reflector_package:
-  pkg.latest:
-    - pkgs:
-      {% if grains['os'] == 'SUSE' %}
-      - avahi
-      - avahi-lang
-      - libavahi-common3
-      - libavahi-core7
-      {% elif grains['os'] == 'Ubuntu' %}
-      - avahi-daemon
-      - libavahi-common-data
-      - libavahi-common3
-      - libavahi-core7
-      {% elif grains['os_family'] == 'RedHat' %}
-      - avahi
-      - avahi-libs
-      {% endif %}
-    - refresh: true
-
 reflector_configuration:
   file.replace:
     - name: /etc/avahi/avahi-daemon.conf


### PR DESCRIPTION
 ## What does this PR change?

This PR makes sure we use our own custom version of Avahi, whenever it is enabled (even if we use no reflector).

This custom version solves the "spurious names conflict" bug (https://bugzilla.suse.com/show_bug.cgi?id=1163683). It is meant to slowly disappear as Avahi 0.8 is out with the fix, as the fix is backported to Avahi 0.7 in SLE 15, and as SLE 12 gets deprecated.

## Yet to be determined

This is using repositories that are currently under `home:ebischoff` in OBS. @moio, maybe you  rather want it under some Sumaform project? That could also spare us an extra repo.
