### PR TITLE
Update main.tf.ssh.example

### DIFF
--- a/main.tf.ssh.example
+++ b/main.tf.ssh.example
@@ -27,7 +27,7 @@ module "server" {
   // if you want to use two networks
 
   provider_settings = {
-    hostname = "192.168.1.1"
+    host = "192.168.1.1"
   }
 }
 
@@ -41,7 +41,7 @@ module "client" {
   // see modules/client/variables.tf for possible values
 
   provider_settings = {
-    hostname = "192.168.1.2"
+    host = "192.168.1.2"
   }
 }
 
@@ -55,6 +55,6 @@ module "minion" {
   // see modules/minion/variables.tf for possible values
 
   provider_settings = {
-    hostname = "192.168.1.3"
+    host = "192.168.1.3"
   }
 }


### PR DESCRIPTION
As covered [in the SSH setup docs](https://github.com/uyuni-project/sumaform/tree/master/backend_modules/ssh#host-modules), the field name is actually `host`, not `hostname`. While `hostname` might be technically better, `host` is currently the expected key.

## What does this PR change?

Fix sample configuration file so that it's usable out of the box.