### PR TITLE
Missing SLE15SP2 repo for desktop product

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -219,6 +219,8 @@ http:
   #  archs: [x86_64]
   #- url: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP2-Module-Containers-POOL-x86_64-Media1/
   #  archs: [x86_64]
+  #- url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Desktop-Applications-POOL-x86_64-Media1/
+  #  archs: [x86_64]
   #- url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Development-Tools-POOL-x86_64-Media1/
   #  archs: [x86_64]
   #- url: http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/GA:/TEST/images/repo/SLE-15-SP2-Module-Python2-POOL-x86_64-Media1/


### PR DESCRIPTION
## What does this PR change?

Missing SLE15SP2 repo for desktop product

Having such commented repos is done so we can just `s/SP2/SP3/g` that part when SP3 beta is ready, and uncomment the lines.
