### PR TITLE
Revert "Upgrade controller image to opensuse152o"

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -83,7 +83,7 @@ module "controller" {
   }
 
 
-  image   = "opensuse152o"
+  image   = "opensuse150o"
   provider_settings = var.provider_settings
 }
 

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -60,12 +60,12 @@ cucumber_requisites:
 chromium_fixed_version:
   pkg.installed:
   - name: chromium
-  - version: 85.0.4183.121
+  - version: 73.0.3683.75
 
 chromedriver_fixed_version:
   pkg.installed:
   - name: chromedriver
-  - version: 85.0.4183.121
+  - version: 73.0.3683.75
 
 create_syslink_for_chromedriver:
   file.symlink:


### PR DESCRIPTION
Reverts uyuni-project/sumaform#779

We have problems on Leap 15.2 not supporting VA

suma-41-ctl:~/spacewalk/testsuite # /usr/lib64/chromium/chromium --no-sandbox --disable-dev-shm-usage --headless --disable-gpu-sandbox
[1015/154337.242264:ERROR:vaapi_wrapper.cc(422)] Could not get a valid VA display
