### PR TITLE
disable forwarding of registrations by default in sumaform

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -248,6 +248,7 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
    * `create_sample_bootstrap_script`: whether to create a sample bootstrap script for traditional clients. Requires `create_sample_activation_key`
    * `publish_private_ssl_key`: copies the private SSL key in /pub for Proxies to copy automatically. Set to `false` for manual distribution
    * `disable_download_tokens`: disable package token download checks. Set to `false` to enable checking
+   * `forward_registration`: enable forwarding of registrations to SCC (default off)
 
 
 ## Adding channels to SUSE Manager Servers

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -47,6 +47,7 @@ module "server" {
   create_sample_bootstrap_script = false
   publish_private_ssl_key        = false
   disable_download_tokens        = false
+  forward_registration           = false
   monitored                      = true
   use_os_released_updates        = true
   ssh_key_path                   = "./salt/controller/id_rsa.pub"

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -75,6 +75,7 @@ module "server" {
     traceback_email                = var.traceback_email
     saltapi_tcpdump                = var.saltapi_tcpdump
     repository_disk_size           = var.repository_disk_size
+    forward_registration           = var.forward_registration
   }
 
 

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -269,3 +269,8 @@ variable "server_mounted_mirror" {
   description = "hostname of a mounted mirror in the server (to get packages from it)"
   default     = null
 }
+
+variable "forward_registration" {
+  description = "Forward client registrations to SCC"
+  default     = false
+}

--- a/salt/server/rhn.sls
+++ b/salt/server/rhn.sls
@@ -91,6 +91,17 @@ rhn_conf_prometheus:
 
 {% endif %}
 
+{% if not grains.get('forward_registration') | default(false, true) %}
+
+rhn_conf_forward_reg:
+  file.append:
+    - name: /etc/rhn/rhn.conf
+    - text: server.susemanager.forward_registration = 0
+    - require:
+      - sls: server
+
+{% endif %}
+
 # catch-all to ensure we always have at least one state covering /etc/rhn/rhn.conf
 rhn_conf_present:
   file.touch:


### PR DESCRIPTION
## What does this PR change?

Disable forwarding registrations to SCC by default. This is to prevent dozen of dummy registration proxies to appear in SCC.
