### PR TITLE
Ubuntu2004 image support on libvirt and aws

### DIFF
--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -250,6 +250,27 @@ data "aws_ami" "centos6" {
   }
 }
 
+data "aws_ami" "ubuntu2004" {
+  most_recent = true
+  name_regex  = "^ubuntu/images/hvm-ssd/ubuntu-focal-20.04"
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
 data "aws_ami" "ubuntu1804" {
   most_recent = true
   name_regex  = "^ubuntu/images/hvm-ssd/ubuntu-bionic-18.04"
@@ -336,6 +357,7 @@ locals {
       sles11sp4   = { ami = data.aws_ami.sles11sp4.image_id },
       centos7     = { ami = data.aws_ami.centos7.image_id, ssh_user = "centos" },
       centos6     = { ami = data.aws_ami.centos6.image_id, ssh_user = "centos" },
+      ubuntu2004  = { ami = data.aws_ami.ubuntu2004.image_id, ssh_user = "ubuntu" },
       ubuntu1804  = { ami = data.aws_ami.ubuntu1804.image_id, ssh_user = "ubuntu" },
       ubuntu1604  = { ami = data.aws_ami.ubuntu1604.image_id, ssh_user = "ubuntu" },
     }

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -110,6 +110,42 @@ runcmd:
   # HACK: needed because onboard traditional clients
   - "/usr/bin/update-ca-trust force-enable"
 %{ endif }
+%{ if image == "ubuntu2004" }
+
+apt:
+  sources:
+    tools_pool_repo:
+      source: "deb https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/ /"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v2.0.15 (GNU/Linux)
+
+        mQENBFsnulUBCADNjL4hvhVtSzqVDlMtFFFP28Acq+UNF8WKKMhbBirfOpXwwI1C
+        NR3i0CXPOce5eKShuuWAjD2E36e2XAp3rUAo/aCA7UgtJkMNKzzlTOcqHHxKTx6H
+        gvp0Fb6xTKywZ7VttGhwUynl+CsDuOst3ROXTNdb8XMfm4joH2FW5D3ACN2qNiv0
+        MVcFNKxQ98w8M9xJxdI8DuyngnSeZwAosNzEio3JhTPiTv9ngY2Z3AuYUcwTEt7o
+        feEN+ivAgYnn+a6DBKFBeCW7VUD3V+tH8/fKnkvI4gf2o3N7Ok+/uE+DPUBb+14f
+        +9dhBjd+7+pR3ayEZFjQns5XFShoYu2+CQspABEBAAG0UHN5c3RlbXNtYW5hZ2Vt
+        ZW50OlV5dW5pIE9CUyBQcm9qZWN0IDxzeXN0ZW1zbWFuYWdlbWVudDpVeXVuaUBi
+        dWlsZC5vcGVuc3VzZS5vcmc+iQE+BBMBCAAoBQJbJ7pVAhsDBQkEHrAABgsJCAcD
+        AgYVCAIJCgsEFgIDAQIeAQIXgAAKCRCXLl1sDSCDPoS+B/4inB/cDPfk5ad3IzdY
+        SsFB+maVHaMhVdxFToM68pj7yLAEzYdVXjZYuUCmRiGuXhFdojFdTsDeYbPYflxi
+        xfGvQ/18zPSI/UA+UMyRxaT9e6D2IUqmWAwc+/WwQbzoyItgKVc4UB6N+vWq4JFq
+        pNCVpKvwi9d38HAROl6suzxm3m6GeDe0UCPXW/Rju/7uHrHE0tnUacQru8k2rJhM
+        FIoZxUrdAPjhDx+hDX/J/jFTIX6k05Nbn7n43G0UTV4kFNaqYKmy+8S5gTgpePfO
+        pHB9YLqe0zxGRERXgjT82iM799OfmD3kc+/s4l45i/jk6MOjkX217grKIujwXf0v
+        tG6giEYEExECAAYFAlsnulUACgkQOzARt2udZSO/4QCcDf+j/XRbJn2PudsSoyjw
+        3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
+        =lTyy
+        -----END PGP PUBLIC KEY BLOCK-----
+
+runcmd:
+  # HACK: cloud-init in Ubuntu does not take care of the following
+  - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+  - systemctl restart sshd
+
+packages: ["salt-minion"]
+%{ endif }
 %{ if image == "ubuntu1804" }
 
 runcmd:

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -27,6 +27,7 @@ locals {
     ubuntu1604o  = "https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img"
     ubuntu1804   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.4.0/ubuntu1804.qcow2"
     ubuntu1804o  = "https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img"
+    ubuntu2004o  = "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
   }
   pool               = lookup(var.provider_settings, "pool", "default")
   network_name       = lookup(var.provider_settings, "network_name", "default")

--- a/backend_modules/libvirt/host/network_config.yaml
+++ b/backend_modules/libvirt/host/network_config.yaml
@@ -2,7 +2,7 @@ network:
   version: 1
   config:
   - type: physical
-%{ if image == "ubuntu1804o" || image == "ubuntu1604o" }
+%{ if image == "ubuntu2004o" || image == "ubuntu1804o" || image == "ubuntu1604o" }
     name: ens3
 %{ else }
     name: eth0

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -192,7 +192,24 @@ runcmd:
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ endif }
 
-%{ if image == "ubuntu1804o" }
+%{ if image == "ubuntu1804o"}
+
+runcmd:
+  # HACK: cloud-init in Ubuntu does not take care of the following
+  - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+  - systemctl restart sshd
+
+packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
+%{ endif }
+
+%{ if image == "ubuntu2004o"}
+
+apt:
+  sources:
+    tools_pool_repo:
+      # TODO after release, update this repository to use UYUNI instead
+      #source: "deb http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04 /"
+      source: "deb [trusted=yes] http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu20.04-SUSE-Manager-Tools/xUbuntu_20.04 /"
 
 runcmd:
   # HACK: cloud-init in Ubuntu does not take care of the following

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -192,7 +192,7 @@ runcmd:
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ endif }
 
