### PR TITLE
use official ubuntu image by default in cucumber test

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -187,7 +187,7 @@ module "min-ubuntu1804" {
 
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "min-ubuntu1804", "ubuntu1804")
+  image              = lookup(local.images, "min-ubuntu1804", "ubuntu1804o")
   name               = lookup(local.names, "min-ubuntu1804", "min-ubuntu1804")
 
   server_configuration   = local.minimal_configuration

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -31,7 +31,7 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos7", "opensuse150", "opensuse151", "sles15", "sles15sp1", "sles15sp2", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
+  default     = ["centos7", "opensuse150", "opensuse151", "sles15", "sles15sp1", "sles15sp2", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804o"]
 }
 
 variable "mirror" {


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Change ubuntu default image used in cucumber test suite to be the official one.

The image packed by sumaform are generating some python/salt error when used with the new salt 3000 version. The errors are related with python 2/3 packing and salt team are aware of it.
