### PR TITLE
Do not always install proxy pattern

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -228,7 +228,8 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
    * `auto_connect_to_master`: automatically connects to the Salt Master. Set to `false` to manually configure. Requires `minion` to be `true`
    * `auto_register`: automatically registers the proxy to its upstream Server or Proxy. Defaults to `false`, requires `minion` to be `false`
    * `download_private_ssl_key`: automatically copies SSL certificates from the upstream SUSE Manager Server or SUSE Manager Proxy. Requires `publish_private_ssl_key` on the upstream server or proxy. Set to `false` for manual distribution
-   * `auto_configure`: automatically runs the `confure-proxy.sh` script which enables Proxy functionality. Set to `false` to run manually. Requires `auto_register` and `download_private_ssl_key`
+   * `install_proxy_pattern`: install proxy pattern with all proxy-related software. Set to `false` to install manually
+   * `auto_configure`: automatically runs the `confure-proxy.sh` script which enables Proxy functionality. Set to `false` to run manually. Requires `auto_register`, `download_private_ssl_key`, and `install_proxy_pattern`
    * `generate_bootstrap_script`: generates a bootstrap script for traditional clients and copies it in /pub. Set to `false` to generate manually. Requires `auto_configure`
    * `publish_private_ssl_key`: copies the private SSL key in /pub for cascaded Proxies to copy automatically. Set to `false` for manual distribution. Requires `download_private_ssl_key`
    * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -71,6 +71,7 @@ module "proxy" {
   auto_register             = false
   auto_connect_to_master    = false
   download_private_ssl_key  = false
+  install_proxy_pattern     = false
   auto_configure            = false
   generate_bootstrap_script = false
   publish_private_ssl_key   = false

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -39,6 +39,7 @@ module "proxy" {
     auto_connect_to_master    = var.auto_connect_to_master
     auto_register             = var.auto_register
     download_private_ssl_key  = var.download_private_ssl_key
+    install_proxy_pattern     = var.install_proxy_pattern
     auto_configure            = var.auto_configure
     server_username           = var.server_configuration["username"]
     server_password           = var.server_configuration["password"]

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -41,6 +41,11 @@ variable "download_private_ssl_key" {
   default     = true
 }
 
+variable "install_proxy_pattern" {
+  description = "whether to install proxy pattern upon deployment"
+  default     = true
+}
+
 variable "auto_configure" {
   description = "whether to automatically run configure-proxy.sh upon deployment"
   default     = true

--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -8,11 +8,13 @@ include:
 proxy-packages:
   pkg.installed:
     - pkgs:
+{% if grains.get('install_proxy_pattern') %}
       {% if grains['osfullname'] == 'Leap' %}
       - patterns-uyuni_proxy
       {% else %}
       - patterns-suma_proxy
       {% endif %}
+{% endif %}
 {% if grains.get('osmajorrelease', None)|int() == 15 %}
       - firewalld
 {% else %}
@@ -26,7 +28,7 @@ wget:
     - require:
       - sls: repos
 
-{% if grains['use_avahi'] %}
+{% if grains['use_avahi'] and grains.get('install_proxy_pattern') %}
 
 squid-configuration-dns-multicast:
   file.replace:


### PR DESCRIPTION
## What does this PR change?

In the cucumber test suites, we already install retail pattern manually. We would like to do the same for the proxy pattern.

Benefits:
 - BV test suite: do not collide with salt cleanup scenario (it was removing `/etc/salt/broker` configuration file)
 - closer mimicking of what a customer does in the test suite
 - independance of sumaform

To achieve that, this PR introduces a new `install_proxy_pattern` configuration variable that defaults to `true` for compatibility.

See also uyuni-project/uyuni#3487 and SUSE/susemanager-ci#219