### PR TITLE
Set product for proxy

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -23,6 +23,12 @@ proxy-packages:
     - require:
       - sls: repos
 
+{% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' %}
+product_package_installed:
+   cmd.run:
+     - name: zypper --non-interactive install --auto-agree-with-licenses --force-resolution -t product SUSE-Manager-Proxy
+{% endif %}
+
 wget:
   pkg.installed:
     - require:


### PR DESCRIPTION
## What does this PR change?

PR set product for proxy to `SUSE-Manager-Proxy` by calling:

```
zypper --non-interactive install --auto-agree-with-licenses --force-resolution -t product SUSE-Manager-Proxy
```
