### PR TITLE
Let the resolver work correctly with multicast DNS

### DIFF
--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -17,6 +17,15 @@ custom_avahi_repo:
     - gpgcheck: 0
 {% endif %}
 
+# TODO: remove the following state when fix to bsc#1168306 is applied to SLES 15 SP2
+{% if grains['osfullname'] == 'SLES' and grains['osrelease'] == '15.2' %}
+apparmor_allow_avahi_custom_domains:
+  file.line:
+    - name: /etc/apparmor.d/abstractions/nameservice
+    - after: /etc/nsswitch.conf
+    - content: "  /etc/mdns.allow         r,"
+{% endif %}
+
 {% if grains['os_family'] == 'RedHat' and grains.get('osmajorrelease', None)|int() == 6 %}
 dbus_enable_service:
   service.running:


### PR DESCRIPTION
## What does this PR change?

This PR works around this bug: https://bugzilla.suse.com/show_bug.cgi?id=1168306

It sets apparmor so that the resolver can read /etc/mdns.allow.

