### PR TITLE
Do not remove firewall packages but disable it

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -202,8 +202,14 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
 
  * `client` module:
    * `auto_register`: automatically registers clients to the SUSE Manager Server. Set to `false` for manual registration
+   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
  * `minion` module:
    * `auto_connect_to_master`: automatically connects to the Salt Master. Set to `false` to manually configure
+   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
+ * `sshminion` module:
+   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
+ * `host` module:
+   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
  * `proxy` module:
    * `minion`: whether to configure this Proxy as a Salt minion. Set to `false` to have the Proxy set up as a traditional client
    * `auto_connect_to_master`: automatically connects to the Salt Master. Set to `false` to manually configure. Requires `minion` to be `true`
@@ -212,6 +218,7 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
    * `auto_configure`: automatically runs the `confure-proxy.sh` script which enables Proxy functionality. Set to `false` to run manually. Requires `auto_register` and `download_private_ssl_key`
    * `generate_bootstrap_script`: generates a bootstrap script for traditional clients and copies it in /pub. Set to `false` to generate manually. Requires `auto_configure`
    * `publish_private_ssl_key`: copies the private SSL key in /pub for cascaded Proxies to copy automatically. Set to `false` for manual distribution. Requires `download_private_ssl_key`
+   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
  * `server` module:
    * `auto_accept`: whether to automatically accept minion keys. Set to `false` to manually accept
    * `create_first_user`: whether to automatically create the first user (the SUSE Manager Admin)

