### PR TITLE
Force the start of qemu-guest-agent service

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -98,7 +98,7 @@ runcmd:
 %{ endif }
 
 %{ if image == "opensuse152o" }
-packages: ["qemu-guest-agent"]
+packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
 
 runcmd:
   - zypper removerepo --all

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -98,7 +98,7 @@ runcmd:
 %{ endif }
 
 %{ if image == "opensuse152o" }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+packages: ["qemu-guest-agent"]
 
 runcmd:
   - zypper removerepo --all
@@ -138,6 +138,10 @@ zypper:
       autorefresh: 1
 
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+
+runcmd:
+  - service qemu-guest-agent start
+
 %{ endif }
 
 %{ if image == "sles15sp1o" }
@@ -196,6 +200,7 @@ runcmd:
   # HACK: cloud-init in Ubuntu does not take care of the following
   - "sed -i -e's/prohibit-password/yes/' /etc/ssh/sshd_config"
   - systemctl restart sshd
+  - service qemu-guest-agent start
 
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ endif }
@@ -243,6 +248,7 @@ runcmd:
   # HACK: cloud-init in Ubuntu does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
+  - service qemu-guest-agent start
 
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ endif }


### PR DESCRIPTION
## What does this PR change?

Some VMs are not deployed on my main.tf, showing this error:

```
Error: Error: couldn't retrieve IP address of domain.Please check following: 
1) is the domain running proplerly? 
2) has the network interface an IP address? 
3) Networking issues on your libvirt setup? 
 4) is DHCP enabled on this Domain's network? 
5) if you use bridge network, the domain should have the pkg qemu-agent installed 
IMPORTANT: This error is not a terraform libvirt-provider error, but an error caused by your KVM/libvirt infrastructure configuration/setup 
 timeout while waiting for state to become 'all-addresses-obtained' (last state: 'waiting-addresses', timeout: 5m0s)

  on /home/jenkins/jenkins-build/workspace/manager-4.0-qam-setup-cucumber/results/sumaform/backend_modules/libvirt/host/main.tf line 65, in resource "libvirt_domain" "domain":
  65: resource "libvirt_domain" "domain" {
``` 

VMs not deployed:
```
sles15-sshminion
ubuntu1604-sshminion
ubuntu2004-minion
controller
```

Might it fix the issue?
I tried from the workspace of my Jenkins job, and apparently didn't work, but I want to share it with you to discuss it.