### PR TITLE
Change the 4.2 beta url to match mirrors without changing for default

### DIFF
--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -76,7 +76,7 @@ proxy_product_update_repo:
 {% if 'beta' in grains['product_version'] %}
 proxy_module_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP3:/Update:/Products:/Manager42/images/repo/SLE-Module-SUSE-Manager-Proxy-4.2-POOL-x86_64-Media1/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP3:/Update:/Products:/Manager42/images/repo/SLE-Module-SUSE-Manager-Proxy-4.2-POOL-x86_64-Media1/
 {% else %}
 proxy_module_pool_repo:
   pkgrepo.managed:

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -108,7 +108,7 @@ server_product_update_repo:
 {% if 'beta' in grains['product_version'] %}
 server_module_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP3:/Update:/Products:/Manager42/images/repo/SLE-Module-SUSE-Manager-Server-4.2-POOL-x86_64-Media1/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP3:/Update:/Products:/Manager42/images/repo/SLE-Module-SUSE-Manager-Server-4.2-POOL-x86_64-Media1/
 {% else %}
 server_module_pool_repo:
   pkgrepo.managed:


### PR DESCRIPTION
## What does this PR change?

Change the 4.2 beta url to match mirrors without changing for default
Because for download.suse.de the url doesn't change, but our mirror script put the folder of the product with the /ibs/ as well so we need that in the end result url.