### PR TITLE
add workaround for bsc#1181283

### DIFF
--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -14,6 +14,7 @@ include:
   - server.pts
   - server.salt_master
   - server.tcpdump
+  - server.release-notes-workaround
 
 server_packages:
   pkg.installed:

--- a/salt/server/release-notes-workaround.sls
+++ b/salt/server/release-notes-workaround.sls
@@ -1,3 +1,8 @@
+# WORKAROUND for bsc#1181283
+# We are including twice /etc/sudoers.d directory, one with @includedir and one with #includedir
+# Thus, this workaround is adding an extra # to #includedir so that this line is treated as a comment
+# and so ignored.
+
 include:
   - default
 

--- a/salt/server/release-notes-workaround.sls
+++ b/salt/server/release-notes-workaround.sls
@@ -1,0 +1,8 @@
+include:
+  - default
+
+/etc/sudoers:
+  file.replace:
+    - pattern: '^#includedir /etc/sudoers'
+    - repl: '##includedir /etc/sudoers'
+


### PR DESCRIPTION
Comment the extra includedir line in sudoers to prevent including twice
the files in /etc/sudoers.

This workaround will be mentioned in the release notes for 4.2.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>


