### PR TITLE
Start qemu-ga at cloud-init stage on CentOS 6

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -34,6 +34,7 @@ runcmd:
   # HACK: cloud-init in CentOS 6 does not take care of the following
   - "sed -i -e's/without-password/yes/' /etc/ssh/sshd_config"
   - "service sshd restart"
+  - "service qemu-ga start"
 %{ endif }
 
 %{ if image == "centos7o" }


### PR DESCRIPTION
Apparently qemu-ga is installed but not started by default at least on CentOS 6, leading to terraform-provider-libvirt errors at deploy time.

This is a tentative fix.
