### PR TITLE
Fix SLES12SP4 python-cryptography dependency issue with its version

### DIFF
--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -23,6 +23,12 @@ suse_client_cucumber_requisites:
     - require:
       - sls: repos
 
+python-cryptography:
+  pkg.latest:
+    - fromrepo: os_update_repo
+    - require:
+      - sls: repos
+
 {% endif %}
 
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/13314

By default in our official image, from sumaform, we have pre-installed:
```suma-qam-41-min-sles12sp4:~ # rpm -qa| grep cryptography
python-cryptography-1.3.1-7.10.1.x86_64
```

That results on this issue, at boostrap:
```* registering
From cffi callback <function ssl_verify_callback at 0x7f3797639488>:
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/OpenSSL/SSL.py", line 214, in wrapper
    _lib.X509_up_ref(x509)
AttributeError: 'module' object has no attribute 'X509_up_ref'
An error has occurred:
rhn-plugin: The SSL certificate failed verification.
See /var/log/up2date for more information
```

But in our repos we have the proper version 2.1.4:
zypper actually display the correct version is also available 
```S | Name                 | Type       | Version      | Arch   | Repository    
--+----------------------+------------+--------------+--------+---------------
v | python-cryptography  | package    | 2.1.4-7.28.2 | x86_64 | os_update_repo
v | python-cryptography  | package    | 1.7.2-7.24.1 | x86_64 | os_update_repo
v | python-cryptography  | package    | 1.3.1-7.13.4 | x86_64 | os_update_repo
i | python-cryptography  | package    | 1.3.1-7.10.1 | x86_64 | os_pool_repo  
````

This PR force before bootstrapping to have update the rpm with the latest version from `os_update_repo`


Note
------
We might want to document this need in our official documentation or find another way to have this dependency at boostrap time self-contained