### PR TITLE
Reduce noise in the sumaform log

### DIFF
--- a/salt/wait_for_salt.sh
+++ b/salt/wait_for_salt.sh
@@ -4,7 +4,7 @@
 
 for i in {0..100}
 do
-  if [[ `salt-call --help` ]]; then
+  if salt-call --help &>/dev/null; then
     break
   fi
   echo "Waiting for salt to be installed..."


### PR DESCRIPTION
## What does this PR change?
This prevents from lines as the following one in the output:
... minion.module.host.null_resource.provisioning[0] (remote-exec): /root/salt/wait_for_salt.sh: line 7: salt-call: command not found

- salt/wait_for_salt.sh:
Redirect both, stdout and stderr to /dev/null.

