### PR TITLE
There is no man-db package on CentOS 6

### DIFF
--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -12,7 +12,7 @@ client_cucumber_requisites:
       - spacewalk-oscap
       - openscap-utils
       - mgr-cfg-actions
-      {% if grains['os'] == 'CentOS' %}
+      {% if grains['os'] == 'CentOS' and grains['osrelease'] > '6' %}
       - man-db
       {% else %}
       - man


### PR DESCRIPTION
## What does this PR change?

CentOS 6 has 2 packages for manual pages:
```
man man-pages
```
where CentOS 7 has 3:
```
man man-db man-pages
```
This PR avoids installing `man-db` on CentOS 6.

Note: the version comparaison is between two strings: it will probably use lexicographic order. HCL syntax is not clear in this respect... I took https://github.com/uyuni-project/sumaform/pull/755/files from Silvio as an example.
