### PR TITLE
Improve mirroring wrapper that handles errors in all cases

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -133,6 +133,13 @@ module "mirror" {
 
 Note that `mirror` must be populated before any host can be deployed - by default its cache is refreshed nightly via `cron`, you can also schedule a one-time refresh via the `/root/mirror.sh` script.
 
+It is also possible to use parameters with `/root/mirror.sh` to limit what is going to be done.
+
+Check the help with:
+```bash
+/root/mirror.sh -h
+```
+
 ## Virtual hosts
 
 Virtualization hosts are Salt minions that are also capable to run virtual machines using the KVM hypervisor.

--- a/salt/mirror/mirror.sh.conf
+++ b/salt/mirror/mirror.sh.conf
@@ -1,0 +1,13 @@
+SCC_CREDS="{{ grains.get('cc_username') }}:{{ grains.get('cc_password') }}"
+IMAGES="https://github.com/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2
+https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse150.x86_64.qcow2
+https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse151.x86_64.qcow2
+http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15.x86_64.qcow2
+http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp1.x86_64.qcow2
+http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles11sp4.x86_64.qcow2
+http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12.x86_64.qcow2
+http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64.qcow2
+http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp2.x86_64.qcow2
+http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp3.x86_64.qcow2
+http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp4.x86_64.qcow2
+https://github.com/moio/sumaform-images/releases/download/4.4.0/ubuntu1804.qcow2"


### PR DESCRIPTION
## What does this PR change?

So now cron will send email to the administrator **only if** there are errors.

It also allows a more flexible usage of mirror.sh, for example to spread execution of each step... or to define a reduced set of repositories with a new yaml file, and run a second cron job with that an extra time each day.

This comes from the SUSE Manager internal repository, as we precisely needed that.

I am also porting a fix from @mcalmer for handling of the nvidia repo. Sorry for not using a separate PR, but I was not aware our script was taking from sumaform :-)
