### PR TITLE
Add new sanity check stage into the run-testsuite command

### DIFF
--- a/salt/controller/run-testsuite
+++ b/salt/controller/run-testsuite
@@ -27,6 +27,7 @@ parallel_stage() {
 
 # normal run
 if [ -z "$1" ]; then
+  stage sanity_check
   stage core
   stage reposync
   stage init_clients
@@ -37,6 +38,7 @@ fi
 
 # parallel run
 if [ "$1" = "parallel" ]; then
+  parallel_stage sanity_check
   stage core
   stage reposync
   parallel_stage init_clients
@@ -47,6 +49,7 @@ fi
 
 # essential features
 if [ "$1" = "essential" ]; then
+  stage sanity_check
   stage core
   stage reposync
   stage init_clients


### PR DESCRIPTION
## What does this PR change?

To support the change made in our YAML files, we need to add the new sanity check stage into the run-testsuite command.
I added it to the sequential and parallel test suite executions, leaving the "essentials" run without it.
