### PR TITLE
Install NTP on most hosts

### DIFF
--- a/.ci-travis/salt-client-validation
+++ b/.ci-travis/salt-client-validation
@@ -8,6 +8,7 @@ gpg_keys: []
 domain: travis
 use_avahi: 0
 timezone: Europe/Berlin
+use_ntp: true
 additional_repos: {}
 additional_certs: {}
 additional_packages: []

--- a/.ci-travis/salt-ctl-validation
+++ b/.ci-travis/salt-ctl-validation
@@ -8,6 +8,7 @@ gpg_keys: []
 domain: travis
 use_avahi: 0
 timezone: Europe/Berlin
+use_ntp: true
 additional_repos: {}
 additional_certs: {}
 additional_packages: []

--- a/.ci-travis/salt-minion-validation
+++ b/.ci-travis/salt-minion-validation
@@ -8,6 +8,7 @@ gpg_keys: []
 domain: travis
 use_avahi: 0
 timezone: Europe/Berlin
+use_ntp: true
 additional_repos: {}
 additional_certs: {}
 additional_packages: []

--- a/.ci-travis/salt-server-validation
+++ b/.ci-travis/salt-server-validation
@@ -8,6 +8,7 @@ gpg_keys: []
 domain: travis
 use_avahi: 0
 timezone: Europe/Berlin
