### PR TITLE
WIP Use mirror in cloudinit too

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -27,7 +27,9 @@ locals {
 data "template_file" "user_data" {
   template = file("${path.module}/user_data.yaml")
   vars = {
-    image = var.image
+    image             = var.image
+    use_mirror_images = var.base_configuration["use_mirror_images"]
+    mirror            = var.base_configuration["mirror"]
   }
 }
 

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -109,7 +109,7 @@ zypper:
   repos:
     - id: os_pool_repo
       name: os_pool_repo
-      baseurl: http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
       enabled: 1
       autorefresh: 1
 
@@ -121,7 +121,7 @@ zypper:
   repos:
     - id: os_pool_repo
       name: os_pool_repo
-      baseurl: http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP5/x86_64/product/
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-SERVER/12-SP5/x86_64/product/
       enabled: 1
       autorefresh: 1
 
@@ -133,7 +133,7 @@ zypper:
   repos:
     - id: os_pool_repo
       name: os_pool_repo
-      baseurl: http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product
       enabled: 1
       autorefresh: 1
 
@@ -145,12 +145,12 @@ zypper:
   repos:
     - id: os_pool_repo
       name: os_pool_repo
-      baseurl: http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product
       enabled: 1
       autorefresh: 1
     - id: module_server_applications_pool_repo
       name: module_server_applications_pool_repo
-      baseurl: http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product
       enabled: 1
       autorefresh: 1
 
@@ -162,7 +162,7 @@ zypper:
   repos:
     - id: os_pool_repo
       name: os_pool_repo
-      baseurl: http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product
       enabled: 1
       autorefresh: 1
 


### PR DESCRIPTION
## What does this PR change?

This PR changes `user_data.yaml` to use the mirror in the case of libvirt backend, like we already do with aws backend.
