### PR TITLE
Reduce the content checkout from github to the ctl and checkout last 100 commits

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -129,7 +129,12 @@ spacewalk_git_repository:
 {%-     set url = 'https://github.com/SUSE/spacewalk.git' %}
 {%-   endif %}
 {%- endif %}
-    - name: git clone --depth 1 {{ url }} -b {{ branch }} /root/spacewalk
+    - name: |
+        git clone --depth 100 --no-checkout --branch {{ branch }} {{ url }} /root/spacewalk
+        cd /root/spacewalk
+        git sparse-checkout init --cone
+        git sparse-checkout set testsuite
+        git checkout
     - creates: /root/spacewalk
     - require:
       - pkg: cucumber_requisites


### PR DESCRIPTION
## What does this PR change?

Inside the controller, we only make use of the `testsuite` folder, so there is no need to download the rest of the repository.

Also, we increase the depth of the shallow-clone to 100 commits, so we can compare and navigate from the last 100 commits.
We need that in order to extract, during our test suite pipeline the product commit changes between to test suite executions (Internal card: https://github.com/SUSE/spacewalk/issues/13630)

Our current shallow clone takes about 354M, with these changes the repository folder will size around 60M.