### PR TITLE
add support for additional network

### DIFF
--- a/backend_modules/aws/README.md
+++ b/backend_modules/aws/README.md
@@ -4,8 +4,9 @@
 
 Base Module will create:
  - a VPC
- - two subnets
-   - one private, that can only access other hosts in the VPC
+ - three subnets
+   - one private, that can only access other hosts in the VPC and outbound connection to internet
+   - one additional network, private too, that only allows communications between hosts inside the subnet and no outbound connections allowed
    - one public, that can also access the Internet and accepts connections from an IP whitelist
  - security groups, routing tables, Internet gateways, NAT gateway as appropriate
  - one `bastion` host is also created in the public network
@@ -35,15 +36,15 @@ Most modules have configuration settings specific to the AWS backend, those are 
 ### Base Module
 Available provider settings for the base module:
 
-| Variable name      | Type   | Default value | Description                                                              |
-|--------------------|--------|---------------|--------------------------------------------------------------------------|
-| region             | string | `null`        | AWS region where infrastructure will be created                          |
-| availability_zone  | string | `null`        | AWS availability zone inside region                                      |
-| ssh_allowed_ips    | array  | `[]`          | Array of IP's to white list for ssh connection                           |
-| key_name           | string | `null`        | ssh key name in AWS                                                      |
-| key_file           | string | `null`        | ssh key file                                                             |
-| bastion_host       | string | `null`        | bastian host use to connect machines in private network                  |
-| additional_network | string | `null`        | A network mask for PXE tests                                             |
+| Variable name      | Type   | Default value   | Description                                                                                                    |
+|--------------------|--------|-----------------|----------------------------------------------------------------------------------------------------------------|
+| region             | string | `null`          | AWS region where infrastructure will be created                                                                |
+| availability_zone  | string | `null`          | AWS availability zone inside region                                                                            |
+| ssh_allowed_ips    | array  | `[]`            | Array of IP's to white list for ssh connection                                                                 |
+| key_name           | string | `null`          | ssh key name in AWS                                                                                            |
+| key_file           | string | `null`          | ssh key file                                                                                                   |
+| bastion_host       | string | `null`          | bastian host use to connect machines in private network                                                        |
+| additional_network | string | `172.16.2.0/24` | A network mask for the additional network (needs to follow the pattern 172.16.X.Y/24, where X cannot be 0 or 1) |
 
 An example follows:
 ```hcl-terraform

--- a/backend_modules/aws/README_ADVANCED.md
+++ b/backend_modules/aws/README_ADVANCED.md
@@ -110,14 +110,16 @@ To remove the older snapshot and create a new one, taint its resource via `terra
 One can deploy to existing pre-created infrastructure (VPC, networks, bastion) which should follow the pattern defined for the network. See README.md for more information.
 To use it, a set of properties should be set on sumaform base module.
 
-| Variable name             | Type    | Default value | Description                                                      |
-|---------------------------|---------|---------------|------------------------------------------------------------------|
-| create_network            | boolean | `true`        | flag indicate if a new infrastructure should be created          |
-| public_subnet_id          | string  | `null`        | aws public subnet id                                             |
-| private_subnet_id         | string  | `null`        | aws private subnet id                                            |
-| public_security_group_id  | string  | `null`        | aws public security group id                                     |
-| private_security_group_id | string  | `null`        | aws private security group id                                    |
-| bastion_host              | string  | `null`        | bastion machine hostname (to access machines in private network) |
+| Variable name                        | Type    | Default value | Description                                                      |
+|--------------------------------------|---------|---------------|------------------------------------------------------------------|
+| create_network                       | boolean | `true`        | flag indicate if a new infrastructure should be created          |
+| public_subnet_id                     | string  | `null`        | aws public subnet id                                             |
+| private_subnet_id                    | string  | `null`        | aws private subnet id                                            |
+| private_additional_subnet_id         | string  | `null`        | aws private additional subnet id                                 |
+| public_security_group_id             | string  | `null`        | aws public security group id                                     |
+| private_security_group_id            | string  | `null`        | aws private security group id                                    |
+| private_additional_security_group_id | string  | `null`        | aws private additional security group id                         |
+| bastion_host                         | string  | `null`        | bastion machine hostname (to access machines in private network) |
 
 Example:
 ```hcl
@@ -125,12 +127,14 @@ module "base" {
   source = "./modules/base"
   ...
   provider_settings = {
-    create_network            = false
-    public_subnet_id          = ...
-    private_subnet_id         = ...
-    public_security_group_id  = ...
-    private_security_group_id = ...
-    bastion_host              = ...
+    create_network                       = false
+    public_subnet_id                     = ...
+    private_subnet_id                    = ...
+    private_additional_subnet_id         = ...
+    public_security_group_id             = ...
+    private_security_group_id            = ...
+    private_additional_security_group_id = ...
+    bastion_host                         = ...
   }
 }
 ```

--- a/backend_modules/aws/network/variables.tf
+++ b/backend_modules/aws/network/variables.tf
@@ -18,6 +18,11 @@ variable "name_prefix" {
   default     = "sumaform"
 }
 
+variable "additional_network" {
+  description = "Additional network cidr_block (of the form 172.16.x.x/24)"
+  default = "172.16.2.0/24"
+}
+
 variable "create_network" {
   description = "defined if a new network should be created"
   default     = true


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

https://github.com/SUSE/spacewalk/issues/11396

Add support for the additional network on aws backend.

An additional network is always created. By default, it has the ip mask 172.16.2.0/24.
This network only allows connections between host on the network, this means not in-bound or out-bound communication
The goal of this network configuration is to simulate client scenarios where minions are placed in a totally independent network, only reachable through a susemanager proxy.

Bastion host is connected with two networks: public (which also allow connections to private network) and the additional private network.

The approach followed on libvirt, which only creates the additional network if the field named `additional_network` where defined on the base module **cannot be applied on AWS backend**.

On libvirt, the decision about associate a host with the additional network is made base on the flag `connect_to_additional_network` and field from base module output.
AWS provider don't allow use that value to calculate the count in another resource (in this case secondary network interface). It would force us to first create the base module only, and then start creating the remaining modules.
This is not very user frendly. 

