### PR TITLE
Disable GPG check for all sle15 repos

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -272,9 +272,7 @@ tools_update_repo:
     {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/
 {# HACK to workaround invalid GPG keys for sle15}
-{% if grains['sle_version_path'] == '15' %}
     - gpgcheck: 1
-{% endif %}
     {% endif %}
 {% else %}
 tools_pool_repo:
@@ -309,9 +307,7 @@ os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
 {# HACK to workaround invalid GPG keys for sle15}
-{% if grains['sle_version_path'] == '15' %}
     - gpgcheck: 1
-{% endif %}
 
 os_update_repo:
   pkgrepo.managed:

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -271,6 +271,10 @@ tools_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15-BETA/x86_64/update/
     {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/
+{# HACK to workaround invalid GPG keys for sle15}
+{% if grains['sle_version_path'] == '15' %}
+    - gpgcheck: 1
+{% endif %}
     {% endif %}
 {% else %}
 tools_pool_repo:
@@ -304,10 +308,18 @@ tools_update_repo:
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
+{# HACK to workaround invalid GPG keys for sle15}
+{% if grains['sle_version_path'] == '15' %}
+    - gpgcheck: 1
+{% endif %}
 
 os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
+{# HACK to workaround invalid GPG keys for sle15}
+{% if grains['sle_version_path'] == '15' %}
+    - gpgcheck: 1
+{% endif %}
 
 {% if grains.get('use_os_unreleased_updates') | default(False, true) %}
 test_update_repo:

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -272,7 +272,7 @@ tools_update_repo:
     {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/
 {# HACK to workaround invalid GPG keys for sle15}
-    - gpgcheck: 1
+    - gpgcheck: 0
     {% endif %}
 {% else %}
 tools_pool_repo:
@@ -307,14 +307,14 @@ os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
 {# HACK to workaround invalid GPG keys for sle15}
-    - gpgcheck: 1
+    - gpgcheck: 0
 
 os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
 {# HACK to workaround invalid GPG keys for sle15}
 {% if grains['sle_version_path'] == '15' %}
-    - gpgcheck: 1
+    - gpgcheck: 0
 {% endif %}
 
 {% if grains.get('use_os_unreleased_updates') | default(False, true) %}

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -26,28 +26,52 @@ containers_updates_repo:
 containers_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/{{ sle_version_path }}/x86_64/product/
+{# HACK to workaround invalid GPG keys for sle15}
+{% if grains['sle_version_path'] == '15' %}
+    - gpgcheck: 1
+{% endif %}
 
 containers_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/{{ sle_version_path }}/x86_64/update/
+{# HACK to workaround invalid GPG keys for sle15}
+{% if grains['sle_version_path'] == '15' %}
+    - gpgcheck: 1
+{% endif %}
 
 devel_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/product/
+{# HACK to workaround invalid GPG keys for sle15}
+{% if grains['sle_version_path'] == '15' %}
+    - gpgcheck: 1
+{% endif %}
 
 devel_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/update/
+{# HACK to workaround invalid GPG keys for sle15}
+{% if grains['sle_version_path'] == '15' %}
+    - gpgcheck: 1
+{% endif %}
 
 {# The following "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" module #}
 desktop_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/product/
+{# HACK to workaround invalid GPG keys for sle15}
+{% if grains['sle_version_path'] == '15' %}
+    - gpgcheck: 1
+{% endif %}
 
 {# The following "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" module #}
 desktop_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
+{# HACK to workaround invalid GPG keys for sle15}
+{% if grains['sle_version_path'] == '15' %}
+    - gpgcheck: 1
+{% endif %}
 
 {% if '3.2-nightly' in grains.get('product_version') or '4.0-nightly' in grains.get('product_version') %}
 python2_pool_repo:

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -28,7 +28,7 @@ containers_pool_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/{{ sle_version_path }}/x86_64/product/
 {# HACK to workaround invalid GPG keys for sle15}
 {% if grains['sle_version_path'] == '15' %}
-    - gpgcheck: 1
+    - gpgcheck: 0
 {% endif %}
 
 containers_updates_repo:
@@ -36,7 +36,7 @@ containers_updates_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/{{ sle_version_path }}/x86_64/update/
 {# HACK to workaround invalid GPG keys for sle15}
 {% if grains['sle_version_path'] == '15' %}
-    - gpgcheck: 1
+    - gpgcheck: 0
 {% endif %}
 
 devel_pool_repo:
@@ -44,7 +44,7 @@ devel_pool_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/product/
 {# HACK to workaround invalid GPG keys for sle15}
 {% if grains['sle_version_path'] == '15' %}
-    - gpgcheck: 1
+    - gpgcheck: 0
 {% endif %}
 
 devel_updates_repo:
@@ -52,7 +52,7 @@ devel_updates_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/update/
 {# HACK to workaround invalid GPG keys for sle15}
 {% if grains['sle_version_path'] == '15' %}
-    - gpgcheck: 1
+    - gpgcheck: 0
 {% endif %}
 
 {# The following "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" module #}
@@ -61,7 +61,7 @@ desktop_pool_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/product/
 {# HACK to workaround invalid GPG keys for sle15}
 {% if grains['sle_version_path'] == '15' %}
-    - gpgcheck: 1
+    - gpgcheck: 0
 {% endif %}
 
 {# The following "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" module #}
@@ -70,7 +70,7 @@ desktop_updates_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
 {# HACK to workaround invalid GPG keys for sle15}
 {% if grains['sle_version_path'] == '15' %}
-    - gpgcheck: 1
+    - gpgcheck: 0
 {% endif %}
 
 {% if '3.2-nightly' in grains.get('product_version') or '4.0-nightly' in grains.get('product_version') %}


### PR DESCRIPTION
## What does this PR change?

Disable GPG check for all sle15 repos as workaround to have a QAM deployment until build service updates the GPG keys