### PR TITLE
fix workaround for bsc#1181283

### DIFF
--- a/salt/server/release-notes-workaround.sls
+++ b/salt/server/release-notes-workaround.sls
@@ -1,0 +1,13 @@
+# WORKAROUND for bsc#1181283
+# We are including twice /etc/sudoers.d directory, one with @includedir and one with #includedir
+# Thus, this workaround is adding an extra # to @includedir so that this line is treated as a comment
+# and so ignored.
+
+include:
+  - default
+
+/etc/sudoers:
+  file.replace:
+    - pattern: '^@includedir /etc/sudoers'
+    - repl: '#@includedir /etc/sudoers'
+


### PR DESCRIPTION
## What does this PR change?

The bug only affects SLE15SP3, meaning @includedir is only added in SLE15SP3
By having commented #includedir, I introduced a bug for previous
products based on SLE15SP2 or older, which was that there was no includedir
so sudo was not working on those products.

Let's comment the one that starts with @ so it only affects SP3.
