### PR TITLE
virthost: use host-passthrough rather than host-model

### DIFF
--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -101,7 +101,7 @@ Some roles such as `suse_manager` or `mirror` have specific defaults that overri
 | mirror       | `{memory=512}`                                                                               |
 | controller   | `{memory=2048}`                                                                              |
 | grafana      | `{memory=4096}`                                                                              |
-| virthost     | `{memory=2048, vcpu=3, cpu_model = "host-model", xslt = file("${path.module}/sysinfos.xsl"}` |
+| virthost     | `{memory=2048, vcpu=3, cpu_model = "host-passthrough", xslt = file("${path.module}/sysinfos.xsl"}` |
 
 ## Accessing VMs
 

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -19,7 +19,7 @@ locals {
     contains(var.roles, "grafana") ? { memory = 4096 } : {},
     contains(var.roles, "virthost") ? { memory = 2048, vcpu = 3 } : {},
     var.provider_settings,
-    contains(var.roles, "virthost") ? { cpu_model = "host-model", xslt = file("${path.module}/sysinfos.xsl") } : {},
+    contains(var.roles, "virthost") ? { cpu_model = "host-passthrough", xslt = file("${path.module}/sysinfos.xsl") } : {},
     contains(var.roles, "pxe_boot") ? { xslt = file("${path.module}/pxe.xsl") } : {})
     cloud_init = length(regexall("o$", var.image)) > 0
 }


### PR DESCRIPTION
## What does this PR change?

For some reason the host-model CPU mode may not show the VMX flag on the
virtual CPU while the host-passthrough blindly passes every flag from
the physical CPU.
