### PR TITLE
Enable SUSE Manager 4.1 on the mirror

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -100,10 +100,10 @@ scc:
     - SLE-Product-SUSE-Manager-Server-4.0-Updates
     - SLE-Module-SUSE-Manager-Server-4.0-Pool
     - SLE-Module-SUSE-Manager-Server-4.0-Updates
-    #- SLE-Product-SUSE-Manager-Server-4.1-Pool
-    #- SLE-Product-SUSE-Manager-Server-4.1-Updates
-    #- SLE-Module-SUSE-Manager-Server-4.1-Pool
-    #- SLE-Module-SUSE-Manager-Server-4.1-Updates
+    - SLE-Product-SUSE-Manager-Server-4.1-Pool
+    - SLE-Product-SUSE-Manager-Server-4.1-Updates
+    - SLE-Module-SUSE-Manager-Server-4.1-Pool
+    - SLE-Module-SUSE-Manager-Server-4.1-Updates
     # SUSE Manager Proxy
     - SUSE-Manager-Proxy-3.2-Pool
     - SUSE-Manager-Proxy-3.2-Updates
@@ -111,19 +111,19 @@ scc:
     - SLE-Product-SUSE-Manager-Proxy-4.0-Updates
     - SLE-Module-SUSE-Manager-Proxy-4.0-Pool
     - SLE-Module-SUSE-Manager-Proxy-4.0-Updates
-    #- SLE-Product-SUSE-Manager-Proxy-4.1-Pool
-    #- SLE-Product-SUSE-Manager-Proxy-4.1-Updates
-    #- SLE-Module-SUSE-Manager-Proxy-4.1-Pool
-    #- SLE-Module-SUSE-Manager-Proxy-4.1-Updates
+    - SLE-Product-SUSE-Manager-Proxy-4.1-Pool
+    - SLE-Product-SUSE-Manager-Proxy-4.1-Updates
+    - SLE-Module-SUSE-Manager-Proxy-4.1-Pool
+    - SLE-Module-SUSE-Manager-Proxy-4.1-Updates
     # Retail Branch Server
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Pool
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Updates
     - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-Pool
     - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-Updates
-    #- SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Pool
-    #- SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Updates
-    #- SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Pool
-    #- SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Updates
+    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Pool
+    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Updates
+    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Pool
+    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Updates
     # SUSE Manager Tools
     - SLES11-SP4-SUSE-Manager-Tools
     - SLE-Manager-Tools12-Pool
@@ -243,29 +243,9 @@ http:
     archs: [x86_64]
 
   # SUSE Manager 4.1 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1/SLE_15_SP2
-  #  archs: [x86_64]
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/ToSLE/SLE_15_SP2/
-  #  archs: [x86_64]
-
-  # SLE 11 SP4 Manager Tools 3.2 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1/SLE_15_SP2
     archs: [x86_64]
-
-  # SLE 12 (GA and all SPs) Manager Tools 3.2 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1
-    archs: [x86_64]
-
-  # SLE 15 Manager Tools 3.2 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1
-    archs: [x86_64]
-
-  # RES 6 Manager Tools 3.2 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/RES6-SUSE-Manager-Tools/SUSE_RES-6_Update_standard
-    archs: [x86_64]
-
-  # RES 7 Manager Tools 3.2 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/ToSLE/SLE_15_SP2/
     archs: [x86_64]
 
   # SLE 11 SP4 Manager Tools 4.0 devel
@@ -293,28 +273,28 @@ http:
     archs: [amd64]
 
   # SLE 11 SP4 Manager Tools 4.1 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse
+    archs: [x86_64]
 
   # SLE 12 (GA and all SPs) Manager Tools 4.1 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1
+    archs: [x86_64]
 
   # SLE 15 Manager Tools 4.1 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1
+    archs: [x86_64]
 
   # RES 6 Manager Tools 4.1 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/RES6-SUSE-Manager-Tools/SUSE_RES-6_Update_standard
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/RES6-SUSE-Manager-Tools/SUSE_RES-6_Update_standard
+    archs: [x86_64]
 
   # RES 7 Manager Tools 4.1 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
+    archs: [x86_64]
 
   # Ubuntu 18.04 Manager Tools 4.1 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04
-  #  archs: [amd64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04
+    archs: [amd64]
 
   # SUSE Manager Head devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/SLE_15_SP2


### PR DESCRIPTION
## What does this PR change?

Enable SUSE Manager 4.1 on the mirror. Do not merge yet. I need the product definitions building at 4.1 devel project (in a few days)

3.2 are not used by any product since 4.0 GM was published, and are not needed anymore.