### PR TITLE
Connect only real terminals and branch server to private network

### DIFF
--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -14,7 +14,7 @@ module "client" {
   ssh_key_path                  = var.ssh_key_path
   ipv6                          = var.ipv6
   connect_to_base_network       = true
-  connect_to_additional_network = true
+  connect_to_additional_network = false
   roles                         = ["client"]
   disable_firewall              = var.disable_firewall
   grains = {

--- a/modules/minion/main.tf
+++ b/modules/minion/main.tf
@@ -14,7 +14,7 @@ module "minion" {
   ssh_key_path                  = var.ssh_key_path
   ipv6                          = var.ipv6
   connect_to_base_network       = true
-  connect_to_additional_network = true
+  connect_to_additional_network = false
   roles                         = var.roles
   disable_firewall              = var.disable_firewall
 

--- a/modules/sshminion/main.tf
+++ b/modules/sshminion/main.tf
@@ -14,7 +14,7 @@ module "sshminion" {
   ssh_key_path                  = var.ssh_key_path
   ipv6                          = var.ipv6
   connect_to_base_network       = true
-  connect_to_additional_network = true
+  connect_to_additional_network = false
   roles                         = ["sshminion"]
   disable_firewall              = var.disable_firewall
   grains = {


### PR DESCRIPTION
## What does this PR change?

We will simplify the test suite and connect only PXE boot minion and branch server to private network.

Connecting other clients was needed only to test the DHCP and DNS formulas worked. But it also created a series of problems.

