### PR TITLE
Revert change to old repositories name

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -169,12 +169,10 @@ test_update_repo:
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-    - name: SLE-12-SP4-x86_64-Pool
 
 os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP4/x86_64/update/
-    - name: SLE-12-SP4-x86_64-Update
 
 {% if grains.get('use_os_unreleased_updates') | default(False, true) %}
 test_update_repo:
@@ -188,12 +186,10 @@ test_update_repo:
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-SERVER/12-SP5/x86_64/product/
-    - name: SLE-12-SP5-x86_64-Pool
 
 os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/
-    - name: SLE-12-SP5-x86_64-Update
 
 {% if grains.get('use_os_unreleased_updates') | default(False, true) %}
 test_update_repo:
@@ -210,12 +206,10 @@ test_update_repo:
 tools_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/
-    - name: SLE-Manager-Tools12-Pool
 
 tools_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/
-    - name: SLE-Manager-Tools12-Update
 {% else %}
 tools_pool_repo:
   pkgrepo.managed:

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -4,12 +4,10 @@
 containers_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/12/x86_64/product/
-    - name: SLE-Module-Containers-12-Pool
 
 containers_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/12/x86_64/update/
-    - name: SLE-Module-Containers-12-Update
 
 {% endif %}
 


### PR DESCRIPTION
## What does this PR change?

This PR reverts commit 0a0391dccc49233a2f089be2c6b6e511c62202bb from 17 October 2019. 

That commit tried to revert to old repositories names in sumaform, while the issue was already fixed on the test suite side by switching to the new names on 16 October 2019 in commit  SUSE/spacewalk@05a0aa0fbde999e8e6412a49bd965d333ec8d7fa .
