### PR TITLE
Show the right location of the list of the supported images

### DIFF
--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -147,4 +147,4 @@ module "base" {
 }
 ```
 
-The list of all supported images is available in "modules/libvirt/base/variables.tf".
+The list of all supported images is available in "backend_modules/libvirt/base/variables.tf".


### PR DESCRIPTION
## What does this PR change?

- backend_modules/libvirt/README.md: Update it with the right location for the list
of supported images.