### PR TITLE
Ubuntu 1804 unable to get apt lock when updating salt

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -461,6 +461,14 @@ disable_apt_daily_upgrade_service:
     - name: apt-daily-upgrade.service
     - enable: False
 
+wait_until_apt_lock_file_unlock:
+  cmd.run:
+    - name: "test ! -f /var/lib/apt/lists/lock || ! lsof /var/lib/apt/lists/lock"
+    - retry:
+      - attempts: 10
+      - interval: 5
+      - until: True
+
 tools_update_repo:
   pkgrepo.managed:
     - file: /etc/apt/sources.list.d/Ubuntu{{ short_release }}-Client-Tools.list


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?
https://github.com/SUSE/spacewalk/issues/11454

After stop all apt services make sure lock is released before continue to apt update steps.

The code checks if the file don't exist or if exist it is not locked by another process.