### PR TITLE
Testsuite: openSCAP is only supported for Ubuntu minions from 18.04 on

### DIFF
--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -8,12 +8,9 @@ minion_cucumber_requisites:
   pkg.installed:
     - pkgs:
       - salt-minion
-      {%- if grains['os_family'] == 'Debian' %}
+      {%- if grains['os'] == 'Ubuntu' and grains['osrelease'] > '16.04' %}
       - libopenscap8
-      {%- if grains['os'] == 'Ubuntu' %}
       - ssg-debderived
-      {% else %}
-      - ssg-debian
       {% endif %}
       {% else %}
       - openscap-utils


### PR DESCRIPTION
Make conditions more precise to match current reality.