+use_ntp: true
 additional_repos: {}
 additional_certs: {}
 additional_packages: []

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -392,6 +392,7 @@ locals {
     cc_username          = var.cc_username
     cc_password          = var.cc_password
     timezone             = var.timezone
+    use_ntp              = var.use_ntp
     ssh_key_path         = var.ssh_key_path
     mirror               = var.mirror
     use_mirror_images    = var.use_mirror_images

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -145,6 +145,8 @@ resource "null_resource" "host_salt_configuration" {
     domain_id      = length(aws_instance.instance) == var.quantity ? aws_instance.instance[count.index].id : null
     grains_subset = yamlencode(
       {
+        timezone              = var.base_configuration["timezone"]
+        use_ntp               = var.base_configuration["use_ntp"]
         testsuite             = var.base_configuration["testsuite"]
         roles                 = var.roles
         additional_repos      = var.additional_repos
@@ -189,6 +191,7 @@ resource "null_resource" "host_salt_configuration" {
         use_avahi : false
 
         timezone                  = var.base_configuration["timezone"]
+        use_ntp                   = var.base_configuration["use_ntp"]
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -157,6 +157,7 @@ resource "null_resource" "provisioning" {
         domain                    = var.base_configuration["domain"]
         use_avahi                 = var.base_configuration["use_avahi"]
         timezone                  = var.base_configuration["timezone"]
+        use_ntp                   = var.base_configuration["use_ntp"]
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
@@ -199,6 +200,7 @@ resource "null_resource" "provisioning" {
         use_avahi                 = var.base_configuration["use_avahi"]
         additional_network        = var.base_configuration["additional_network"]
         timezone                  = var.base_configuration["timezone"]
+        use_ntp                   = var.base_configuration["use_ntp"]
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates

--- a/backend_modules/null/base/main.tf
+++ b/backend_modules/null/base/main.tf
@@ -5,6 +5,7 @@ resource "null_resource" "base" {
     cc_username          = var.cc_username
     cc_password          = var.cc_password
     timezone             = var.timezone
+    use_ntp              = var.use_ntp
     ssh_key_path         = var.ssh_key_path
     mirror               = var.mirror
     use_mirror_images    = var.use_mirror_images
@@ -23,6 +24,7 @@ output "configuration" {
     cc_username          = var.cc_username
     cc_password          = var.cc_password
     timezone             = var.timezone
+    use_ntp              = var.use_ntp
     ssh_key_path         = var.ssh_key_path
     mirror               = var.mirror
     use_mirror_images    = var.use_mirror_images

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -13,6 +13,11 @@ variable "timezone" {
   default     = "Europe/Berlin"
 }
 
+variable "use_ntp" {
+  description = "use false if you don't want to run Network Time Protocol"
+  default     = true
+}
+
 variable "ssh_key_path" {
   description = "path of pub ssh key you want to use to access VMs, see libvirt/README.md"
   default     = "~/.ssh/id_rsa.pub"

--- a/backend_modules/ssh/base/main.tf
+++ b/backend_modules/ssh/base/main.tf
@@ -4,6 +4,7 @@ resource "null_resource" "base" {
     cc_username          = var.cc_username
     cc_password          = var.cc_password
     timezone             = var.timezone
+    use_ntp              = var.use_ntp
     ssh_key_path         = var.ssh_key_path
     mirror               = var.mirror
     use_mirror_images    = var.use_mirror_images
@@ -21,6 +22,7 @@ output "configuration" {
     cc_username          = var.cc_username
     cc_password          = var.cc_password
     timezone             = var.timezone
+    use_ntp              = var.use_ntp
     ssh_key_path         = var.ssh_key_path
     mirror               = var.mirror
     use_mirror_images    = var.use_mirror_images

--- a/backend_modules/ssh/host/main.tf
+++ b/backend_modules/ssh/host/main.tf
@@ -22,6 +22,9 @@ resource "null_resource" "provisioning" {
     base_configuration = yamlencode(var.base_configuration)
     grains_subset = yamlencode(
       {
+        timezone                  = var.base_configuration["timezone"]
+        use_ntp                   = var.base_configuration["use_ntp"]
+        testsuite                 = var.base_configuration["testsuite"]
         hostname                  = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
@@ -74,6 +77,7 @@ resource "null_resource" "provisioning" {
         use_avahi                 = var.base_configuration["use_avahi"]
         additional_network        = var.base_configuration["additional_network"]
         timezone                  = var.base_configuration["timezone"]
+        use_ntp                   = var.base_configuration["use_ntp"]
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates

--- a/main.tf.libvirt.example
+++ b/main.tf.libvirt.example
@@ -12,6 +12,7 @@ module "base" {
   // use_avahi = true
   // name_prefix = "" // if you use name_prefix, make sure to update the server_configuration for clients/minions below
   // timezone = "Europe/Berlin"
+  // use_ntp = true
 
 //  provider_settings = {
 //    bridge = null

--- a/main.tf.ssh.example
+++ b/main.tf.ssh.example
@@ -8,6 +8,7 @@ module "base" {
   // use_avahi = true
   // name_prefix = "" // if you use name_prefix, make sure to update the server_configuration for clients/minions below
   // timezone = "Europe/Berlin"
+  // use_ntp = true
 
 //  provider_settings = {
 //    additional_network = null

--- a/main.tf.uyuni.example
+++ b/main.tf.uyuni.example
@@ -12,6 +12,7 @@ module "base" {
   // use_avahi = true
   // name_prefix = "" // if you use name_prefix, make sure to update the server_configuration for clients/minions below
   // timezone = "Europe/Berlin"
+  // use_ntp = true
 
   // provider specific properties
 //  provider_settings = {

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -4,6 +4,7 @@ module "base_backend" {
   cc_username          = var.cc_username
   cc_password          = var.cc_password
   timezone             = var.timezone
+  use_ntp              = var.use_ntp
   ssh_key_path         = var.ssh_key_path
   mirror               = var.mirror
   use_mirror_images    = var.use_mirror_images
@@ -21,6 +22,7 @@ output "configuration" {
     cc_username          = var.cc_username
     cc_password          = var.cc_password
     timezone             = var.timezone
+    use_ntp              = var.use_ntp
     ssh_key_path         = var.ssh_key_path
     mirror               = var.mirror
     use_mirror_images    = var.use_mirror_images

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -13,6 +13,11 @@ variable "timezone" {
   default     = "Europe/Berlin"
 }
 
+variable "use_ntp" {
+  description = "use false if you don't want to run Network Time Protocol"
+  default     = true
+}
+
 variable "ssh_key_path" {
   description = "path of pub ssh key you want to use to access VMs, see libvirt/README.md"
   default     = "~/.ssh/id_rsa.pub"

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -7,29 +7,6 @@ include:
   {% endif %}
   - default.testsuite
 
-timezone_package:
-  pkg.installed:
-{% if grains['os_family'] == 'Suse' %}
-    - name: timezone
-{% else %}
-    - name: tzdata
-{% endif %}
-
-timezone_symlink:
-  file.symlink:
-    - name: /etc/localtime
-    - target: /usr/share/zoneinfo/{{ grains['timezone'] }}
-    - force: true
-    - require:
-      - pkg: timezone_package
-
-timezone_setting:
-  timezone.system:
-    - name: {{ grains['timezone'] }}
-    - utc: True
-    - require:
-      - file: timezone_symlink
-
 {% if grains.get('use_os_unreleased_updates') | default(False, true) or grains.get('use_os_released_updates') | default(False, true) %}
 update_packages:
   pkg.uptodate:

--- a/salt/default/minimal.sls
+++ b/salt/default/minimal.sls
@@ -4,6 +4,7 @@ include:
   {% endif %}
   - default.network
   - default.avahi
+  - default.time
   - repos
 
 minimal_package_update:

--- a/salt/default/ntp.conf
+++ b/salt/default/ntp.conf
@@ -1,0 +1,12 @@
+restrict   127.0.0.1
+restrict   ::1
+
+driftfile  /var/lib/ntp/drift/ntp.drift
+logfile    /var/log/ntp
+keys       /etc/ntp.keys
+
+trustedkey 1
+requestkey 1
+controlkey 1
+
+pool       0.pool.ntp.org     iburst

--- a/salt/default/time.sls
+++ b/salt/default/time.sls
@@ -1,0 +1,55 @@
+timezone_package:
+  pkg.installed:
+{% if grains['os_family'] == 'Suse' %}
+    - name: timezone
+{% else %}
+    - name: tzdata
+{% endif %}
+
+timezone_symlink:
+  file.symlink:
+    - name: /etc/localtime
+    - target: /usr/share/zoneinfo/{{ grains['timezone'] }}
+    - force: true
+    - require:
+      - pkg: timezone_package
+
+timezone_setting:
+  timezone.system:
+    - name: {{ grains['timezone'] }}
+    - utc: True
+    - require:
+      - file: timezone_symlink
+
+{% if grains['use_ntp'] %}
+
+{% if grains['osfullname'] == 'SLES' %}
+
+chrony_pkg:
+  pkg.installed:
+    - name: chrony
+
+chrony_enable_service:
+  service.running:
+    - name: chronyd
+    - enable: true
+
+{% elif grains['osfullname'] == 'Leap' %}
+
+ntp_pkg:
+  pkg.installed:
+    - name: ntp
+
+ntp_conf_file:
+  file.managed:
+    - name: /etc/ntp.conf
+    - source: salt://default/ntp.conf
+
+ntp_enable_service:
+  service.running:
+    - name: ntpd
+    - enable: true
+
+{% endif %}
+
+{% endif %}


### PR DESCRIPTION
## What does this PR change?

Experimentation proved we could have up to 5 minutes offset between the different machines deployed by sumaform. It's not only a problem for the test suite, but could hit the operation of SUSE Manager itself.

Corresponding issue: https://github.com/SUSE/spacewalk/issues/11934
Test suite part: uyuni-project/uyuni#2413

Implementation details:
* there's a new option, `use_ntp`, that is `true` by default, and that enables you to disable this code.
* the old `timezone` stuff moves to the new `time.sls` states file.
* CentOS and Ubuntu are not handled because they are already correct, as far as I can see

Concerns with current code:
* what happens with vanilla hosts? I guess we will get this stuff (?) as I call it from `minimal.sls`. Do we really want that?
* probably too many `use_ntp` here and there, I threw them a bit at random
