### PR TITLE
baseproduct symlink  ofsuse manager product in jeos images

### DIFF
--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -29,12 +29,9 @@ server_packages:
       - sls: server.firewall
 
 {% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' %}
-baseproduct_link:
-  file.symlink:
-    - name: /etc/products.d/baseproduct
-    - target: SUSE-Manager-Server.prod
-    - require:
-      - pkg: server_packages
+product_package_installed:
+   cmd.run:
+     - name: zypper --non-interactive install --auto-agree-with-licenses --force-resolution -t product SUSE-Manager-Server
 {% endif %}
 
 environment_setup_script:


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?
 In replace of https://github.com/uyuni-project/sumaform/pull/808

Solves: https://github.com/uyuni-project/sumaform/issues/806

I have tried to use pkg.install but it doesn't have support for the flag `--force-resolution`.
As an alternative, I'm running a `cmd.run` with the needed full command.