### PR TITLE
fix bandit python dependency at 1.6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
 
 install:
   - pip3 install 'importlib-metadata>=1.7.0'
+  - pip3 install 'bandit==1.6.2'
   - pip3 install coala coala-bears
   - wget https://download.opensuse.org/repositories/systemsmanagement:/sumaform/openSUSE_Leap_15.1/x86_64/terraform.rpm
   - rpm2cpio ./terraform.rpm | cpio --extract --make-directories --verbose "./usr/bin/terraform"


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Set `bandit` python dependency to version `1.6.2` to fix the error currently happening in github actions.

Bandit dependency on is last release (`1.6.3`) bump the version for dependency `PyYAML` from version `3.13` to version `5.3.1` [1].
Coala have a dependency from bandit set to `bandit~=1.2` and also dependes on `pyyaml~=3.12` [2]. This pop up an error:
```
There is a conflict in the version of a dependency you have installed and the requirements of coala. This may be resolved by creating a separate virtual environment for coala or running `pip install "PyYAML>=5.3.1"`. Be aware that the latter solution might break other python packages that depend on the currently installed version.
```

[1] https://github.com/PyCQA/bandit/pull/588/files
[2] https://github.com/coala/coala-bears/blob/master/bear-requirements.txt