### PR TITLE
Add 4.2-beta to sumaform

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -10,6 +10,7 @@ Legal values for released software are:
  * `3.2-released`   (latest released Maintenance Update for SUSE Manager 3.2 and Tools)
  * `4.0-released`   (latest released Maintenance Update for SUSE Manager 4.0 and Tools)
  * `4.1-released`   (latest released Maintenance Update for SUSE Manager 4.1 and Tools)
+ * `4.2-beta`       (beta releases for SUSE Manager 4.2 and Tools)
  * `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
 
 Legal values for work-in-progress software are:

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -6,6 +6,7 @@ variable "testsuite-branch" {
     "4.0-nightly"    = "Manager-4.0"
     "4.1-released"   = "Manager-4.1"
     "4.1-nightly"    = "Manager-4.1"
+    "4.2-beta"       = "master"
     "head"           = "master"
     "uyuni-master"   = "master"
     "uyuni-released" = "master"

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -62,7 +62,7 @@ variable "host_settings" {
 
 // server
 variable "product_version" {
-  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, 4.1-nightly, 4.1-released, head, test, uyuni-released"
+  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, 4.1-nightly, 4.1-released, 4.2-beta, head, test, uyuni-released"
   type        = string
 }
 

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -6,6 +6,7 @@ variable "images" {
     "4.0-nightly"    = "sles15sp1o"
     "4.1-released"   = "sles15sp2o"
     "4.1-nightly"    = "sles15sp2o"
+    "4.2-beta"       = "sles15sp3o"
     "head"           = "sles15sp3o"
     "uyuni-master"   = "opensuse152o"
     "uyuni-released" = "opensuse152o"

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, 4.1-released, 4.1-nightly, head"
+  description = "One of: 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, 4.1-released, 4.1-nightly, 4.2-beta, head"
   type        = string
 }
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -6,6 +6,7 @@ variable "images" {
     "4.0-nightly"    = "sles15sp1o"
     "4.1-released"   = "sles15sp2o"
     "4.1-nightly"    = "sles15sp2o"
+    "4.2-beta"       = "sles15sp3o"
     "head"           = "sles15sp3o"
     "uyuni-master"   = "opensuse152o"
     "uyuni-released" = "opensuse152o"

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, 4.1-released, 4.1-nightly, head, test, uyuni-released"
+  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, 4.1-released, 4.1-nightly, 4.2-beta, head, test, uyuni-released"
   type        = string
 }
 

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -87,6 +87,22 @@ scc:
     - SLE-Module-DevTools15-SP2-Updates
     - SLE-Module-Python2-15-SP2-Pool
     - SLE-Module-Python2-15-SP2-Update
+    # SLE 15-SP3 Products
+    - SLE-Product-SLES15-SP3-Pool
+    - SLE-Product-SLES15-SP3-Updates
+    # SLE 15-SP3 Basic Modules
+    - SLE-Module-Basesystem15-SP3-Pool
+    - SLE-Module-Basesystem15-SP3-Updates
+    - SLE-Module-Server-Applications15-SP3-Pool
+    - SLE-Module-Server-Applications15-SP3-Updates
+    - SLE-Module-Web-Scripting15-SP3-Pool
+    - SLE-Module-Web-Scripting15-SP3-Updates
+    - SLE-Module-Desktop-Applications15-SP3-Pool
+    - SLE-Module-Desktop-Applications15-SP3-Updates
+    - SLE-Module-DevTools15-SP3-Pool
+    - SLE-Module-DevTools15-SP3-Updates
+    - SLE-Module-Python2-15-SP3-Pool
+    - SLE-Module-Python2-15-SP3-Update
     # SLE Legacy Module
     - SLE-Module-Legacy12-Pool
     - SLE-Module-Legacy12-Updates
@@ -110,6 +126,10 @@ scc:
     - SLE-Product-SUSE-Manager-Server-4.1-Updates
     - SLE-Module-SUSE-Manager-Server-4.1-Pool
     - SLE-Module-SUSE-Manager-Server-4.1-Updates
+    - SLE-Product-SUSE-Manager-Server-4.2-Pool
+    - SLE-Product-SUSE-Manager-Server-4.2-Updates
+    - SLE-Module-SUSE-Manager-Server-4.2-Pool
+    - SLE-Module-SUSE-Manager-Server-4.2-Updates
     # SUSE Manager Proxy
     - SUSE-Manager-Proxy-3.2-Pool
     - SUSE-Manager-Proxy-3.2-Updates
@@ -121,6 +141,10 @@ scc:
     - SLE-Product-SUSE-Manager-Proxy-4.1-Updates
     - SLE-Module-SUSE-Manager-Proxy-4.1-Pool
     - SLE-Module-SUSE-Manager-Proxy-4.1-Updates
+    - SLE-Product-SUSE-Manager-Proxy-4.2-Pool
+    - SLE-Product-SUSE-Manager-Proxy-4.2-Updates
+    - SLE-Module-SUSE-Manager-Proxy-4.2-Pool
+    - SLE-Module-SUSE-Manager-Proxy-4.2-Updates
     # Retail Branch Server
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Pool
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Updates
@@ -130,6 +154,10 @@ scc:
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Updates
     - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Pool
     - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Updates
+    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.2-Pool
+    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.2-Updates
+    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.2-Pool
+    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.2-Updates
     # SUSE Manager Tools
     - SLES11-SP4-SUSE-Manager-Tools
     - SLE-Manager-Tools12-Pool
@@ -142,6 +170,20 @@ scc:
     - RES8-Manager-Tools-Updates
     - Ubuntu-16.04-SUSE-Manager-Tools
     - Ubuntu-18.04-SUSE-Manager-Tools
+    - Ubuntu-20.04-SUSE-Manager-Tools
+    # SUSE Manager Beta Tools
+    - SLES11-SP4-SUSE-Manager-Tools-Beta
+    - SLE-Manager-Tools12-Pool-Beta
+    - SLE-Manager-Tools12-Updates-Beta
+    - SLE-Manager-Tools15-Pool-Beta
+    - SLE-Manager-Tools15-Updates-Beta
+    - RES-6-SUSE-Manager-Tools-Beta
+    - RES-7-SUSE-Manager-Tools-Beta
+    - RES8-Manager-Tools-Pool-Beta
+    - RES8-Manager-Tools-Updates-Beta
+    - Ubuntu-16.04-SUSE-Manager-Tools-Beta
+    - Ubuntu-18.04-SUSE-Manager-Tools-Beta
+    - Ubuntu-20.04-SUSE-Manager-Tools-Beta
   archs: [x86_64, amd64]
 
 http:

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -68,20 +68,26 @@ test_update_repo:
 tools_pool_repo:
   pkgrepo.managed:
     {% if grains.get('mirror') %}
+    {% if 'beta' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-SUSE-Manager-Tools-BETA/sle-11-x86_64/
+    {% else %}
     - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-SUSE-Manager-Tools/sle-11-x86_64/
+    {% endif %}
+    {% else %}
+    {% if 'beta' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://euklid.nue.suse.com/mirror/SuSE/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SP4-CLIENT-TOOLS-BETA/x86_64/update/
     {% else %}
     - baseurl: http://euklid.nue.suse.com/mirror/SuSE/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SP4-CLIENT-TOOLS/x86_64/update/
     {% endif %}
+    {% endif %}
 
 {% if 'nightly' in grains.get('product_version') | default('', true) %}
-
 tools_additional_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse/
     - priority: 98
 
 {% elif 'head' in grains.get('product_version') | default('', true) %}
-
 tools_additional_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse/
@@ -205,11 +211,19 @@ test_update_repo:
 {% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %}
 tools_pool_repo:
   pkgrepo.managed:
+    {% if 'beta' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/12-BETA/x86_64/product/
+    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/
+    {% endif %}
 
 tools_update_repo:
   pkgrepo.managed:
+    {% if 'beta' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/12-BETA/x86_64/update/
+    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/
+    {% endif %}
 {% else %}
 tools_pool_repo:
   pkgrepo.managed:
@@ -245,11 +259,19 @@ tools_additional_repo:
 {% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %}
 tools_pool_repo:
   pkgrepo.managed:
+    {% if 'beta' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15-BETA/x86_64/product/
+    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/
+    {% endif %}
 
 tools_update_repo:
   pkgrepo.managed:
+    {% if 'beta' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15-BETA/x86_64/update/
+    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/
+    {% endif %}
 {% else %}
 tools_pool_repo:
   pkgrepo.managed:
@@ -262,6 +284,7 @@ tools_additional_repo:
   pkgrepo.managed:
   - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
   - priority: 98
+
 {% elif 'head' in grains.get('product_version') | default('', true) %}
 tools_additional_repo:
   pkgrepo.managed:
@@ -315,10 +338,13 @@ os_update_repo:
 {% endif %} {# '15.2' == grains['osrelease'] #}
 
 {% if '15.3' == grains['osrelease'] %}
-# Moving target, only until SLE15SP3 GA is ready
+# Moving target, only until SLE15SP3 GA is ready. Remove this block when we start using GA.
+{% if '4.2-nightly' in grains['product_version'] %}
 os_movingtarget_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP3:/GA:/TEST/images/repo/SLE-15-SP3-Module-Basesystem-POOL-x86_64-Media1/
+{% endif %} {# if '4.2-nightly' in grains['product_version'] #}
+# Moving target, only until SLE15SP3 GA is ready
 
 os_pool_repo:
   pkgrepo.managed:
@@ -384,11 +410,23 @@ tools_pool_repo:
   pkgrepo.managed:
     - humanname: tools_pool_repo
     {% if release >= 8 %}
+    {% if 'beta' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/RES/{{ release }}-CLIENT-TOOLS-BETA/x86_64/product/
+    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/RES/{{ release }}-CLIENT-TOOLS/x86_64/product/
+    {% endif %}
     {% elif grains.get('mirror') %}
+    {% if 'beta' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/RES{{ release }}-SUSE-Manager-Tools-BETA/x86_64/
+    {% else %}
     - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/RES{{ release }}-SUSE-Manager-Tools/x86_64/
+    {% endif %}
+    {% else %}
+    {% if 'beta' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://download.suse.de/ibs/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS-BETA/x86_64/update/
     {% else %}
     - baseurl: http://download.suse.de/ibs/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS/x86_64/update/
+    {% endif %}
     {% endif %}
     - require:
       - cmd: galaxy_key
@@ -397,7 +435,11 @@ tools_pool_repo:
 tools_update_repo:
   pkgrepo.managed:
     - humanname: tools_update_repo
+    {% if 'beta' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS-BETA/x86_64/update/
+    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS/x86_64/update/
+    {% endif %}
     - require:
       - cmd: galaxy_key
 {% endif %}
@@ -500,20 +542,13 @@ tools_update_repo:
     - file: /etc/apt/sources.list.d/Ubuntu{{ short_release }}-Client-Tools.list
 {% if 'head' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
-{% elif '4.1-nightly' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.1:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
-{% elif '4.1-released' in grains.get('product_version') | default('', true) %}
+{% elif 'beta' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS-BETA/x86_64/update/' %}
+{% elif 'released' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
-# We only have one shared Client Tools repository, so we are using 4.1 even for 4.0
-{% elif '4.0-nightly' in grains.get('product_version') | default('', true) %}
+# We only have one shared Client Tools repository, so we are using 4.1 for 4.0 and 3.2
+{% elif 'nightly' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.1:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
-{% elif '4.0-released' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
-# We only have one shared Client Tools repository, so we are using 4.1 even for 3.2
-{% elif '3.2-nightly' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.1:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
-{% elif '3.2-released' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu' + short_release + '-Uyuni-Client-Tools/xUbuntu_' + release %}
 {% else %}

--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -64,6 +64,33 @@ module_server_applications_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/
 {% endif %}
 
+{% if '4.2' in grains['product_version'] %}
+proxy_product_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Proxy/4.2/x86_64/product/
+
+proxy_product_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Proxy/4.2/x86_64/update/
+
+proxy_module_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Proxy/4.2/x86_64/product/
+
+proxy_module_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Proxy/4.2/x86_64/update/
+
+module_server_applications_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15-SP3/x86_64/product/
+
+module_server_applications_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP3/x86_64/update/
+
+{% endif %}
+
 
 {% if 'uyuni-released' in grains['product_version'] %}
 proxy_pool_repo:
@@ -109,7 +136,6 @@ server_devel_repo:
 module_server_applications_movingtarget_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP3:/GA:/TEST/images/repo/SLE-15-SP3-Module-Server-Applications-POOL-x86_64-Media1/
-
 
 module_server_applications_pool_repo:
   pkgrepo.managed:

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -96,6 +96,50 @@ module_python2_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP2/x86_64/update/
 {% endif %}
 
+{% if '4.2' in grains['product_version'] %}
+server_product_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.2/x86_64/product/
+
+server_product_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Server/4.2/x86_64/update/
+
+server_module_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Server/4.2/x86_64/product/
+
+server_module_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Server/4.2/x86_64/update/
+
+module_server_applications_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15-SP3/x86_64/product/
+
+module_server_applications_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP3/x86_64/update/
+
+module_web_scripting_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Web-Scripting/15-SP3/x86_64/product/
+
+module_web_scripting_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Web-Scripting/15-SP3/x86_64/update/
+
+module_python2_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/15-SP3/x86_64/product/
+
+module_python2_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP3/x86_64/update/
+
+{% endif %}
+
+
 {% if 'uyuni-released' in grains['product_version'] %}
 server_pool_repo:
   pkgrepo.managed:
@@ -149,14 +193,14 @@ module_server_applications_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP3/x86_64/update/
 
-module_web_scripting_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Web-Scripting/15-SP3/x86_64/product/
-
 # Moving target, only until SLE15SP3 GA is ready
 module_web_scripting_movingtarget_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP3:/GA:/TEST/images/repo/SLE-15-SP3-Module-Web-Scripting-POOL-x86_64-Media1/
+
+module_web_scripting_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Web-Scripting/15-SP3/x86_64/product/
 
 module_web_scripting_update_repo:
   pkgrepo.managed:


### PR DESCRIPTION
## What does this PR change?

Adds something similar to what `4.2-released` will be, but using beta channels for the clients.

So if you specify `4.2-beta`, you get:

- Server: SLE15SP3 pool + update repos (for whatever milestone is out) + 4.2 beta pool + update repos  (for whatever milestone is out)
- Proxy: SLE15SP3 pool + update repos  (for whatever milestone is out) + 4.2 beta pool + update repos  (for whatever milestone is out)
- Client tools: The usual OS repositories + pool and/or beta repos (depending on the OS, for whatever milestone is out)

Requested by QA so they can use it for the QAM testsuite during milestone validations (https://github.com/SUSE/spacewalk/issues/13202)

Also:
- Simplify Ubuntu repo management

Tests:
In all cases I used a `tf` file that defined: Server, Proxy, SLE11 Traditional Cllient, SLE15 salt client, Ubuntu 18.04 salt client, CentOS7 salt client.

- [x] Provision `4.1-nightly` and inspect repositories on the instances
- [x] Provision `4.1-released` and inspect repositories on the instances
- [x] Provision `4.2-beta` and inspect repositories on the instances (NOTE: `4.2-beta` server alone, since deployment fails but it's enough to check repos, and then `4.1-released` + rest of `4.2-beta` instances.)

NOTE: I could not complete the `4.1-nightly` and `4.1-released` deployments because it seems I have some problems with the DNS resolution even after enabling avahi (so the proxy and clients can't resolve the server hostname). I am pretty sure this is related to my local dnsmasq. Will try to fix it other day. For now the inspection of repositories should be enough.

NOTE: Adding Beta for subsequent versions of SUSE Manager will be easy. Nothing to do for the clients, and we just need to add the final channel names for the next version at minima, and the final URLs at the states for server and proxy. Remember: the beta channels for server and proxy become the "release channels" on GA day. No changes to the names or the URLs. In other words, this PR is pretty much also adding everything that will be needed for `4.2-released` and part of what will be needed for `4.2-nightly`.