### PR TITLE
specify an alternative container registry (without auth) for the testsuite

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -190,14 +190,14 @@ module "cucumber_testsuite" {
 
 ## Alternative Container Registry server
 
-If you want the test suite to use an unauthenticated container registry server, you can specify it with the `registry_uri` variable.
+If you want the test suite to use an unauthenticated container registry server, you can specify it with the `no_auth_registry` variable.
 
 Example:
 
 ```hcl
 module "cucumber_testsuite" {
    ...
-   registry_uri = "uri.of.registry:443/used"
+   no_auth_registry = "uri.of.registry:443/used"
    ...
 }
 ```

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -190,7 +190,7 @@ module "cucumber_testsuite" {
 
 ## Alternative Container Registry server
 
-If you want the test suite to use a unauthenticated container registry server, you can specufy it with the `registry_uri` variable.
+If you want the test suite to use an unauthenticated container registry server, you can specify it with the `registry_uri` variable.
 
 Example:
 
@@ -204,7 +204,7 @@ module "cucumber_testsuite" {
 
 ## Alternative Portus server
 
-If you want the test suite to use a Portus server, you can specify it with the `portus_uri`, `portus_username`, and `portus_password` variables.
+If you want the test suite to use a Portus server (authenticated registry), you can specify it with the `portus_uri`, `portus_username`, and `portus_password` variables.
 
 Example:
 

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -188,6 +188,20 @@ module "cucumber_testsuite" {
 }
 ```
 
+## Alternative Container Registry server
+
+If you want the test suite to use a unauthenticated container registry server, you can specufy it with the `registry_uri` variable.
+
+Example:
+
+```hcl
+module "cucumber_testsuite" {
+   ...
+   registry_uri = "uri.of.registry:443/used"
+   ...
+}
+```
+
 ## Alternative Portus server
 
 If you want the test suite to use a Portus server, you can specify it with the `portus_uri`, `portus_username`, and `portus_password` variables.

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -204,16 +204,16 @@ module "cucumber_testsuite" {
 
 ## Alternative Portus server
 
-If you want the test suite to use a Portus server (authenticated registry), you can specify it with the `portus_uri`, `portus_username`, and `portus_password` variables.
+If you want the test suite to use a Portus server (authenticated registry), you can specify it with the `auth_registry`, `auth_registry_username`, and `auth_registry_password` variables.
 
 Example:
 
 ```hcl
 module "cucumber_testsuite" {
    ...
-   portus_uri = "uri.of.portus:5000/used"
-   portus_username = "username"
-   portus_password = "password"
+   auth_registry = "uri.of.auth.registry:5000/used"
+   auth_registry_username = "username"
+   auth_registry_password = "password"
    ...
 }
 ```

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -47,7 +47,7 @@ module "controller" {
     xen_host      = length(var.xenhost_configuration["hostnames"]) > 0 ? var.xenhost_configuration["hostnames"][0] : null
 
     git_profiles_repo = var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo
-    registry_uri      = var.registry_uri
+    no_auth_registry  = var.no_auth_registry
     portus_uri        = var.portus_uri
     portus_username   = var.portus_username
     portus_password   = var.portus_password

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -46,13 +46,13 @@ module "controller" {
     kvm_host      = length(var.kvmhost_configuration["hostnames"]) > 0 ? var.kvmhost_configuration["hostnames"][0] : null
     xen_host      = length(var.xenhost_configuration["hostnames"]) > 0 ? var.xenhost_configuration["hostnames"][0] : null
 
-    git_profiles_repo = var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo
-    no_auth_registry  = var.no_auth_registry
-    portus_uri        = var.portus_uri
-    portus_username   = var.portus_username
-    portus_password   = var.portus_password
-    server_http_proxy = var.server_http_proxy
-    pxeboot_image     = var.pxeboot_configuration["image"]
+    git_profiles_repo      = var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo
+    no_auth_registry       = var.no_auth_registry
+    auth_registry          = var.auth_registry
+    auth_registry_username = var.auth_registry_username
+    auth_registry_password = var.auth_registry_password
+    server_http_proxy      = var.server_http_proxy
+    pxeboot_image          = var.pxeboot_configuration["image"]
 
     sle11sp4_minion      = length(var.sle11sp4_minion_configuration["hostnames"]) > 0 ? var.sle11sp4_minion_configuration["hostnames"][0] : null
     sle11sp4_sshminion   = length(var.sle11sp4_sshminion_configuration["hostnames"]) > 0 ? var.sle11sp4_sshminion_configuration["hostnames"][0] : null

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -47,6 +47,7 @@ module "controller" {
     xen_host      = length(var.xenhost_configuration["hostnames"]) > 0 ? var.xenhost_configuration["hostnames"][0] : null
 
     git_profiles_repo = var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles" : var.git_profiles_repo
+    registry_uri      = var.registry_uri
     portus_uri        = var.portus_uri
     portus_username   = var.portus_username
     portus_password   = var.portus_password

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -319,6 +319,11 @@ variable "git_profiles_repo" {
   default     = "default"
 }
 
+variable "registry_uri" {
+  description = "URI of container registry server, see README_ADVANCED.md"
+  default     = null
+}
+
 variable "portus_uri" {
   description = "URI of portus server, see README_ADVANCED.md"
   default     = null

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -324,18 +324,18 @@ variable "no_auth_registry" {
   default     = null
 }
 
-variable "portus_uri" {
-  description = "URI of portus server, see README_ADVANCED.md"
+variable "auth_registry" {
+  description = "URI of authenticated registry, see README_ADVANCED.md"
   default     = null
 }
 
-variable "portus_username" {
-  description = "username on portus server, see README_ADVANCED.md"
+variable "auth_registry_username" {
+  description = "username on registry, see README_ADVANCED.md"
   default     = null
 }
 
-variable "portus_password" {
-  description = "password on portus server, see README_ADVANCED.md"
+variable "auth_registry_password" {
+  description = "password on registry, see README_ADVANCED.md"
   default     = null
 }
 

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -319,7 +319,7 @@ variable "git_profiles_repo" {
   default     = "default"
 }
 
-variable "registry_uri" {
+variable "no_auth_registry" {
   description = "URI of container registry server, see README_ADVANCED.md"
   default     = null
 }

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -272,7 +272,7 @@ module "controller" {
   git_password      = var.git_password
   git_repo          = var.git_repo
   git_profiles_repo = var.git_profiles_repo
-  registry_uri      = var.registry_uri
+  no_auth_registry  = var.no_auth_registry
   portus_uri        = var.portus_uri
   portus_username   = var.portus_username
   portus_password   = var.portus_password

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -267,17 +267,17 @@ module "controller" {
   kvmhost_configuration   = contains(local.hosts, "kvm-host") ? module.kvm-host.configuration : { hostnames = [], ids = [] }
   xenhost_configuration   = contains(local.hosts, "xen-host") ? module.xen-host.configuration : { hostnames = [], ids = [] }
 
-  branch            = var.branch
-  git_username      = var.git_username
-  git_password      = var.git_password
-  git_repo          = var.git_repo
-  git_profiles_repo = var.git_profiles_repo
-  no_auth_registry  = var.no_auth_registry
-  portus_uri        = var.portus_uri
-  portus_username   = var.portus_username
-  portus_password   = var.portus_password
-  server_http_proxy = var.server_http_proxy
-  swap_file_size    = null
+  branch                 = var.branch
+  git_username           = var.git_username
+  git_password           = var.git_password
+  git_repo               = var.git_repo
+  git_profiles_repo      = var.git_profiles_repo
+  no_auth_registry       = var.no_auth_registry
+  auth_registry          = var.auth_registry
+  auth_registry_username = var.auth_registry_username
+  auth_registry_password = var.auth_registry_password
+  server_http_proxy      = var.server_http_proxy
+  swap_file_size         = null
 
   additional_repos  = lookup(local.additional_repos, "controller", {})
   provider_settings = lookup(local.provider_settings_by_host, "controller", {})

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -272,6 +272,7 @@ module "controller" {
   git_password      = var.git_password
   git_repo          = var.git_repo
   git_profiles_repo = var.git_profiles_repo
+  registry_uri      = var.registry_uri
   portus_uri        = var.portus_uri
   portus_username   = var.portus_username
   portus_password   = var.portus_password

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -97,6 +97,11 @@ variable "git_profiles_repo" {
   default     = "default"
 }
 
+variable "registry_uri" {
+  description = "URI of container registry server, see README_TESTING.md"
+  default     = null
+}
+
 variable "portus_uri" {
   description = "URI of portus server, see README_TESTING.md"
   default     = null

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -97,7 +97,7 @@ variable "git_profiles_repo" {
   default     = "default"
 }
 
-variable "registry_uri" {
+variable "no_auth_registry" {
   description = "URI of container registry server, see README_TESTING.md"
   default     = null
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -102,18 +102,18 @@ variable "no_auth_registry" {
   default     = null
 }
 
-variable "portus_uri" {
-  description = "URI of portus server, see README_TESTING.md"
+variable "auth_registry" {
+  description = "URI of authenticated registry, see README_TESTING.md"
   default     = null
 }
 
-variable "portus_username" {
-  description = "username on portus server, see README_TESTING.md"
+variable "auth_registry_username" {
+  description = "username on registry, see README_TESTING.md"
   default     = null
 }
 
-variable "portus_password" {
-  description = "password on portus server, see README_TESTING.md"
+variable "auth_registry_password" {
+  description = "password on registry, see README_TESTING.md"
   default     = null
 }
 

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -48,9 +48,9 @@ export VIRTHOST_XEN_PASSWORD="linux" {% else %}# no Xen host defined {% endif %}
 # various test suite settings
 export GITPROFILES="{{ grains.get('git_profiles_repo') }}"
 export SCC_CREDENTIALS="{{ grains.get('cc_username') }}|{{ grains.get('cc_password') }}"
-export PORTUS_URI="{{ grains.get('portus_uri') }}"
 export PORTUS_CREDENTIALS="{{ grains.get('portus_username') }}|{{ grains.get('portus_password') }}"
-export REGISTRY_URI="{{ grains.get('registry_uri') | default('registry.mgr.suse.de', true) }}"
+{% if grains.get('portus_uri') | default(false, true) %}export PORTUS_URI="{{ grains.get('portus_uri') }}" {% else %}# no portus registry defined {% endif %}
+{% if grains.get('registry_uri') | default(false, true) %}export REGISTRY_URI="{{ grains.get('registry_uri') }}" {% else %}# no container registry defined {% endif %}
 {% if grains.get('server_http_proxy') | default(false, true) %}export SERVER_HTTP_PROXY="{{ grains.get('server_http_proxy') }}" {% else %}# no server HTTP proxy defined {% endif %}
 {% if grains.get('pxeboot_image') | default(false, true) %}export PXEBOOT_IMAGE="{{ grains.get('pxeboot_image') }}" {% else %}# no PXE boot image defined {% endif %}
 

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -48,8 +48,8 @@ export VIRTHOST_XEN_PASSWORD="linux" {% else %}# no Xen host defined {% endif %}
 # various test suite settings
 export GITPROFILES="{{ grains.get('git_profiles_repo') }}"
 export SCC_CREDENTIALS="{{ grains.get('cc_username') }}|{{ grains.get('cc_password') }}"
-export PORTUS_CREDENTIALS="{{ grains.get('auth_registry_username') }}|{{ grains.get('auth_registry_password') }}"
-{% if grains.get('auth_registry') | default(false, true) %}export PORTUS_URI="{{ grains.get('auth_registry') }}" {% else %}# no authenticated registry defined {% endif %}
+export AUTH_REGISTRY_CREDENTIALS="{{ grains.get('auth_registry_username') }}|{{ grains.get('auth_registry_password') }}"
+{% if grains.get('auth_registry') | default(false, true) %}export AUTH_REGISTRY="{{ grains.get('auth_registry') }}" {% else %}# no authenticated registry defined {% endif %}
 {% if grains.get('no_auth_registry') | default(false, true) %}export NO_AUTH_REGISTRY="{{ grains.get('no_auth_registry') }}" {% else %}# no container registry defined {% endif %}
 {% if grains.get('server_http_proxy') | default(false, true) %}export SERVER_HTTP_PROXY="{{ grains.get('server_http_proxy') }}" {% else %}# no server HTTP proxy defined {% endif %}
 {% if grains.get('pxeboot_image') | default(false, true) %}export PXEBOOT_IMAGE="{{ grains.get('pxeboot_image') }}" {% else %}# no PXE boot image defined {% endif %}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -48,8 +48,8 @@ export VIRTHOST_XEN_PASSWORD="linux" {% else %}# no Xen host defined {% endif %}
 # various test suite settings
 export GITPROFILES="{{ grains.get('git_profiles_repo') }}"
 export SCC_CREDENTIALS="{{ grains.get('cc_username') }}|{{ grains.get('cc_password') }}"
-export PORTUS_CREDENTIALS="{{ grains.get('portus_username') }}|{{ grains.get('portus_password') }}"
-{% if grains.get('portus_uri') | default(false, true) %}export PORTUS_URI="{{ grains.get('portus_uri') }}" {% else %}# no portus registry defined {% endif %}
+export PORTUS_CREDENTIALS="{{ grains.get('auth_registry_username') }}|{{ grains.get('auth_registry_password') }}"
+{% if grains.get('auth_registry') | default(false, true) %}export PORTUS_URI="{{ grains.get('auth_registry') }}" {% else %}# no authenticated registry defined {% endif %}
 {% if grains.get('no_auth_registry') | default(false, true) %}export NO_AUTH_REGISTRY="{{ grains.get('no_auth_registry') }}" {% else %}# no container registry defined {% endif %}
 {% if grains.get('server_http_proxy') | default(false, true) %}export SERVER_HTTP_PROXY="{{ grains.get('server_http_proxy') }}" {% else %}# no server HTTP proxy defined {% endif %}
 {% if grains.get('pxeboot_image') | default(false, true) %}export PXEBOOT_IMAGE="{{ grains.get('pxeboot_image') }}" {% else %}# no PXE boot image defined {% endif %}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -50,7 +50,7 @@ export GITPROFILES="{{ grains.get('git_profiles_repo') }}"
 export SCC_CREDENTIALS="{{ grains.get('cc_username') }}|{{ grains.get('cc_password') }}"
 export PORTUS_CREDENTIALS="{{ grains.get('portus_username') }}|{{ grains.get('portus_password') }}"
 {% if grains.get('portus_uri') | default(false, true) %}export PORTUS_URI="{{ grains.get('portus_uri') }}" {% else %}# no portus registry defined {% endif %}
-{% if grains.get('registry_uri') | default(false, true) %}export REGISTRY_URI="{{ grains.get('registry_uri') }}" {% else %}# no container registry defined {% endif %}
+{% if grains.get('no_auth_registry') | default(false, true) %}export NO_AUTH_REGISTRY="{{ grains.get('no_auth_registry') }}" {% else %}# no container registry defined {% endif %}
 {% if grains.get('server_http_proxy') | default(false, true) %}export SERVER_HTTP_PROXY="{{ grains.get('server_http_proxy') }}" {% else %}# no server HTTP proxy defined {% endif %}
 {% if grains.get('pxeboot_image') | default(false, true) %}export PXEBOOT_IMAGE="{{ grains.get('pxeboot_image') }}" {% else %}# no PXE boot image defined {% endif %}
 

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -50,6 +50,7 @@ export GITPROFILES="{{ grains.get('git_profiles_repo') }}"
 export SCC_CREDENTIALS="{{ grains.get('cc_username') }}|{{ grains.get('cc_password') }}"
 export PORTUS_URI="{{ grains.get('portus_uri') }}"
 export PORTUS_CREDENTIALS="{{ grains.get('portus_username') }}|{{ grains.get('portus_password') }}"
+export REGISTRY_URI="{{ grains.get('registry_uri') | default('registry.mgr.suse.de', true) }}"
 {% if grains.get('server_http_proxy') | default(false, true) %}export SERVER_HTTP_PROXY="{{ grains.get('server_http_proxy') }}" {% else %}# no server HTTP proxy defined {% endif %}
 {% if grains.get('pxeboot_image') | default(false, true) %}export PXEBOOT_IMAGE="{{ grains.get('pxeboot_image') }}" {% else %}# no PXE boot image defined {% endif %}
 

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -40,10 +40,10 @@ registry_certificate:
     - source: salt://minion/certs/registry.mgr.suse.de.pem
     - makedirs: True
 
-portus_registry_certificate:
+auth_registry_certificate:
   file.managed:
-    - name: /etc/pki/trust/anchors/portus.mgr.suse.de-ca.crt
-    - source: salt://minion/certs/portus.mgr.suse.de-ca.crt
+    - name: /etc/pki/trust/anchors/authreg.mgr.suse.de-ca.crt
+    - source: salt://minion/certs/authreg.mgr.suse.de-ca.crt
     - makedirs: True
 
 suse_certificate:


### PR DESCRIPTION
## What does this PR change?

configure a different container registry for the testsuite 

Part of a series of PRs in different repos:

https://github.com/uyuni-project/sumaform/pull/716
https://github.com/SUSE/susemanager-ci/pull/78
https://github.com/uyuni-project/uyuni/pull/2224

