### PR TITLE
Allow unauthenticated packages on ubuntu 16.04

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -171,6 +171,12 @@ packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
 
 %{ if image == "ubuntu1604o" }
 apt:
+  conf: |
+    APT {
+      Get {
+        "AllowUnauthenticated" true;
+      };
+    };
   sources:
     tools_pool_repo:
       source: "deb http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu1604-Uyuni-Client-Tools/xUbuntu_16.04 /"


### PR DESCRIPTION
## What does this PR change?

This PR solves a problem with ubuntu 16.04 official image:
```
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
```