### PR TITLE
Add openSUSE Leap 15.2 and move Uyuni Master to it

### DIFF
--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -61,6 +61,27 @@ data "aws_ami" "opensuse151" {
   }
 }
 
+data "aws_ami" "opensuse152" {
+  most_recent = true
+  name_regex  = "^openSUSE-Leap-15-2-v"
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
 data "aws_ami" "sles15" {
   most_recent = true
   name_regex  = "^suse-sles-15-byos-v"

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -10,7 +10,7 @@ chpasswd:
     root:linux
 %{ endif }
 
-%{ if image == "opensuse151" || image == "opensuse150"}
+%{ if image == "opensuse152" || image == "opensuse151" || image == "opensuse150"}
 packages: ["salt-minion"]
 
 runcmd:

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -10,6 +10,7 @@ locals {
     opensuse150o = "https://download.opensuse.org/distribution/leap/15.0/jeos/openSUSE-Leap-15.0-JeOS.x86_64-15.0.1-OpenStack-Cloud-Current.qcow2"
     opensuse151  = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse151.x86_64.qcow2"
     opensuse151o = "https://download.opensuse.org/distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2"
+    opensuse152o = "https://download.opensuse.org/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2"
     sles15       = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15.x86_64.qcow2"
     sles15o      = "http://download.suse.de/install/SLE-15-JeOS-GM/SLES15-JeOS.x86_64-15.0-OpenStack-Cloud-GM.qcow2"
     sles15sp1    = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp1.x86_64.qcow2"

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -96,6 +96,13 @@ runcmd:
   - zypper removerepo --all
 %{ endif }
 
+%{ if image == "opensuse152o" }
+packages: ["qemu-guest-agent"]
+
+runcmd:
+  - zypper removerepo --all
+%{ endif }
+
 %{ if image == "sles12sp4o" }
 zypper:
   repos:

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -60,6 +60,6 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos7", "opensuse150", "opensuse151", "sles15", "sles15sp1", "sles15sp2", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
+  default     = ["centos7", "opensuse150", "opensuse151", "opensuse152o", "sles15", "sles15sp1", "sles15sp2", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
   type        = set(string)
 }

--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -86,7 +86,7 @@ variable "connect_to_additional_network" {
 }
 
 variable "image" {
-  description = "One of: opensuse150, opensuse151, sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles12sp4, sles15, centos7"
+  description = "One of: opensuse150, opensuse151, opensuse152o, sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles12sp4, sles15, centos7"
   type        = string
 }
 

--- a/main.tf.uyuni.example
+++ b/main.tf.uyuni.example
@@ -22,7 +22,7 @@ module "base" {
 //  }
 
   // Required images
-  images = ["centos7", "opensuse151", "ubuntu1804"]
+  images = ["centos7", "opensuse151", "opensuse152o", "ubuntu1804"]
 }
 
 module "server" {
@@ -30,7 +30,7 @@ module "server" {
   base_configuration = module.base.configuration
   product_version = "uyuni-master"
   name = "srv"
-  image = "opensuse151"
+  image = "opensuse152o"
   use_os_released_updates = true
   // see modules/server/variables.tf for possible values
 

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -60,6 +60,6 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos7", "opensuse150", "opensuse151", "sles15", "sles15sp1", "sles15sp2", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
+  default     = ["centos7", "opensuse150", "opensuse151", "opensuse152o", "sles15", "sles15sp1", "sles15sp2", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
   type        = set(string)
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -31,7 +31,7 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos7", "opensuse150", "opensuse151", "sles15", "sles15sp1", "sles15sp2", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
+  default     = ["centos7", "opensuse150", "opensuse151", "opensuse152o", "sles15", "sles15sp1", "sles15sp2", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
 }
 
 variable "mirror" {

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -86,7 +86,7 @@ variable "connect_to_additional_network" {
 }
 
 variable "image" {
-  description = "One of: opensuse150, opensuse151, sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles12sp4, sles15, centos7"
+  description = "One of: opensuse150, opensuse151, opensuse152o, sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles12sp4, sles15, centos7"
   type        = string
 }
 

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -5,7 +5,7 @@ variable "images" {
     "4.0-released"   = "sles15sp1"
     "4.0-nightly"    = "sles15sp1"
     "head"           = "sles15sp2"
-    "uyuni-master"   = "opensuse151"
+    "uyuni-master"   = "opensuse152o"
     "uyuni-released" = "opensuse151"
   }
 }

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -5,7 +5,7 @@ variable "images" {
     "4.0-released"   = "sles15sp1"
     "4.0-nightly"    = "sles15sp1"
     "head"           = "sles15sp2"
-    "uyuni-master"   = "opensuse151"
+    "uyuni-master"   = "opensuse152o"
     "uyuni-released" = "opensuse151"
   }
 }

--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -76,7 +76,7 @@ variable "connect_to_additional_network" {
 }
 
 variable "image" {
-  description = "One of: opensuse150, opensuse151, sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles12sp4, sles15, centos7"
+  description = "One of: opensuse150, opensuse151, opensuse152o, sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles12sp4, sles15, centos7"
   type        = string
 }
 

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -80,7 +80,7 @@ variable "hvm_disk_image_hash" {
 }
 
 variable "image" {
-  description = "One of: sles15, sles15sp1, sles15sp2, opensuse150 or opensuse151"
+  description = "One of: sles15, sles15sp1, sles15sp2, opensuse150, opensuse151 or opensuse152o"
   type        = string
 }
 

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -335,6 +335,11 @@ http:
   - url: http://download.opensuse.org/update/leap/15.1/oss
     archs: [x86_64]
 
+  - url: http://download.opensuse.org/distribution/leap/15.2/repo/oss
+    archs: [x86_64]
+  - url: http://download.opensuse.org/update/leap/15.2/oss
+    archs: [x86_64]
+
   # Testsuite dummy packages for testing repo
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb
@@ -362,9 +367,11 @@ http:
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.1
     archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.2
+    archs: [x86_64]
 
   # Uyuni Master
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.1/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.2/
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Server-POOL-x86_64-Media1/
     archs: [x86_64]

--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -95,7 +95,7 @@ server_devel_releasenotes_repo:
 {% if grains['osfullname'] == 'Leap' %}
 server_devel_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.1/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.2/
     - priority: 96
 {% else %}
 server_devel_repo:

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -126,7 +126,7 @@ server_devel_releasenotes_repo:
 {% if grains['osfullname'] == 'Leap' %}
 server_devel_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.1/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.2/
     - priority: 96
 {% else %}
 server_devel_repo:


### PR DESCRIPTION
## What does this PR change?

Add openSUSE Leap 15.2 and move Uyuni Master to it

Libvirt image: https://build.opensuse.org/package/show/systemsmanagement:sumaform:images:libvirt/opensuse152
OpenStack iamge: https://build.opensuse.org/package/show/systemsmanagement:sumaform:images:openstack/opensuse152