### PR TITLE
AWS: add image support for RHEL 7/8

### DIFF
--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -288,6 +288,48 @@ data "aws_ami" "ubuntu1604" {
   }
 }
 
+data "aws_ami" "rhel8" {
+  most_recent = true
+  name_regex  = "^RHEL-8.2.0_HVM-"
+  owners      = ["309956199498"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+data "aws_ami" "rhel7" {
+  most_recent = true
+  name_regex  = "^RHEL-7.7_HVM-"
+  owners      = ["309956199498"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
 module "network" {
   source = "../network"
 
@@ -333,6 +375,8 @@ locals {
       centos6     = { ami = data.aws_ami.centos6.image_id, ssh_user = "centos" },
       ubuntu1804  = { ami = data.aws_ami.ubuntu1804.image_id, ssh_user = "ubuntu" },
       ubuntu1604  = { ami = data.aws_ami.ubuntu1604.image_id, ssh_user = "ubuntu" },
+      rhel8       = { ami = data.aws_ami.rhel8.image_id},
+      rhel7       = { ami = data.aws_ami.rhel7.image_id},
     }
     },
     local.create_network ? module.network.configuration : {

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -76,7 +76,20 @@ runcmd:
   - zypper removerepo --all
   - rm /etc/modprobe.d/50-ipv6.conf
 %{ endif }
-%{ if image == "centos7" }
+%{ if image == "rhel8"}
+yum_repos:
+  # repo for salt
+  temp_tools_pool_repo:
+    baseurl: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    name: temp_tools_pool_repo
+    priority: 98
+
+packages: ["salt-minion"]
+%{ endif }
+%{ if image == "centos7" || image == "rhel7"}
 yum_repos:
   # repo for salt
   temp_tools_pool_repo:


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Add support for rhel 8 and rhel 7 images on aws.
At the moment this PR is using community images provided by red Hat.

https://github.com/SUSE/spacewalk/issues/11453