### PR TITLE
Changing selinux to permissive in CentOS official images

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -35,6 +35,14 @@ runcmd:
   - "sed -i -e's/without-password/yes/' /etc/ssh/sshd_config"
   - "service sshd restart"
   - "service qemu-ga start"
+  
+write_files:
+  - content: |
+    SELINUX=permissive
+    SELINUXTYPE=targeted
+  owner: root:root
+  path: /etc/sysconfig/selinux
+  permissions: '0644'
 %{ endif }
 
 %{ if image == "centos7o" }
@@ -58,6 +66,14 @@ yum_repos:
     name: epel
 
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+
+write_files:
+  - content: |
+    SELINUX=permissive
+    SELINUXTYPE=targeted
+  owner: root:root
+  path: /etc/sysconfig/selinux
+  permissions: '0644'
 %{ endif }
 
 %{ if image == "centos8o" }
@@ -81,6 +97,14 @@ yum_repos:
     name: epel
 
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+
+write_files:
+  - content: |
+    SELINUX=permissive
+    SELINUXTYPE=targeted
+  owner: root:root
+  path: /etc/sysconfig/selinux
+  permissions: '0644'
 %{ endif }
 
 %{ if image == "opensuse150o" }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -37,7 +37,7 @@ runcmd:
   - "service qemu-ga start"
   
 write_files:
-  - content: |
+  content: |
     SELINUX=permissive
     SELINUXTYPE=targeted
   owner: root:root
@@ -68,7 +68,7 @@ yum_repos:
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 
 write_files:
-  - content: |
+  content: |
     SELINUX=permissive
     SELINUXTYPE=targeted
   owner: root:root
@@ -99,7 +99,7 @@ yum_repos:
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 
 write_files:
-  - content: |
+  content: |
     SELINUX=permissive
     SELINUXTYPE=targeted
   owner: root:root

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -35,7 +35,7 @@ runcmd:
   - "sed -i -e's/without-password/yes/' /etc/ssh/sshd_config"
   - "service sshd restart"
   - "service qemu-ga start"
-  
+
 write_files:
   content: |
     SELINUX=permissive


### PR DESCRIPTION
## What does this PR change?

Changing `selinux` from enforcing to permissive in CentOS official images.
As we were having problems with that, @hustodemon knows more about it.

Note: 
Still not tested, I just created the PR together with the branch :)

