### PR TITLE
Revert "Get rid of CentOS 6 workaround about Vault repo"

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -8,6 +8,11 @@ chpasswd:
      root:linux
 
 %{ if image == "centos6o" }
+bootcmd:
+  # WORKAROUND: yum_repos state cant replace a repo, so we need to delete it,
+  # otherwise the workaround for archived repo doesn't work
+  - [rm, -f, /etc/yum.repos.d/CentOS-Base.repo]
+
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -25,6 +30,22 @@ yum_repos:
     gpgcheck: false
     priority: 99
     name: epel
+  # repo for Centos-Base backup
+  CentOS-Base_backup:
+    baseurl: http://vault.centos.org/centos/6/os/$basearch
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: CentOS-Base_backup
+  # repo for Centos-Updates backup
+  CentOS-Updates_backup:
+    baseurl: http://vault.centos.org/centos/6/updates/$basearch
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: CentOS-Updates_backup
 
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 


### PR DESCRIPTION
Reverts uyuni-project/sumaform#863

My bad, this workaround still valid.
We want to enable Vault repositories for 6 last version, not to any specific 6.x