-%{ if image == "ubuntu1804o"}
+%{ if image == "ubuntu1804o" }
 
 runcmd:
   # HACK: cloud-init in Ubuntu does not take care of the following
@@ -202,14 +202,34 @@ runcmd:
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ endif }
 
-%{ if image == "ubuntu2004o"}
+%{ if image == "ubuntu2004o" }
 
 apt:
   sources:
     tools_pool_repo:
-      # TODO after release, update this repository to use UYUNI instead
-      #source: "deb http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04 /"
-      source: "deb [trusted=yes] http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu20.04-SUSE-Manager-Tools/xUbuntu_20.04 /"
+      source: "deb https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/ /"
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v2.0.15 (GNU/Linux)
+
+        mQENBFsnulUBCADNjL4hvhVtSzqVDlMtFFFP28Acq+UNF8WKKMhbBirfOpXwwI1C
+        NR3i0CXPOce5eKShuuWAjD2E36e2XAp3rUAo/aCA7UgtJkMNKzzlTOcqHHxKTx6H
+        gvp0Fb6xTKywZ7VttGhwUynl+CsDuOst3ROXTNdb8XMfm4joH2FW5D3ACN2qNiv0
+        MVcFNKxQ98w8M9xJxdI8DuyngnSeZwAosNzEio3JhTPiTv9ngY2Z3AuYUcwTEt7o
+        feEN+ivAgYnn+a6DBKFBeCW7VUD3V+tH8/fKnkvI4gf2o3N7Ok+/uE+DPUBb+14f
+        +9dhBjd+7+pR3ayEZFjQns5XFShoYu2+CQspABEBAAG0UHN5c3RlbXNtYW5hZ2Vt
+        ZW50OlV5dW5pIE9CUyBQcm9qZWN0IDxzeXN0ZW1zbWFuYWdlbWVudDpVeXVuaUBi
+        dWlsZC5vcGVuc3VzZS5vcmc+iQE+BBMBCAAoBQJbJ7pVAhsDBQkEHrAABgsJCAcD
+        AgYVCAIJCgsEFgIDAQIeAQIXgAAKCRCXLl1sDSCDPoS+B/4inB/cDPfk5ad3IzdY
+        SsFB+maVHaMhVdxFToM68pj7yLAEzYdVXjZYuUCmRiGuXhFdojFdTsDeYbPYflxi
+        xfGvQ/18zPSI/UA+UMyRxaT9e6D2IUqmWAwc+/WwQbzoyItgKVc4UB6N+vWq4JFq
+        pNCVpKvwi9d38HAROl6suzxm3m6GeDe0UCPXW/Rju/7uHrHE0tnUacQru8k2rJhM
+        FIoZxUrdAPjhDx+hDX/J/jFTIX6k05Nbn7n43G0UTV4kFNaqYKmy+8S5gTgpePfO
+        pHB9YLqe0zxGRERXgjT82iM799OfmD3kc+/s4l45i/jk6MOjkX217grKIujwXf0v
+        tG6giEYEExECAAYFAlsnulUACgkQOzARt2udZSO/4QCcDf+j/XRbJn2PudsSoyjw
+        3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
+        =lTyy
+        -----END PGP PUBLIC KEY BLOCK-----
 
 runcmd:
   # HACK: cloud-init in Ubuntu does not take care of the following

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -40,6 +40,8 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 {% if grains.get('ubuntu1604_sshminion') | default(false, true) %}export UBUNTU1604_SSHMINION="{{ grains.get('ubuntu1604_sshminion') }}" {% else %}# no UBUNTU1604 ssh minion defined {% endif %}
 {% if grains.get('ubuntu1804_minion') | default(false, true) %}export UBUNTU1804_MINION="{{ grains.get('ubuntu1804_minion') }}" {% else %}# no UBUNTU1804 minion defined {% endif %}
 {% if grains.get('ubuntu1804_sshminion') | default(false, true) %}export UBUNTU1804_SSHMINION="{{ grains.get('ubuntu1804_sshminion') }}" {% else %}# no UBUNTU1804 ssh minion defined {% endif %}
+{% if grains.get('ubuntu2004_minion') | default(false, true) %}export UBUNTU1804_MINION="{{ grains.get('ubuntu2004_minion') }}" {% else %}# no UBUNTU2004 minion defined {% endif %}
+{% if grains.get('ubuntu2004_sshminion') | default(false, true) %}export UBUNTU1804_SSHMINION="{{ grains.get('ubuntu2004_sshminion') }}" {% else %}# no UBUNTU2004 ssh minion defined {% endif %}
 
 # various test suite settings
 export GITPROFILES="{{ grains.get('git_profiles_repo') }}"

--- a/salt/mirror/apt-mirror.list
+++ b/salt/mirror/apt-mirror.list
@@ -7,7 +7,7 @@ set nthreads       20
 ## Sources
 ##
 
-{% set ubuntu_names = {'16.04': 'xenial', '18.04': 'bionic'} %}
+{% set ubuntu_names = {'16.04': 'xenial', '18.04': 'bionic', '20.04': 'focal'} %}
 
 {% for distro in grains['ubuntu_distros']|default([], true) %}
 {% set distro_name = ubuntu_names.get(distro, distro) %}


### PR DESCRIPTION
## What does this PR change?

Issue: https://github.com/SUSE/spacewalk/issues/11489
Draft PR to add ubuntu 20.04 image support for libvirt and aws.

After clients tools get published on Uyuni, we need to update the repositories in use on cloud-init user data.
