### PR TITLE
SLE 11 SP4 uses "service ntp start"

### DIFF
--- a/salt/default/time.sls
+++ b/salt/default/time.sls
@@ -25,6 +25,24 @@ timezone_setting:
 
 {% if grains['osfullname'] == 'SLES' %}
 
+{% if grains['osrelease'] == '11.4' %}
+
+ntp_pkg:
+  pkg.installed:
+    - name: ntp
+
+ntp_conf_file:
+  file.managed:
+    - name: /etc/ntp.conf
+    - source: salt://default/ntp.conf
+
+ntp_enable_service:
+  service.running:
+    - name: ntp
+    - enable: true
+
+{% else %}
+
 chrony_pkg:
   pkg.installed:
     - name: chrony
@@ -38,6 +56,8 @@ chrony_enable_service:
   service.running:
     - name: chronyd
     - enable: true
+
+{% endif %}
 
 {% elif grains['osfullname'] == 'Leap' %}
 


### PR DESCRIPTION
## What does this PR change?

follow-up of recent chrony and ntp additions, this time for SLE 11 SP4
