### PR TITLE
Update variables with full list of images available

### DIFF
--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -65,6 +65,6 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos7o", "opensuse150o", "opensuse151o", "opensuse152o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "ubuntu1804o"]
+  default     = [ "centos6o", "centos7", "centos7o", "centos8o", "opensuse150", "opensuse150o", "opensuse151", "opensuse151o", "opensuse152o", "sles15", "sles15o", "sles15sp1", "sles15sp1o", "sles15sp2", "sles15sp2o", "sles15sp3o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "sles12sp4o", "sles12sp5o", "ubuntu1604o", "ubuntu1804", "ubuntu1804o", "ubuntu2004o" ]
   type        = set(string)
 }


### PR DESCRIPTION
## What does this PR change?

Update variables with full list of images available for libvirt and null provider. These are already available in https://github.com/uyuni-project/sumaform/blob/master/backend_modules/libvirt/base/main.tf#L5, this PR is just documenting it