### PR TITLE
Update sles15sp3o image

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -17,7 +17,7 @@ locals {
     sles15sp1o   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.suse.de"}/install/SLE-15-SP1-JeOS-QU4/SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU4.qcow2"
     sles15sp2    = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp2.x86_64.qcow2"
     sles15sp2o   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.suse.de"}/install/SLE-15-SP2-JeOS-GM/SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-GM.qcow2"
-    sles15sp3o   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.suse.de"}/install/SLE-15-SP3-JeOS-TEST/SLES15-SP3-JeOS.x86_64-15.3-OpenStack-Cloud-Build23.7.qcow2"
+    sles15sp3o   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.suse.de"}/install/SLE-15-SP3-JeOS-Snapshot9/SLES15-SP3-JeOS.x86_64-15.3-OpenStack-Cloud-Snapshot9.qcow2"
     sles11sp4    = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles11sp4.x86_64.qcow2"
     sles12       = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12.x86_64.qcow2"
     sles12sp1    = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64.qcow2"


### PR DESCRIPTION
## What does this PR change?

The image at SLE-15-SP3-Full-TEST is updated quite often.
Instead, use the one at SLE-15-SP3-JeOS-Snapshot9.
- backend_modules/libvirt/base/main.tf (sles15sp3o):
Update image URL.
