### PR TITLE
Default to stable Uyuni tools for Ubuntu hosts

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -500,7 +500,7 @@ tools_update_repo:
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu' + short_release + '-Uyuni-Client-Tools/xUbuntu_' + release %}
-{% elif 'released' in grains.get('product_version') | default('', true) %}
+{% else %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu' + short_release + '-Uyuni-Client-Tools/xUbuntu_' + release %}
 {% endif %}
     - name: deb {{ tools_repo_url }} /


### PR DESCRIPTION
Prevents a traceback on vanilla hosts

## What does this PR change?

Fixes #764
