### PR TITLE
Add RES8 repos to mirror

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -132,6 +132,8 @@ scc:
     - SLE-Manager-Tools15-Updates
     - RES-6-SUSE-Manager-Tools
     - RES-7-SUSE-Manager-Tools
+    - RES8-Manager-Tools-Pool
+    - RES8-Manager-Tools-Updates
     - Ubuntu-16.04-SUSE-Manager-Tools
     - Ubuntu-18.04-SUSE-Manager-Tools
   archs: [x86_64, amd64]
@@ -268,6 +270,10 @@ http:
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
     archs: [x86_64]
 
+  # RES 8 Manager Tools 4.0 devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/RES8-SUSE-Manager-Tools/SUSE_RES-8_Update_standard
+    archs: [x86_64]
+
   # Ubuntu 18.04 Manager Tools 4.0 devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04
     archs: [amd64]
@@ -290,6 +296,10 @@ http:
 
   # RES 7 Manager Tools 4.1 devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
+    archs: [x86_64]
+
+  # RES 8 Manager Tools 4.1 devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/RES8-SUSE-Manager-Tools/SUSE_RES-8_Update_standard
     archs: [x86_64]
 
   # Ubuntu 18.04 Manager Tools 4.1 devel
@@ -318,6 +328,10 @@ http:
 
   # RES 7 Manager Tools Head devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
+    archs: [x86_64]
+
+  # RES 8 Manager Tools Head devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/RES8-SUSE-Manager-Tools/SUSE_RES-8_Update_standard
     archs: [x86_64]
 
   # Ubuntu 18.04 Manager Tools Head devel

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -367,13 +367,24 @@ uyuni_key:
 tools_pool_repo:
   pkgrepo.managed:
     - humanname: tools_pool_repo
-    {% if grains.get('mirror') %}
+    {% if release >= 8 %}
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/RES/{{ release }}-CLIENT-TOOLS/x86_64/product/
+    {% elif grains.get('mirror') %}
     - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/RES{{ release }}-SUSE-Manager-Tools/x86_64/
     {% else %}
     - baseurl: http://download.suse.de/ibs/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS/x86_64/update/
     {% endif %}
     - require:
       - cmd: galaxy_key
+
+{% if release >= 8 %}
+tools_update_repo:
+  pkgrepo.managed:
+    - humanname: tools_update_repo
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS/x86_64/update/
+    - require:
+      - cmd: galaxy_key
+{% endif %}
 
 suse_res7_key:
   file.managed:


### PR DESCRIPTION
## What does this PR change?

Adds missing repos to support CentOS 8 minions/clients using the `centos8o` image with a mirror.
