### PR TITLE
Update libvirt readme

### DIFF
--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -11,7 +11,8 @@
      - change the `network_name` variable declaration to `null`
      - optionally specify fixed MAC addresses by adding `mac = "CA:FE:BA:BE:00:01"` lines to VM modules
    - if other sumaform users deploy to the same host, or different bridged hosts in the same network, uncomment the `name_prefix` variable declaration in the `base` module to specify a unique prefix for your VMs
- - complete the `cc_password` variable in the `base` module
+ - if you have a [SUSE Customer Center (SCC) account](https://scc.suse.com/), fill the in the credentials in the `cc_username` and `cc_password` variables in the `base` module
+   - alternatively, if you don't have an SCC account, you may need to update source repositories under [sumaform/salt/repos](https://github.com/uyuni-project/sumaform/tree/master/salt/repos) depending on what VMs you want to provision
  - make sure that:
    - either your target libvirt host has a storage pool named `default`
    - or you [create one](https://documentation.suse.com/sles/12-SP4/html/SLES-all/cha-libvirt-storage.html#sec-libvirt-storage-vmm-addpool)

--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -12,7 +12,6 @@
      - optionally specify fixed MAC addresses by adding `mac = "CA:FE:BA:BE:00:01"` lines to VM modules
    - if other sumaform users deploy to the same host, or different bridged hosts in the same network, uncomment the `name_prefix` variable declaration in the `base` module to specify a unique prefix for your VMs
  - if you have a [SUSE Customer Center (SCC) account](https://scc.suse.com/), fill the in the credentials in the `cc_username` and `cc_password` variables in the `base` module
-   - alternatively, if you don't have an SCC account, you may need to update source repositories under [sumaform/salt/repos](https://github.com/uyuni-project/sumaform/tree/master/salt/repos) depending on what VMs you want to provision
  - make sure that:
    - either your target libvirt host has a storage pool named `default`
    - or you [create one](https://documentation.suse.com/sles/12-SP4/html/SLES-all/cha-libvirt-storage.html#sec-libvirt-storage-vmm-addpool)


### PR DESCRIPTION
Currently, there's no information about what `cc_username` and `cc_password` stand for. Without knowing the context, it's difficult to search for and figure out what they mean. This PR adds a small reference to contextualize the terms.

## What does this PR change?

This PR updates the libvirt configuration readme with background context.