### PR TITLE
Fix: add section to troubleshoot Avahi and mDNS

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -30,6 +30,7 @@ Check that:
   - on SUSE systems check YaST -> Security and Users -> Firewall -> Zones -> public, "mdns" should appear on the list on the right
  - avahi is installed and running
    - typically you can check this via systemd: `systemctl status avahi-daemon`
+ - Avahi is capable of resolving the host you are trying to reach: `avahi-resolve -n mbologna-uyuni.tf.local`
  - mdns is configured in glibc's Name Server Switch configuration file
 
 In `/etc/nsswitch.conf` you should see a `hosts:` line that looks like the following:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -39,6 +39,15 @@ hosts:          files mdns [NOTFOUND=return] dns
 ```
 `mdns` (optionally suffixed with `4` for IPv4-only or `6` for IPv6-only) should be present in this line. If it is not, add it.
 
+Starting with `nss-mdns` version 0.14.1, you also need to populate `/etc/mdns.allow` with:
+
+```
+.local.
+.local
+```
+
+`mdns.allow` is required to [force all .local domains to be resolved regardless of label count or unicast SOA records](https://github.com/lathiat/nss-mdns/blob/master/README.md#etcmdnsallow).
+
 ## Q: how can I work around slowness in resolution of `tf.local` mDNS/Zeroconf/Bonjour/Avahi names?
 
 If there is a 5-second delay on any name resolution (or ping) between Avahi hosts, a likely cause is that ipv6 is enabled on the VMs (that is the default setting) but the network is blocking ipv6 traffic.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -28,9 +28,9 @@ Could not resolve hostname server.tf.local: Name or service not known
 Check that:
  - your firewall is not blocking UDP port 5353
   - on SUSE systems check YaST -> Security and Users -> Firewall -> Zones -> public, "mdns" should appear on the list on the right
- - avahi is installed and running
+ - Avahi is installed and running
    - typically you can check this via systemd: `systemctl status avahi-daemon`
- - Avahi is capable of resolving the host you are trying to reach: `avahi-resolve -n mbologna-uyuni.tf.local`
+ - Avahi is capable of resolving the host you are trying to reach: `avahi-resolve -n uyuni.tf.local`
  - mdns is configured in glibc's Name Server Switch configuration file
 
 In `/etc/nsswitch.conf` you should see a `hosts:` line that looks like the following:
@@ -42,11 +42,11 @@ hosts:          files mdns [NOTFOUND=return] dns
 Starting with `nss-mdns` version 0.14.1, you also need to populate `/etc/mdns.allow` with:
 
 ```
-.local.
 .local
+.tf.local
 ```
 
-`mdns.allow` is required to [force all .local domains to be resolved regardless of label count or unicast SOA records](https://github.com/lathiat/nss-mdns/blob/master/README.md#etcmdnsallow).
+`mdns.allow` is required to [force all multicast DNS domains to be resolved regardless of label count or unicast SOA records](https://github.com/lathiat/nss-mdns/blob/master/README.md#etcmdnsallow).
 
 ## Q: how can I work around slowness in resolution of `tf.local` mDNS/Zeroconf/Bonjour/Avahi names?
 


### PR DESCRIPTION
## What does this PR change?

I was having resolution problems with Avahi on an openSUSE 15.2 host trying to resolve a sumaformed Uyuni server:

```
opensuse # avahi-resolve -n uyuni.tf.local
uyuni.tf.local 192.168.122.154
# ping uyuni.tf.local
ping: uyuni.tf.local: Name or service not known
# ping 192.168.122.154
PING 192.168.122.154 (192.168.122.154) 56(84) bytes of data.
64 bytes from 192.168.122.154: icmp_seq=1 ttl=64 time=0.245 ms
```

The problem disappears when I change Avahi configuration in the Uyuni host to use the first-level domain `local` (instead of `tf.local`).

Turns out that in the newest version of `nss-mdns` (shipping with OpenSUSE 15.2), second-level `.local` domains must be explicitly allowed to be resolved in `/etc/mdns.allow` AND `mdns` (not `mdns_minimal`) must be used in `nsswitch.conf`.
The latter is already covered in the troubleshooting, I took care of adding the former information into the docs.

Upstream issue: https://github.com/lathiat/nss-mdns/issues/64
Upstream resolution (linked in sumaform docs): https://github.com/lathiat/nss-mdns/blob/master/README.md#etcmdnsallow