### PR TITLE
Beta urls

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -69,7 +69,7 @@ tools_pool_repo:
   pkgrepo.managed:
     {% if grains.get('mirror') %}
     {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-SUSE-Manager-Tools-BETA/sle-11-x86_64/
+    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-SUSE-Manager-Tools-Beta/sle-11-x86_64/
     {% else %}
     - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-SUSE-Manager-Tools/sle-11-x86_64/
     {% endif %}
@@ -417,7 +417,7 @@ tools_pool_repo:
     {% endif %}
     {% elif grains.get('mirror') %}
     {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/RES{{ release }}-SUSE-Manager-Tools-BETA/x86_64/
+    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/RES{{ release }}-SUSE-Manager-Tools-Beta/x86_64/
     {% else %}
     - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/RES{{ release }}-SUSE-Manager-Tools/x86_64/
     {% endif %}
@@ -436,7 +436,7 @@ tools_update_repo:
   pkgrepo.managed:
     - humanname: tools_update_repo
     {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS-BETA/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS-Beta/x86_64/update/
     {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS/x86_64/update/
     {% endif %}

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -415,7 +415,7 @@ tools_pool_repo:
     {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/RES/{{ release }}-CLIENT-TOOLS/x86_64/product/
     {% endif %}
-    {% elif release == 7 %}
+    {% elif grains.get('mirror') %}
     {% if 'beta' in grains.get('product_version') | default('', true) %}
     - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/RES{{ release }}-SUSE-Manager-Tools-Beta/x86_64/
     {% else %}
@@ -436,7 +436,7 @@ tools_update_repo:
   pkgrepo.managed:
     - humanname: tools_update_repo
     {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS-Beta/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS-BETA/x86_64/update/
     {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/RES/{{ release }}-CLIENT-TOOLS/x86_64/update/
     {% endif %}

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -415,7 +415,7 @@ tools_pool_repo:
     {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/RES/{{ release }}-CLIENT-TOOLS/x86_64/product/
     {% endif %}
-    {% elif grains.get('mirror') %}
+    {% elif release == 7 %}
     {% if 'beta' in grains.get('product_version') | default('', true) %}
     - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/RES{{ release }}-SUSE-Manager-Tools-Beta/x86_64/
     {% else %}


### PR DESCRIPTION
## What does this PR change?

Correct res and sle11 beta urls for mirror from BETA to Beta. 
Also fix detection of release in RES 7 case for tools_pool_repo