### PR TITLE
Add 3 needed packages in debian deployment for bootstrap

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -325,7 +325,7 @@ runcmd:
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
 
-packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
+packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
 %{ endif }
 %{ if image == "debian9o" }
 runcmd:
@@ -333,5 +333,5 @@ runcmd:
   - echo '\nPermitRootLogin yes' >> /etc/ssh/sshd_config
   - systemctl restart sshd
 
-packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
+packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
 %{ endif }


### PR DESCRIPTION
## What does this PR change?

Adds 3 needed packages in debian deployment for bootstrap. `apt-transport-https", "python-apt", "python3-apt"` are needed, see https://bugzilla.suse.com/show_bug.cgi?id=1183649#c2 . Using this I deployed 2 debian hosts and it worked. So there is no concern about the order of the package installation (cloud-init vs salt)