--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -15,6 +15,7 @@ module "client" {
   connect_to_base_network       = true
   connect_to_additional_network = true
   roles                         = ["client"]
+  disable_firewall              = var.disable_firewall
   grains = {
     product_version = var.product_version
     mirror          = var.base_configuration["mirror"]
@@ -22,7 +23,7 @@ module "client" {
     auto_register   = var.auto_register
   }
 
-  image   = var.image
+  image             = var.image
   provider_settings = var.provider_settings
 }
 

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -31,6 +31,11 @@ variable "use_os_unreleased_updates" {
   default     = false
 }
 
+variable "disable_firewall" {
+  description = "whether to disable the built-in firewall, opening up all ports"
+  default     = true
+}
+
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
   default     = {}

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -12,7 +12,6 @@ module "host" {
   additional_certs              = var.additional_certs
   additional_packages           = var.additional_packages
   quantity                      = var.quantity
-  grains                        = var.grains
   swap_file_size                = var.swap_file_size
   ssh_key_path                  = var.ssh_key_path
   gpg_keys                      = var.gpg_keys
@@ -24,6 +23,9 @@ module "host" {
   provider_settings             = var.provider_settings
   additional_disk_size          = var.additional_disk_size
   volume_provider_settings      = var.volume_provider_settings
+
+  grains = merge({ disable_firewall = var.disable_firewall },
+  var.grains)
 }
 
 output "configuration" {

--- a/modules/host/variables.tf
+++ b/modules/host/variables.tf
@@ -22,6 +22,11 @@ variable "use_os_unreleased_updates" {
   default     = false
 }
 
+variable "disable_firewall" {
+  description = "whether to disable the built-in firewall, opening up all ports"
+  default     = true
+}
+
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
   default     = {}

--- a/modules/minion/main.tf
+++ b/modules/minion/main.tf
@@ -15,6 +15,7 @@ module "minion" {
   connect_to_base_network       = true
   connect_to_additional_network = true
   roles                         = var.roles
+  disable_firewall              = var.disable_firewall
 
   grains = merge({
     product_version        = var.product_version
@@ -29,7 +30,7 @@ module "minion" {
     evil_minion_slowdown_factor = var.evil_minion_slowdown_factor
   }, var.additional_grains)
 
-  image     = var.image
+  image             = var.image
   provider_settings = var.provider_settings
 }
 

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -56,6 +56,11 @@ variable "avahi_reflector" {
   default     = false
 }
 
+variable "disable_firewall" {
+  description = "whether to disable the built-in firewall, opening up all ports"
+  default     = true
+}
+
 variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default     = {}

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -29,6 +29,7 @@ module "proxy" {
   connect_to_base_network       = true
   connect_to_additional_network = true
   roles                         = ["proxy"]
+  disable_firewall              = var.disable_firewall
   grains = {
     product_version           = var.product_version
     mirror                    = var.base_configuration["mirror"]

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -16,6 +16,11 @@ variable "server_configuration" {
   description = "use module.<SERVER_NAME>.configuration, see README_ADVANCED.md"
 }
 
+variable "disable_firewall" {
+  description = "whether to disable the built-in firewall, opening up all ports"
+  default     = true
+}
+
 variable "minion" {
   description = "whether this Proxy should be onboarded as a minion"
   default     = true

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -30,7 +30,7 @@ module "server" {
   connect_to_base_network       = true
   connect_to_additional_network = false
   roles                         = var.register_to_server == null ? ["server"] : ["server", "minion"]
-
+  disable_firewall              = var.disable_firewall
   grains = {
     product_version        = var.product_version
     cc_username            = var.base_configuration["cc_username"]
@@ -49,7 +49,6 @@ module "server" {
     smt                            = var.smt
     server_username                = var.server_username
     server_password                = var.server_password
-    disable_firewall               = var.disable_firewall
     allow_postgres_connections     = var.allow_postgres_connections
     unsafe_postgres                = var.unsafe_postgres
     postgres_log_min_duration      = var.postgres_log_min_duration

--- a/modules/sshminion/main.tf
+++ b/modules/sshminion/main.tf
@@ -15,13 +15,14 @@ module "sshminion" {
   connect_to_base_network       = true
   connect_to_additional_network = true
   roles                         = ["sshminion"]
+  disable_firewall              = var.disable_firewall
   grains = {
     product_version = var.product_version
     mirror          = var.base_configuration["mirror"]
   }
 
 
-  image     = var.image
+  image             = var.image
   provider_settings = var.provider_settings
 }
 

--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -22,6 +22,11 @@ variable "use_os_unreleased_updates" {
   default     = false
 }
 
+variable "disable_firewall" {
+  description = "whether to disable the built-in firewall, opening up all ports"
+  default     = true
+}
+
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
   default     = {}

--- a/salt/default/firewall.sls
+++ b/salt/default/firewall.sls
@@ -1,0 +1,12 @@
+
+{% if grains.get('disable_firewall') | default(true, true)  %}
+
+disable_firewall:
+  service.dead:
+{% if grains.get('osmajorrelease', None)|int() == 15 %}
+    - name: firewalld
+{% else %}
+    - name: SuSEfirewall2
+{% endif %}
+    - enable: False
+{% endif %}

--- a/salt/default/minimal.sls
+++ b/salt/default/minimal.sls
@@ -3,6 +3,7 @@ include:
   - default.hostname
   {% endif %}
   - default.network
+  - default.firewall
   - default.avahi
   - default.time
   - repos

--- a/salt/default/network.sls
+++ b/salt/default/network.sls
@@ -62,10 +62,6 @@ ipv6_disable_all:
 
 {% endif %}
 
-remove_firewall_packages:
-  pkg.removed:
-    - pkgs: [firewalld, SuSEfirewall2]
-
 {% if grains['os_family'] == 'RedHat' and grains.get('osmajorrelease', None)|int() == 6 %}
 mdns_iptables:
   iptables.insert:

--- a/salt/server/firewall.sls
+++ b/salt/server/firewall.sls
@@ -11,18 +11,7 @@ firewall:
     - require:
       - sls: default
 
-{% if grains.get('disable_firewall') %}
-
-disable_firewall:
-  service.dead:
-{% if grains.get('osmajorrelease', None)|int() == 15 %}
-    - name: firewalld
-{% else %}
-    - name: SuSEfirewall2
-{% endif %}
-    - enable: False
-
-{% else %}
+{% if not grains.get('disable_firewall') | default(true, true)  %}
 
 firewall_configuration:
 {% if grains.get('osmajorrelease', None)|int() == 15 %}
@@ -39,6 +28,6 @@ firewall_configuration:
     - append_if_not_found: True
     - require:
       - pkg: firewall
-{% endif %}
 
+{% endif %}
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Instead of removing firewall packages which will be needed
by susemanager we now disable the firewall with a parameter
if it is needed.

PR relates to: https://github.com/uyuni-project/sumaform/pull/725

Solves: https://github.com/SUSE/spacewalk/issues/12012

## TODO
- [ ] Run CI with this branch and check results

