### PR TITLE
force installed version of importlib-metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ addons:
       - libvirt-daemon
 
 install:
+  - pip3 install 'importlib-metadata>=1.7.0'
   - pip3 install coala coala-bears
   - wget https://download.opensuse.org/repositories/systemsmanagement:/sumaform/openSUSE_Leap_15.1/x86_64/terraform.rpm
   - rpm2cpio ./terraform.rpm | cpio --extract --make-directories --verbose "./usr/bin/terraform"


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

    force installed version of importlib-metadata
    
    This library is a transitive dependency from coala.
    We are getting some conflicts on version number
    since another transitive library is depending on
    this one (stevedore)
