### PR TITLE
CentOS6 deprecated repo, using archived repo

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -8,6 +8,11 @@ chpasswd:
      root:linux
 
 %{ if image == "centos6o" }
+bootcmd:
+  # HACK: yum_repos state cant replace a repo, so we need to delete it,
+  #       otherwise the workaround for archived repo doesnt work
+  - [rm, -f, /etc/yum.repos.d/CentOS-Base.repo]
+
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -25,6 +30,22 @@ yum_repos:
     gpgcheck: false
     priority: 99
     name: epel
+  # repo for Centos-Base backup
+  CentOS-Base_backup:
+    baseurl: http://vault.centos.org/centos/6/os/$basearch
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: CentOS-Base_backup
+  # repo for Centos-Updates backup
+  CentOS-Updates_backup:
+    baseurl: http://vault.centos.org/centos/6/updates/$basearch
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: CentOS-Updates_backup
 
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 


### PR DESCRIPTION
## What does this PR change?

As the official CentOS6 repositories were closed.
This PR changes the CentOS6 Base and Updates repositories URLs, to use another server that backups them.

Related to https://github.com/SUSE/spacewalk/issues/13615 and https://github.com/SUSE/spacewalk/issues/13658