### PR TITLE
Upgrade controller image to opensuse152o

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -83,7 +83,7 @@ module "controller" {
   }
 
 
-  image   = "opensuse150o"
+  image   = "opensuse152o"
   provider_settings = var.provider_settings
 }
 

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -60,12 +60,12 @@ cucumber_requisites:
 chromium_fixed_version:
   pkg.installed:
   - name: chromium
-  - version: 73.0.3683.75
+  - version: 85.0.4183.121
 
 chromedriver_fixed_version:
   pkg.installed:
   - name: chromedriver
-  - version: 73.0.3683.75
+  - version: 85.0.4183.121
 
 create_syslink_for_chromedriver:
   file.symlink:


### PR DESCRIPTION
## What does this PR change?

This PR upgrades the controller default image from opensuse150o toopensuse152o

It might need additional packages here:
https://github.com/uyuni-project/sumaform/blob/master/backend_modules/libvirt/host/user_data.yaml#L100-L101

And upgrade versions here:
https://github.com/uyuni-project/sumaform/blob/master/salt/controller/init.sls#L60-L68

But let's give it a try first without any more change.