### PR TITLE
Fix openscap on Ubuntu16

### DIFF
--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -8,9 +8,11 @@ minion_cucumber_requisites:
   pkg.installed:
     - pkgs:
       - salt-minion
-      {%- if grains['os'] == 'Ubuntu' and grains['osrelease'] > '16.04' %}
+      {%- if grains['os'] == 'Ubuntu' %}
+      {%- if grains['osrelease'] > '16.04' %}
       - libopenscap8
       - ssg-debderived
+      {% endif %}
       {% else %}
       - openscap-utils
       {% endif %}


### PR DESCRIPTION
## What does this PR change?

The previous if the statement was wrong.
As if the host was a Ubuntu and higher version than 16.04 it was installing something, but in the `else` case, if you had an Ubuntu with 16.04 it went through the else statement.
What it does now is, only install `openscap-utils` package if it is not a Ubuntu, and only  `libopenscap8` ,`ssg-debderived` if the version of Ubuntu is higher than 16.04.
