### PR TITLE
Fix 'sles15sp3o' image id

### DIFF
--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -31,7 +31,7 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15o", "sles15sp1o", "sles15sp2o", "sle15sp3o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "ubuntu1804o"]
+  default     = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "ubuntu1804o"]
 }
 
 variable "mirror" {

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -95,7 +95,7 @@ variable "hypervisor" {
 }
 
 variable "image" {
-  description = "One of: sles15, sles15sp1, sles15sp2, sles15sp2o, sle15sp3o, opensuse150, opensuse151 or opensuse152o"
+  description = "One of: sles15, sles15sp1, sles15sp2, sles15sp2o, sles15sp3o, opensuse150, opensuse151 or opensuse152o"
   type        = string
 }
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes the **SLES15SP3** image id introduced in https://github.com/uyuni-project/sumaform/pull/792.

The image id should be `sles15sp3o` instead of `sle15sp3o`, otherwise the following error is raised during `terraform apply`, when `images` is not explicitly set on `main.tf`:

![Screenshot from 2020-12-02 14-37-10](https://user-images.githubusercontent.com/14297426/100887402-d7888600-34ac-11eb-8941-ca806c2e6fe3.png)
