### PR TITLE
Cleanup repo metadata after repo changes in CentOS

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -428,6 +428,11 @@ tools_update_repo:
     - require:
       - cmd: uyuni_key
 {% endif %}
+
+clean_repo_metadata:
+  cmd.run:
+    - name: yum clean metadata
+
 {% endif %} {# grains['os_family'] == 'RedHat' #}
 
 {% if grains['os_family'] == 'Debian' and grains['os'] == 'Ubuntu' %}


### PR DESCRIPTION
## What does this PR change?

Differently than zypper, yum does not invalidate cached repo metadata if
a repo's URL changes, this can lead to situations in which package
downloading is attempted from the wrong URL.

This has been reproduced on 4.0-released traditional clients with the
centos7o image.
