### PR TITLE
Get rid of CentOS 6 workaround about Vault repo

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -8,11 +8,6 @@ chpasswd:
      root:linux
 
 %{ if image == "centos6o" }
-bootcmd:
-  # WORKAROUND: yum_repos state cant replace a repo, so we need to delete it,
-  # otherwise the workaround for archived repo doesn't work
-  - [rm, -f, /etc/yum.repos.d/CentOS-Base.repo]
-
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -30,22 +25,6 @@ yum_repos:
     gpgcheck: false
     priority: 99
     name: epel
-  # repo for Centos-Base backup
-  CentOS-Base_backup:
-    baseurl: http://vault.centos.org/centos/6/os/$basearch
-    failovermethod: priority
-    enabled: true
-    gpgcheck: false
-    priority: 99
-    name: CentOS-Base_backup
-  # repo for Centos-Updates backup
-  CentOS-Updates_backup:
-    baseurl: http://vault.centos.org/centos/6/updates/$basearch
-    failovermethod: priority
-    enabled: true
-    gpgcheck: false
-    priority: 99
-    name: CentOS-Updates_backup
 
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 


### PR DESCRIPTION
## What does this PR change?

Apparently, the new version of https://cloud.centos.org/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2 already fixed the workaround we had for Vault repositories, by adding CentOS-Vault.repo.

So we can safely remove our workaround.