### PR TITLE
Fix the minion repositories for SLE15 systems (all SPs)

### DIFF
--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -49,7 +49,7 @@ desktop_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
 
-{% if '3.2-nightly' in grains.get('product_version') or '4.0-nightly' in grains.get('product_version') %}
+{% if '3.2-nightly' in grains.get('product_version') or '4.0-nightly' in grains.get('product_version') or '4.1-nightly' in grains.get('product_version') %}
 python2_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/{{ sle_version_path }}/x86_64/product/

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -39,10 +39,12 @@ devel_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/update/
 
+{# The following "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" module #}
 desktop_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/product/
 
+{# The following "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" module #}
 desktop_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -39,6 +39,14 @@ devel_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/update/
 
+desktop_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/product/
+
+desktop_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
+
 {% if '3.2-nightly' in grains.get('product_version') or '4.0-nightly' in grains.get('product_version') %}
 python2_pool_repo:
   pkgrepo.managed:

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -12,30 +12,41 @@ containers_updates_repo:
 {% endif %}
 
 {% if '15' in grains['osrelease'] %}
+
+{% if grains['osrelease'] == '15' %}
+{% set sle_version_path = '15' %}
+{% elif grains['osrelease'] == '15.1' %}
+{% set sle_version_path = '15-SP1' %}
+{% elif grains['osrelease'] == '15.2' %}
+{% set sle_version_path = '15-SP2' %}
+{% elif grains['osrelease'] == '15.3' %}
+{% set sle_version_path = '15-SP3' %}
+{% endif %}
+
 containers_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15-SP1/x86_64/product/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/{{ sle_version_path }}/x86_64/product/
 
 containers_updates_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15-SP1/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/{{ sle_version_path }}/x86_64/update/
 
 devel_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Development-Tools/15-SP1/x86_64/product/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/product/
 
 devel_updates_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/15-SP1/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/update/
 
 {% if '3.2-nightly' in grains.get('product_version') or '4.0-nightly' in grains.get('product_version') %}
 python2_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/{{ sle_version_path }}/x86_64/product/
 
 python2_updates_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/{{ sle_version_path }}/x86_64/update/
 {% endif %}
 
 {% endif %}

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -49,7 +49,7 @@ desktop_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
 
-{% if '3.2-nightly' in grains.get('product_version') or '4.0-nightly' in grains.get('product_version') or '4.1-nightly' in grains.get('product_version') %}
+{% if '3.2-nightly' in grains.get('product_version') or '4.0-nightly' in grains.get('product_version') %}
 python2_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/{{ sle_version_path }}/x86_64/product/


### PR DESCRIPTION
## What does this PR change?

This PR fixes few issues on the repository definition for SLE15 (all SPs) minions:

- Set the right SP repository for the SLE modules (not always SP1)
- Add "SLE-Modules-Desktop-Applications" repository which is required by already added "SLE-Module-Development-Tools"

This PR should fix issues due a mix of SP1 and SP2 repos on SLE15SP2 minions, and also the issues on the Uyuni:Master testsuite regarding "applying highstate on build host".
