### PR TITLE
virthost: don't restart network

### DIFF
--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -77,13 +77,6 @@ ifcfg-br0:
         BRIDGE=yes
         BRIDGE_PORTS=eth0
 
-network-restart:
-  cmd.run:
-    - name: systemctl restart network
-    - require:
-        - file: ifcfg-br0
-        - file: ifcfg-eth0
-
 {% if grains['hypervisor']|lower() == 'xen' %}
 {% if grains['xen_disk_image'] %}
 disk-image-template-xenpv.qcow2:


### PR DESCRIPTION
## What does this PR change?

Restarting the network is suspecting to cause weird terraform failures
like the following:

remote command exited without exit status or exit signal
