### PR TITLE
4.2 beta version of server and proxy modules have to point to IBS images

### DIFF
--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -73,6 +73,11 @@ proxy_product_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Proxy/4.2/x86_64/update/
 
+{% if 'beta' in grains['product_version'] %}
+proxy_module_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP3:/Update:/Products:/Manager42/images/repo/SLE-Module-SUSE-Manager-Proxy-4.2-POOL-x86_64-Media1/
+{% else %}
 proxy_module_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Proxy/4.2/x86_64/product/
@@ -80,6 +85,7 @@ proxy_module_pool_repo:
 proxy_module_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Proxy/4.2/x86_64/update/
+{% endif %}
 
 module_server_applications_pool_repo:
   pkgrepo.managed:

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -105,6 +105,11 @@ server_product_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Server/4.2/x86_64/update/
 
+{% if 'beta' in grains['product_version'] %}
+server_module_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP3:/Update:/Products:/Manager42/images/repo/SLE-Module-SUSE-Manager-Server-4.2-POOL-x86_64-Media1/
+{% else %}
 server_module_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Server/4.2/x86_64/product/
@@ -112,6 +117,7 @@ server_module_pool_repo:
 server_module_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Server/4.2/x86_64/update/
+{% endif %}
 
 module_server_applications_pool_repo:
   pkgrepo.managed:


### PR DESCRIPTION
## What does this PR change?

As SCC still not contains the latest packages for the Server and Proxy modules, we need to use IBS repositories for 4.2-beta product version
