### PR TITLE
Avoid upgrading on state re-apply

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -6,7 +6,7 @@ include:
 {% endif %}
 
 proxy-packages:
-  pkg.latest:
+  pkg.installed:
     - pkgs:
       {% if grains['osfullname'] == 'Leap' %}
       - patterns-uyuni_proxy

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -16,7 +16,7 @@ include:
   - server.tcpdump
 
 server_packages:
-  pkg.latest:
+  pkg.installed:
     - refresh: True
     {% if grains['osfullname'] == 'Leap' %}
     - name: patterns-uyuni_server

--- a/salt/server/initial_content.sls
+++ b/salt/server/initial_content.sls
@@ -161,7 +161,7 @@ ca_configuration_checksum:
 
 {% if grains.get('cloned_channels') %}
 spacewalk_utils:
-  pkg.latest:
+  pkg.installed:
     - name: spacewalk-utils
 
 {% for cloned_channel_set in grains.get('cloned_channels') %}


### PR DESCRIPTION
## What does this PR change?

As Uyuni/SUSE Manager Server/Proxy require more than updating packages in order for them to be upgraded, do not attempt just updating the packages.

In normal cases (first installations) no change in behavior is expected. When re-applying highstate at a later point in time, do not leave Servers/Proxies in a half-upgraded state.