### PR TITLE
Workaround wrong 50-xen-hvm-x86_64.json on KVM hosts

### DIFF
--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -41,6 +41,14 @@ guestfs-fix:
     - require:
       - pkg: virthost_packages
 {% endif %}
+
+# WORKAROUND for bsc#1181264
+{% if grains['osrelease'] == '15.3' and grains['hypervisor'] == 'kvm' %}
+no-50-xen-hvm-x86_64.json:
+  file.absent:
+    - name: /usr/share/qemu/firmware/50-xen-hvm-x86_64.json
+{% endif %}
+
 fake_systemd_detect_virt:
   file.managed:
     - name: /usr/bin/systemd-detect-virt


### PR DESCRIPTION
## What does this PR change?

Work around https://bugzilla.suse.com/show_bug.cgi?id=1181264