### PR TITLE
Add missing stuff for 4.1

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -9,11 +9,13 @@ Some modules have a `product_version` variable that determines the software prod
 Legal values for released software are:
  * `3.2-released`   (latest released Maintenance Update for SUSE Manager 3.2 and Tools)
  * `4.0-released`   (latest released Maintenance Update for SUSE Manager 4.0 and Tools)
+ * `4.1-released`   (latest released Maintenance Update for SUSE Manager 4.1 and Tools)
  * `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
 
 Legal values for work-in-progress software are:
  * `3.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:3.2)
  * `4.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.0)
+ * `4.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.1)
  * `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, for `server` and `proxy`only works with SLE15SP2 image)
  * `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap 15.1 image)
 

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -4,6 +4,8 @@ variable "testsuite-branch" {
     "3.2-nightly"    = "Manager-3.2"
     "4.0-released"   = "Manager-4.0"
     "4.0-nightly"    = "Manager-4.0"
+    "4.1-released"   = "Manager-4.1"
+    "4.1-nightly"    = "Manager-4.1"
     "head"           = "master"
     "uyuni-master"   = "master"
     "uyuni-released" = "master"

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -64,7 +64,7 @@ variable "host_settings" {
 
 // srv
 variable "product_version" {
-  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, head, test, uyuni-released"
+  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, 4.1-nightly, 4.1-released, head, test, uyuni-released"
   type        = string
 }
 

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -4,6 +4,8 @@ variable "images" {
     "3.2-nightly"    = "sles12sp4"
     "4.0-released"   = "sles15sp1"
     "4.0-nightly"    = "sles15sp1"
+    "4.1-released"   = "sles15sp2o"
+    "4.1-nightly"    = "sles15sp2o"
     "head"           = "sles15sp2o"
     "uyuni-master"   = "opensuse152o"
     "uyuni-released" = "opensuse151"

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, head"
+  description = "One of: 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, 4.1-released, 4.1-nightly, head"
   type        = string
 }
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -4,6 +4,8 @@ variable "images" {
     "3.2-nightly"    = "sles12sp4"
     "4.0-released"   = "sles15sp1"
     "4.0-nightly"    = "sles15sp1"
+    "4.1-released"   = "sles15sp2o"
+    "4.1-nightly"    = "sles15sp2o"
     "head"           = "sles15sp2o"
     "uyuni-master"   = "opensuse152o"
     "uyuni-released" = "opensuse151"

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, head, test, uyuni-released"
+  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, 4.1-released, 4.1-nightly, head, test, uyuni-released"
   type        = string
 }
 

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -193,32 +193,32 @@ http:
     archs: [x86_64]
 
   # SLES 15 SP2 Test (not available until GM)
-  #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Basesystem:/15-SP2:/x86_64/update
-  #  archs: [x86_64]
-  #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Containers:/15-SP2:/x86_64/update
-  #  archs: [x86_64]
-  #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Development-Tools:/15-SP2:/x86_64/update
-  #  archs: [x86_64]
-  #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Python2:/15-SP2:/x86_64/update
-  #  archs: [x86_64]
-  #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Server-Applications:/15-SP2:/x86_64/update
-  #  archs: [x86_64]
-  #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Web-Scripting:/15-SP2:/x86_64/update
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Basesystem:/15-SP2:/x86_64/update
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Containers:/15-SP2:/x86_64/update
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Development-Tools:/15-SP2:/x86_64/update
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Python2:/15-SP2:/x86_64/update
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Server-Applications:/15-SP2:/x86_64/update
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Web-Scripting:/15-SP2:/x86_64/update
+    archs: [x86_64]
 
   # SLE 15 SP2 moving target (valid until GM)
-  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Basesystem-POOL-x86_64-Media1/
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP2-Module-Containers-POOL-x86_64-Media1/
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Development-Tools-POOL-x86_64-Media1/
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Python2-POOL-x86_64-Media1/
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Server-Applications-POOL-x86_64-Media1/
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Web-Scripting-POOL-x86_64-Media1/
-    archs: [x86_64]
+  #- url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Basesystem-POOL-x86_64-Media1/
+  #  archs: [x86_64]
+  #- url: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP2-Module-Containers-POOL-x86_64-Media1/
+  #  archs: [x86_64]
+  #- url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Development-Tools-POOL-x86_64-Media1/
+  #  archs: [x86_64]
+  #- url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Python2-POOL-x86_64-Media1/
+  #  archs: [x86_64]
+  #- url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Server-Applications-POOL-x86_64-Media1/
+  #  archs: [x86_64]
+  #- url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Web-Scripting-POOL-x86_64-Media1/
+  #  archs: [x86_64]
 
   # SUSE Manager Head (SLE15-SP2)
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Server-4.1-POOL-x86_64-Media1

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -77,7 +77,7 @@ tools_pool_repo:
 
 tools_additional_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse/
     - priority: 98
 
 {% elif 'head' in grains.get('product_version') | default('', true) %}
@@ -220,7 +220,7 @@ tools_pool_repo:
 {% if 'nightly' in grains.get('product_version') | default('', true) %}
 tools_additional_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1/
     - priority: 98
 
 {% elif 'head' in grains.get('product_version') | default('', true) %}
@@ -260,7 +260,7 @@ tools_pool_repo:
 {% if 'nightly' in grains.get('product_version') | default('', true) %}
 tools_additional_repo:
   pkgrepo.managed:
-  - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
+  - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
   - priority: 98
 {% elif 'head' in grains.get('product_version') | default('', true) %}
 tools_additional_repo:
@@ -414,7 +414,7 @@ tools_update_repo:
 tools_update_repo:
   pkgrepo.managed:
     - humanname: tools_update_repo
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/RES{{ release }}-SUSE-Manager-Tools/SUSE_RES-{{ release }}_Update_standard/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1:/RES{{ release }}-SUSE-Manager-Tools/SUSE_RES-{{ release }}_Update_standard/
     - require:
       - cmd: galaxy_key
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
@@ -468,13 +468,18 @@ tools_update_repo:
     - file: /etc/apt/sources.list.d/Ubuntu{{ short_release }}-Client-Tools.list
 {% if 'head' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
+{% elif '4.1-nightly' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.1:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
+{% elif '4.1-released' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
+# We only have one shared Client Tools repository, so we are using 4.1 even for 4.0
 {% elif '4.0-nightly' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.0:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.1:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
 {% elif '4.0-released' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
-# We only have one shared Client Tools repository, so we are using 4.0 even for 3.2
+# We only have one shared Client Tools repository, so we are using 4.1 even for 3.2
 {% elif '3.2-nightly' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.0:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.1:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
 {% elif '3.2-released' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
@@ -493,21 +498,32 @@ tools_update_repo_raised_priority:
             Package: *
             Pin: release l=Devel:Galaxy:Manager:Head:Ubuntu{{ release }}-SUSE-Manager-Tools
             Pin-Priority: 800
+{% elif '4.1-nightly' in grains.get('product_version') | default('', true) %}
+    - contents: |
+            Package: *
+            Pin: release l=Devel:Galaxy:Manager:4.1:Ubuntu{{ release }}-SUSE-Manager-Tools
+            Pin-Priority: 800
+{% elif '4.1-released' in grains.get('product_version') | default('', true) %}
+    - contents: |
+            Package: *
+            Pin: release l=SUSE:Updates:Ubuntu:{{ release }}-CLIENT-TOOLS:x86_64:update
+            Pin-Priority: 800
+# We only have one shared Client Tools repository, so we are using 4.1 even for 4.0
 {% elif '4.0-nightly' in grains.get('product_version') | default('', true) %}
     - contents: |
             Package: *
-            Pin: release l=Devel:Galaxy:Manager:4.0:Ubuntu{{ release }}-SUSE-Manager-Tools
+            Pin: release l=Devel:Galaxy:Manager:4.1:Ubuntu{{ release }}-SUSE-Manager-Tools
             Pin-Priority: 800
 {% elif '4.0-released' in grains.get('product_version') | default('', true) %}
     - contents: |
             Package: *
             Pin: release l=SUSE:Updates:Ubuntu:{{ release }}-CLIENT-TOOLS:x86_64:update
             Pin-Priority: 800
-# We only have one shared Client Tools repository, so we are using 4.0 even for 3.2
+# We only have one shared Client Tools repository, so we are using 4.1 even for 3.2
 {% elif '3.2-nightly' in grains.get('product_version') | default('', true) %}
     - contents: |
             Package: *
-            Pin: release l=Devel:Galaxy:Manager:4.0:Ubuntu{{ release }}-SUSE-Manager-Tools
+            Pin: release l=Devel:Galaxy:Manager:4.1:Ubuntu{{ release }}-SUSE-Manager-Tools
             Pin-Priority: 800
 {% elif '3.2-released' in grains.get('product_version') | default('', true) %}
     - contents: |


### PR DESCRIPTION
## What does this PR change?

- Add 4.1 to the doc
- Enable default images for 4.1
- Adjust variables descriptions for 4.1
- Change all SUSE Manager versions to use 4.1 client tools
- Enable Maintenance Test repositories for SLE15SP2 and 4.1 on the mirror

I tested a cucumber environment creation locally based on 4.1-nightly. Worked fine.