### PR TITLE
WIP: Change symlink target to valid file

### DIFF
--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -31,7 +31,7 @@ server_packages:
 baseproduct_link:
   file.symlink:
     - name: /etc/products.d/baseproduct
-    - target: SUSE-Manager-Server.prod
+    - target: SLES.prod
     - require:
       - pkg: server_packages
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Changed the target of `/etc/products.d/baseproduct` symlink because it was invalid before.

Fixes https://github.com/uyuni-project/sumaform/issues/806

This is untested yet. Not to be merged because it has potential to break anything that reads this symlink/file. Although I doubt it because in sumaform there is nothing and in the product we would have seen any breakage already with the invalid symlink. Still I would like to deploy and merge later.