### PR TITLE
Use latest release of minima on server

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -50,8 +50,8 @@ test_vcenter_file:
 minima:
   archive.extracted:
     - name: /usr/bin
-    - source: https://github.com/moio/minima/releases/download/v0.4/minima-linux-amd64.tar.gz
-    - source_hash: https://github.com/moio/minima/releases/download/v0.4/minima-linux-amd64.tar.gz.sha512
+    - source: https://github.com/uyuni-project/minima/releases/download/v0.11/minima-linux-amd64.tar.gz
+    - source_hash: https://github.com/uyuni-project/minima/releases/download/v0.11/minima-linux-amd64.tar.gz.sha512
     - archive_format: tar
     - enforce_toplevel: false
     - keep: True


### PR DESCRIPTION
## What does this PR change?

The SUSE Manager server uses minima to get a copy of the test packages

moio -> uyuni-project
v0.4 -> v0.11

Note: it would be better to get test packages directly, as already stated in SUSE/spacewalk#9429 . This would remove the minima dependency as a side effect.
