### PR TITLE
Let the test suite install OpenSCAP packages

### DIFF
--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -9,22 +9,17 @@ client_cucumber_requisites:
     - pkgs:
       - spacewalk-client-setup
       - spacewalk-check
-      - spacewalk-oscap
-      - openscap-utils
       - mgr-cfg-actions
       - wget
     - require:
       - sls: default
 
-{% if grains['os'] == 'SUSE' %}
+{% if grains['os'] == 'SUSE' and '12' in grains['osrelease'] %}
 
 suse_client_cucumber_requisites:
   pkg.installed:
     - pkgs:
-      - openscap-content
-      {% if '12' in grains['osrelease'] %}
       - aaa_base-extras
-      {% endif %}
     - require:
       - sls: repos
 

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -8,32 +8,21 @@ minion_cucumber_requisites:
   pkg.installed:
     - pkgs:
       - salt-minion
-      {%- if grains['os'] == 'Ubuntu' %}
-      {%- if grains['osrelease'] > '16.04' %}
-      - libopenscap8
-      - ssg-debderived
-      {% endif %}
-      {% else %}
-      - openscap-utils
-      {% endif %}
       - wget
     - require:
       - sls: default
 
 {% if grains['os'] == 'SUSE' %}
+{% if '12' in grains['osrelease'] or '15' in grains['osrelease']%}
 
 suse_minion_cucumber_requisites:
   pkg.installed:
     - pkgs:
-      - openscap-content
-      {% if '12' in grains['osrelease'] or '15' in grains['osrelease']%}
       - aaa_base-extras
       - ca-certificates
-      {% endif %}
     - require:
       - sls: repos
 
-{% if '12' in grains['osrelease'] or '15' in grains['osrelease'] %}
 registry_certificate:
   file.managed:
     - name: /etc/pki/trust/anchors/registry.mgr.suse.de.pem


### PR DESCRIPTION
## What does this PR change?

The openSCAP packages were installed half in sumaform, half in the test suite, leading to a huge mess.

This situation is due to the fact that the QAM test suite does not use sumaform's `testsuite` module. But besides this immediate reason, it has always been wrong to let sumaform prepare ulterior processings. sumaform should prepare machines as pristine as possible.

This PR lets the test suite do all the job. See uyuni-project/uyuni#2880 for implementation on test suite side.
