### PR TITLE
New parameter: server_mounted_mirror (mirror only for product sync.)

### DIFF
--- a/.ci-travis/salt-server-validation
+++ b/.ci-travis/salt-server-validation
@@ -18,6 +18,7 @@ product_version: head
 cc_username: UC7
 cc_password: passme
 mirror: null
+server_mounted_mirror: null
 iss_master: null
 iss_slave: null
 smt: null

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -112,7 +112,7 @@ If you are using `sumaform` outside of the SUSE Nuremberg network you should use
 
 It will be be used exclusively by other VMs to download SUSE content - that means your SUSE Manager servers, clients, minions and proxies will be "fully disconnected", not requiring Internet access to operate.
 
-To enable `mirror`, add `mirror = "mirror.tf.local"` to the `base` section in `main.tf` and add the following mode definition:
+To enable `mirror`, add `mirror = "mirror.tf.local"` to the `base` section in `main.tf` and add the following module definition:
 ```hcl
 module "mirror" {
   source = "./modules/mirror"
@@ -150,6 +150,12 @@ Check the help with:
 ```bash
 /root/mirror.sh -h
 ```
+
+## Mirror only for Server (products synchronization)
+
+In addition to the parameter `mirror`, which will wrap this case, you might only want to setup a mirror for server products syncronization, but not for the repositories used by sumaform during the deployment of your environment.
+For that use case, instead of `mirror` use `server_mounted_mirror` parameter inside the server module definition.
+
 
 ## Virtual hosts
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -40,6 +40,7 @@ module "server" {
     wait_for_reposync      = var.wait_for_reposync
     cloned_channels        = var.cloned_channels
     mirror                 = var.base_configuration["mirror"]
+    server_mounted_mirror  = var.server_mounted_mirror
     iss_master             = var.iss_master
     iss_slave              = var.iss_slave
     server                 = var.register_to_server

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -264,3 +264,8 @@ variable "volume_provider_settings" {
   description = "Map of volume-provider-specific settings, see the backend-specific README file"
   default     = {}
 }
+
+variable "server_mounted_mirror" {
+  description = "hostname of a mounted mirror in the server (to get packages from it)"
+  default     = null
+}

--- a/salt/server/rhn.sls
+++ b/salt/server/rhn.sls
@@ -38,7 +38,9 @@ disable_download_tokens:
       - sls: server
 {% endif %}
 
-{% if salt["grains.get"]("mirror") %}
+{%- set mirror_hostname = grains.get('server_mounted_mirror') if grains.get('server_mounted_mirror') else grains.get('mirror') %}
+
+{% if mirror_hostname %}
 
 nfs_client:
   pkg.installed:
@@ -52,7 +54,7 @@ non_empty_fstab:
 mirror_directory:
   mount.mounted:
     - name: /mirror
-    - device: {{ salt["grains.get"]("mirror") }}:/srv/mirror
+    - device: {{ mirror_hostname }}:/srv/mirror
     - fstype: nfs
     - mkmnt: True
     - require:


### PR DESCRIPTION
## What does this PR change?

Implements https://github.com/uyuni-project/sumaform/issues/859

Currently, if we want to use a Minima mirror only to configure SUSE Manager to download the content from a mirror, so rhn.conf, we can't; we are forced to also mirror everything that sumaform needs during the automatic configuration phase, so during salt states in Sumaform, where tons of temporary repositories are set up.

In this PR we use a different variable to use only for the disk mirror feature on SUMA, when syncing products from SCC.
