### PR TITLE
Add buildhost VM

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -105,6 +105,9 @@ host_settings = {
   min-sles12sp4 = {
     present = true
   }
+  min-build = {
+    present = true
+  }
   minssh-sles12sp4 = {
     present = true
   }

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -36,6 +36,7 @@ module "controller" {
     proxy         = var.proxy_configuration["hostname"]
     client        = length(var.client_configuration["hostnames"]) > 0 ? var.client_configuration["hostnames"][0] : null
     minion        = length(var.minion_configuration["hostnames"]) > 0 ? var.minion_configuration["hostnames"][0] : null
+    build_host    = length(var.buildhost_configuration["hostnames"]) > 0 ? var.buildhost_configuration["hostnames"][0] : null
     centos_minion = length(var.centos_configuration["hostnames"]) > 0 ? var.centos_configuration["hostnames"][0] : null
     ubuntu_minion = length(var.ubuntu_configuration["hostnames"]) > 0 ? var.ubuntu_configuration["hostnames"][0] : null
     ssh_minion    = length(var.sshminion_configuration["hostnames"]) > 0 ? var.sshminion_configuration["hostnames"][0] : null

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -54,6 +54,13 @@ variable "minion_configuration" {
   }
 }
 
+variable "buildhost_configuration" {
+  description = "use module.<BUILDHOST_NAME>.configuration, see main.tf.libvirt-testsuite.example"
+  default = {
+    hostnames = []
+  }
+}
+
 variable "sshminion_configuration" {
   description = "use module.<SSHMINION_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -119,10 +119,29 @@ module "min-sles12sp4" {
   auto_connect_to_master  = false
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
-  avahi_reflector         = var.avahi_reflector
 
   additional_repos  = lookup(local.additional_repos, "min-sles12sp4", {})
   provider_settings = lookup(local.provider_settings_by_host, "min-sles12sp4", {})
+}
+
+module "min-build" {
+  source = "../minion"
+
+  quantity           = contains(local.hosts, "min-build") ? 1 : 0
+  base_configuration = module.base.configuration
+  product_version    = var.product_version
+  image              = lookup(local.images, "min-build", "sles12sp4")
+  name               = lookup(local.names, "min-build", "min-build")
+
+  server_configuration = local.minimal_configuration
+
+  auto_connect_to_master  = false
+  use_os_released_updates = true
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  avahi_reflector         = var.avahi_reflector
+
+  additional_repos  = lookup(local.additional_repos, "min-build", {})
+  provider_settings = lookup(local.provider_settings_by_host, "min-build", {})
 }
 
 module "minssh-sles12sp4" {
@@ -219,6 +238,7 @@ module "ctl" {
   proxy_configuration     = contains(local.hosts, "pxy") ? module.pxy.configuration : { hostname = null }
   client_configuration    = contains(local.hosts, "cli-sles12sp4") ? module.cli-sles12sp4.configuration : { hostnames = [], ids = [] }
   minion_configuration    = contains(local.hosts, "min-sles12sp4") ? module.min-sles12sp4.configuration : { hostnames = [], ids = [] }
+  buildhost_configuration = contains(local.hosts, "min-build") ? module.min-build.configuration : { hostnames = [], ids = [] }
   centos_configuration    = contains(local.hosts, "min-centos7") ? module.min-centos7.configuration : { hostnames = [], ids = [] }
   ubuntu_configuration    = contains(local.hosts, "min-ubuntu1804") ? module.min-ubuntu1804.configuration : { hostnames = [], ids = [] }
   sshminion_configuration = contains(local.hosts, "minssh-sles12sp4") ? module.minssh-sles12sp4.configuration : { hostnames = [], ids = [] }
@@ -245,6 +265,7 @@ output "configuration" {
     pxy = module.pxy.configuration
     cli-sles12sp4 = module.cli-sles12sp4.configuration
     min-sles12sp4 = module.min-sles12sp4.configuration
+    min-build = module.min-build.configuration
     minssh-sles12sp4 = module.minssh-sles12sp4.configuration
     min-centos7 = module.min-centos7.configuration
     min-ubuntu1804 = module.min-ubuntu1804.configuration

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -5,6 +5,7 @@ export SERVER="{{ grains.get('server') }}"
 {% if grains.get('proxy') | default(false, true) %}export PROXY="{{ grains.get('proxy') }}" {% else %}# no proxy defined {% endif %}
 {% if grains.get('client') | default(false, true) %}export CLIENT="{{ grains.get('client') }}"{% else %}# no client defined {% endif %}
 {% if grains.get('minion') | default(false, true) %}export MINION="{{ grains.get('minion') }}"{% else %}# no minion defined {% endif %}
+{% if grains.get('build_host') | default(false, true) %}export BUILD_HOST="{{ grains.get('build_host') }}"{% else %}# no build host defined {% endif %}
 {% if grains.get('ssh_minion') | default(false, true) %}export SSHMINION="{{ grains.get('ssh_minion') }}" {% else %}# no SSH minion defined {% endif %}
 {% if grains.get('centos_minion') | default(false, true) %}export CENTOSMINION="{{ grains.get('centos_minion') }}" {% else %}# no CentOS minion defined {% endif %}
 {% if grains.get('ubuntu_minion') | default(false, true) %}export UBUNTUMINION="{{ grains.get('ubuntu_minion') }}" {% else %}# no Ubuntu minion defined {% endif %}


### PR DESCRIPTION
## What does this PR change?
Add a new VM 'buildhost'

The idea is to have one VM for the 'salt minion' and another VM
for the 'Docker and Kiwi build host' in the Cucumber test suite.

This change adds flexibility to the test suite; by decoupling the 'salt minion'
from the build host we a are able to test more minion versions (not just
those with a build host functionality available).

Another advantage is a reduction in the number of clean up scenarios
(the slow readd entitlements).
See https://github.com/SUSE/spacewalk/issues/10680

- modules/controller/variables.tf
  Add buildhost configuration.

- modules/cucumber_testsuite/main.tf
  Add min-build module section.
  Remove avahi_reflector from the normal minion; keep it only for the min-build.

- salt/controller/bashrc:
  Export environment variable with the build host hostname.

- modules/controller/main.tf
  Read build host configuration.

- README_TESTING.md (Advanced deployments):
  Include the new VM in the example.
