### PR TITLE
Add retrying mechanism after "default.minimal" state is applied

### DIFF
--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -18,7 +18,6 @@ done
 if [ $NEXT_TRY -eq 10 ]
 then
         echo "ERROR: salt-call is not available after 10 retries";
-        exit 1;
 fi
 
 salt-call --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color state.highstate || exit 1

--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -6,6 +6,21 @@
 FILE_ROOT="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 salt-call --local --file-root=$FILE_ROOT/ --log-level=quiet --output=quiet state.sls default.minimal ||:
+
+NEXT_TRY=0
+until [ $NEXT_TRY -eq 10 ] || salt-call --version
+do
+        echo "It seems salt-call is not available after default.minimal state was applied. Retrying... [$NEXT_TRY]";
+        sleep 1;
+        ((NEXT_TRY++));
+done
+
+if [ $NEXT_TRY -eq 10 ]
+then
+        echo "ERROR: salt-call is not available after 10 retries";
+        exit 1;
+fi
+
 salt-call --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color state.highstate || exit 1
 
 chmod +x ${FILE_ROOT}/highstate.sh

--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -8,7 +8,7 @@ FILE_ROOT="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 salt-call --local --file-root=$FILE_ROOT/ --log-level=quiet --output=quiet state.sls default.minimal ||:
 
 NEXT_TRY=0
-until [ $NEXT_TRY -eq 10 ] || salt-call --version
+until [ $NEXT_TRY -eq 10 ] || salt-call --local test.ping
 do
         echo "It seems salt-call is not available after default.minimal state was applied. Retrying... [$NEXT_TRY]";
         sleep 1;


### PR DESCRIPTION
## What does this PR change?

This PR introduces a retrying mechanism in case `salt-call` is temporary crashing after the initial `default.minimal` state is applied on any host: i.a. during the salt upgrade.

On any sumaform deployment, the first `salt-call` executed on a deployed system is made in order to apply the `default.minimal` state, which does some minimal host configuration and upgrade Salt to the latest version available. 

Since we know that "upgrading Salt with Salt" sometimes causes problems, we already ignore possible errors from the initial `salt-call` and allows the script to continue running, but this is not enough.

In some particular cases, we see the initial `salt-call` crashing because Salt being updated but we simply triggers the second `salt-call` without checking that `salt-call` is not crashing anymore due to the actual Salt upgrade is not yet finished.

This PR simply adds a retrying mechanism (10 tries) to wait 1 sec and check if `salt-call --local test.ping` is successfully executed before running the second `salt-call` to continue the deployment.

This would avoid situations where the two `salt-call` crash because Salt upgrade is not yet finished.