### PR TITLE
add ltss repo to sles15sp0 and sles15sp1

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -309,6 +309,10 @@ os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
 
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-LTSS/x86_64/update/
+
 {% if grains.get('use_os_unreleased_updates') | default(False, true) %}
 test_update_repo:
   pkgrepo.managed:
@@ -325,6 +329,11 @@ os_pool_repo:
 os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/
+
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-SP1-LTSS/x86_64/update/
+
 {% endif %} {# '15.1' == grains['osrelease'] #}
 
 {% if '15.2' == grains['osrelease'] %}


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?
fixes: https://github.com/uyuni-project/sumaform/issues/862

Add LTSS repository in all machines with sles15sp0 and sles15sp1.
Deployments tested:
- minion sles15sp0
- minion sles15sp1
- Suse Manager 4.0

This will be needed after LTSS release for python3 bundle.
