### PR TITLE
Work around initrd issue in sle11sp4

### DIFF
--- a/salt/default/grub.sls
+++ b/salt/default/grub.sls
@@ -1,0 +1,20 @@
+# HACK
+# This problem should be fixed when we build the image
+#   https://build.suse.de/package/show/Devel:Galaxy:Terraform:Images/sles11sp4
+{% if grains['osfullname'] == 'SLES' %}
+
+{% if grains['osrelease'] == '11.4' %}
+grub_hack:
+  file.replace:
+    - name: /boot/grub/menu.lst
+    - pattern: ^(title.*)$
+    - count: 1
+    - repl: |
+       title sles11sp4_fixed
+         root (hd0,0)
+         kernel /boot/vmlinuz-3.0.101-108.126-default vga=0x314 splash=silent console=tty0 console=ttyS0,115200 root=/dev/vda1 disk=/dev/vda nomodeset elevator=noop showopts
+         initrd /boot/initrd-3.0.101-108.126-default
+       \1
+{% endif %}
+
+{% endif %}

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -2,6 +2,7 @@ include:
   - default.locale
   - default.minimal
   - default.pkgs
+  - default.grub
   {% if grains.get('reset_ids') | default(false, true) %}
   - default.ids
   {% endif %}


### PR DESCRIPTION
## What does this PR change?

This PR makes sure SLES 11 SP4 uses same version for kernel and kernel modules after a reboot.

A better solution would be to generate correct images. For more details, see #887.