### PR TITLE
Remove files needed for  srv_distro_cobbler.feature from suma deployment and upload its during tests

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -3,44 +3,11 @@
 include:
   - server
 
-fedora_autoinstallation_initrd_file:
-  file.managed:
-    - name: /install/Fedora_12_i386/images/pxeboot/initrd.img
-    - contents:
-      - This is mocked contents for /pxeboot/initrd.img
-    - makedirs: True
-
-fedora_autoinstallation_vmlinuz_file:
-  file.managed:
-    - name: /install/Fedora_12_i386/images/pxeboot/vmlinuz
-    - contents:
-      - This is mocked contents for /pxeboot/vmlinuz
-    - makedirs: True
-
-sles_autoinstallation_initrd_file:
-  file.managed:
-    - name: /install/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd
-    - contents:
-      - This is mocked contents for /boot/x86_64/loader/initrd
-    - makedirs: True
-
-sles_autoinstallation_linux_file:
-  file.managed:
-    - name: /install/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux
-    - contents:
-      - This is mocked contents for /boot/x86_64/loader/linux
-    - makedirs: True
-
 test_package_without_vendor_file:
   file.managed:
     - name: /root/subscription-tools-1.0-0.noarch.rpm
     - source: salt://server/testsuite/subscription-tools-1.0-0.noarch.rpm
 
-test_autoinstallation_file:
-  file.managed:
-    - name: /install/empty.xml
-    - source: salt://server/testsuite/empty.xml
-    - makedirs: True
 
 test_vcenter_file:
   file.managed:


### PR DESCRIPTION
## What does this PR change?

The PR remove the upload of install files needed for srv_distro_cobbler.feature from the sumaform deployment to the testsuite execution.

Dependency : https://github.com/uyuni-project/uyuni/pull/3562

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Links

Issue : 
https://github.com/SUSE/spacewalk/issues/13755

- [x] **DONE**

## Test coverage
- Cucumber background test were added

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
