### PR TITLE
Add tftpboot-installation package on server

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -108,6 +108,7 @@ testsuite_packages:
       - salt-ssh
       - wget
       - OpenIPMI
+      - tftpboot-installation-SLE-15-SP2-x86_64
     - require:
       - sls: repos
 


### PR DESCRIPTION
## What does this PR change?

In order to test provisioning of VMs we need the TFTP images deployed on
the testsuite server.

