### PR TITLE
Follow a recent change in the testsuite

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -19,14 +19,14 @@ fedora_autoinstallation_vmlinuz_file:
 
 sles_autoinstallation_initrd_file:
   file.managed:
-    - name: /install/SLES11-SP1-x86_64/DVD1/boot/x86_64/loader/initrd
+    - name: /install/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd
     - contents:
       - This is mocked contents for /boot/x86_64/loader/initrd
     - makedirs: True
 
 sles_autoinstallation_linux_file:
   file.managed:
-    - name: /install/SLES11-SP1-x86_64/DVD1/boot/x86_64/loader/linux
+    - name: /install/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux
     - contents:
       - This is mocked contents for /boot/x86_64/loader/linux
     - makedirs: True


### PR DESCRIPTION
## What does this PR change?
After https://github.com/uyuni-project/uyuni/pull/3481, the test suite uses SLES15-SP2
in the Cobbler test.

- salt/server/testsuite.sls: Provide SLES15-SP2 .
