### PR TITLE
Prevent from unbeatable defaults

### DIFF
--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -46,7 +46,7 @@ module "proxy" {
     repository_disk_size      = var.repository_disk_size
   }
 
-  image                    = var.image == "default" || var.product_version == "head" ? var.images[var.product_version] : var.image
+  image                    = var.image == "default" ? var.images[var.product_version] : var.image
   provider_settings        = var.provider_settings
   additional_disk_size     = var.repository_disk_size
   volume_provider_settings = var.volume_provider_settings

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -76,7 +76,7 @@ module "server" {
   }
 
 
-  image                    = var.image == "default" || var.product_version == "head" ? var.images[var.product_version] : var.image
+  image                    = var.image == "default" ? var.images[var.product_version] : var.image
   provider_settings        = var.provider_settings
   additional_disk_size     = var.repository_disk_size
   volume_provider_settings = var.volume_provider_settings


### PR DESCRIPTION
## What does this PR change?
Prevent from automatically overriding a value set in the main.tf.

`image` is initialized as 'default' for both server and proxy at
modules/server/variables.tf
modules/proxy/variables.tf

I don't see a need to add extra check for the product version:
if image == 'default' we will get the image matching the product version.

The problem with the extra check is as follows:
if the user sets the image as
image = 'foo' ; maybe for a quick test
and if product_version is 'head', then we will ignore the user value 'foo', taking
the default instead.

