### PR TITLE
Upgrade controller image to opensuse152o. Upgrade chromium and chrome…

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -98,7 +98,7 @@ runcmd:
 %{ endif }
 
 %{ if image == "opensuse152o" }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+packages: ["qemu-guest-agent"]
 
 runcmd:
   - zypper removerepo --all

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -83,7 +83,7 @@ module "controller" {
   }
 
 
-  image   = "opensuse150o"
+  image   = "opensuse152o"
   provider_settings = var.provider_settings
 }
 

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -45,7 +45,6 @@ cucumber_requisites:
       - apache2-worker
       - cantarell-fonts
       - git-core
-      - wget
       - aaa_base-extras
       - zlib-devel
       - libxslt-devel
@@ -57,15 +56,13 @@ cucumber_requisites:
     - require:
       - sls: repos
 
-chromium_fixed_version:
+install_chromium:
   pkg.installed:
   - name: chromium
-  - version: 73.0.3683.75
 
-chromedriver_fixed_version:
+install_chromedriver:
   pkg.installed:
   - name: chromedriver
-  - version: 73.0.3683.75
 
 create_syslink_for_chromedriver:
   file.symlink:


### PR DESCRIPTION
## What does this PR change?

This PR upgrades:
- The controller default image from opensuse150o to opensuse152o
- chromium and chromedriver versions depends always on the OS image used, so it doesn't make sense to fix the version
- Has a dependency with the test suite, which must allow non-compliance W3C actions https://github.com/uyuni-project/uyuni/pull/2786
- Also, for a reason that I couldn't understand it fails in cloud-init installing some packages, letting only what we have in opensuse151o works fine, as you can see here: https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-cucumber-NUE/165/parameters/