### PR TITLE
Rename to tools_update_repo, to follow same naming than other products

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -539,7 +539,8 @@ wait_until_apt_lock_file_unlock:
 
 tools_update_repo:
   pkgrepo.managed:
-    - file: /etc/apt/sources.list.d/Ubuntu{{ short_release }}-Client-Tools.list
+    - humanname: tools_update_repo
+    - file: /etc/apt/sources.list.d/tools_update_repo.list
 {% if 'head' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
 {% elif 'beta' in grains.get('product_version') | default('', true) %}
@@ -559,7 +560,7 @@ tools_update_repo:
 
 tools_update_repo_raised_priority:
   file.managed:
-    - name: /etc/apt/preferences.d/Ubuntu{{ short_release }}-Client-Tools
+    - name: /etc/apt/preferences.d/tools_update_repo
 {% if 'head' in grains.get('product_version') | default('', true) %}
     - contents: |
             Package: *


### PR DESCRIPTION
## What does this PR change?

Rename to `tools_update_repo`, to follow same naming than other products.

Currently, we have:

```
root@suma-head-min-ubuntu2004:/etc/apt/sources.list.d# cat tools_pool_repo.list
# deb http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/ /
root@suma-head-min-ubuntu2004:/etc/apt/sources.list.d# cat Ubuntu2004-Client-Tools.list
# deb http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu20.04-SUSE-Manager-Tools/xUbuntu_20.04 /
root@suma-head-min-ubuntu2004:/etc/apt/sources.list.d# ls /etc/apt/sources.list.d
susemanager:channels.list  test_repo_deb_pool.list  tools_pool_repo.list  Ubuntu2004-Client-Tools.list
``` 

With these changes we expect to have:

```
root@suma-head-min-ubuntu2004:/etc/apt/sources.list.d# cat tools_pool_repo.list
# deb http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/ /
root@suma-head-min-ubuntu2004:/etc/apt/sources.list.d# cat tools_update_repo.list
# deb http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu20.04-SUSE-Manager-Tools/xUbuntu_20.04 /
root@suma-head-min-ubuntu2004:/etc/apt/sources.list.d# ls /etc/apt/sources.list.d
susemanager:channels.list  test_repo_deb_pool.list  tools_pool_repo.list  tools_update_repo.list
``` 

