### PR TITLE
Change Uyuni to Leap 15.3

### DIFF
--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -82,6 +82,27 @@ data "aws_ami" "opensuse152" {
   }
 }
 
+data "aws_ami" "opensuse153" {
+  most_recent = true
+  name_regex  = "^openSUSE-Leap-15-3-v"
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
 data "aws_ami" "sles15" {
   most_recent = true
   name_regex  = "^suse-sles-15-byos-v"
@@ -410,6 +431,7 @@ locals {
     key_name = local.key_name
     key_file = local.key_file
     ami_info = {
+      opensuse153 = { ami = data.aws_ami.opensuse153.image_id },
       opensuse152 = { ami = data.aws_ami.opensuse152.image_id },
       opensuse151 = { ami = data.aws_ami.opensuse151.image_id },
       opensuse150 = { ami = data.aws_ami.opensuse150.image_id },

--- a/backend_modules/azure/base/main.tf
+++ b/backend_modules/azure/base/main.tf
@@ -24,6 +24,13 @@ data "azurerm_platform_image" "opensuse152" {
   sku       = "15-2"
 }
 
+data "azurerm_platform_image" "opensuse153" {
+  location  = local.location
+  publisher = "suse"
+  offer     = "opensuse-leap"
+  sku       = "15-3"
+}
+
 data "azurerm_platform_image" "sles15sp2" {
   location  = local.location
   publisher = "suse"
@@ -72,6 +79,7 @@ locals {
     key_file = local.key_file
     resource_group_name = module.network.configuration.resource_group_name
     platform_image_info = {
+      opensuse153 = { platform_image = data.azurerm_platform_image.opensuse153 },
       opensuse152 = { platform_image = data.azurerm_platform_image.opensuse152 },
       sles15sp2   = { platform_image = data.azurerm_platform_image.sles15sp2 },
       suma41 = { platform_image = data.azurerm_platform_image.suma41 },

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -12,6 +12,8 @@ locals {
     opensuse151o = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2"
     opensuse152-ci-pr  = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse152-ci-pr.x86_64.qcow2"
     opensuse152o = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2"
+    opensuse153-ci-pr  = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse153-ci-pr.x86_64.qcow2"
+    opensuse153o = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
     sles15       = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15.x86_64.qcow2"
     sles15o      = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/install/SLE-15-JeOS-GM/SLES15-JeOS.x86_64-15.0-OpenStack-Cloud-GM.qcow2"
     sles15sp1    = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp1.x86_64.qcow2"

--- a/main.tf.aws-testsuite.example
+++ b/main.tf.aws-testsuite.example
@@ -20,7 +20,7 @@ module "cucumber_testsuite" {
   cc_username = ...
   cc_password = ...
 
-  images = ["opensuse150", "opensuse151"]
+  images = ["opensuse152", "opensuse153"]
 
   name_prefix  = ...
   git_repo     = "https://github.com/uyuni-project/uyuni.git"
@@ -32,16 +32,16 @@ module "cucumber_testsuite" {
     server = {}
     proxy = {}
     suse-client = {
-      image = "opensuse151"
-      name = "cli-opensuse151"
+      image = "opensuse153"
+      name = "cli-opensuse153"
     }
     suse-minion = {
-      image = "opensuse151"
-      name = "min-opensuse151"
+      image = "opensuse153"
+      name = "min-opensuse153"
     }
     suse-sshminion = {
-      image = "opensuse151"
-      name = "minssh-opensuse151"
+      image = "opensuse153"
+      name = "minssh-opensuse153"
     }
   }
 

--- a/main.tf.aws.example
+++ b/main.tf.aws.example
@@ -66,7 +66,7 @@ module "server" {
   base_configuration = local.base_configuration
 
   name            = "server"
-  image           = "opensuse151"
+  image           = "opensuse153"
   product_version = "uyuni-release"
 
   provider_settings = {  }
@@ -77,7 +77,7 @@ module "minion" {
   base_configuration = local.base_configuration
 
   name                 = "minion"
-  image                = "opensuse151"
+  image                = "opensuse153"
   server_configuration = module.server.configuration
   product_version      = "uyuni-release"
 }

--- a/main.tf.azure.example
+++ b/main.tf.azure.example
@@ -80,7 +80,7 @@ module "minion" {
   base_configuration = local.base_configuration
 
   name                 = "minion"
-  image                = "opensuse152"
+  image                = "opensuse153"
   server_configuration =  module.server.configuration
   product_version      = "uyuni-release"
 }

--- a/main.tf.uyuni.example
+++ b/main.tf.uyuni.example
@@ -23,7 +23,7 @@ module "base" {
 //  }
 
   // Required images
-  images = ["centos7", "opensuse151", "opensuse152o", "ubuntu1804"]
+  images = ["centos7", "opensuse153o", "ubuntu1804"]
 }
 
 module "server" {
@@ -31,7 +31,7 @@ module "server" {
   base_configuration = module.base.configuration
   product_version = "uyuni-master"
   name = "srv"
-  image = "opensuse152o"
+  image = "opensuse153o"
   use_os_released_updates = true
   // see modules/server/variables.tf for possible values
 
@@ -74,7 +74,7 @@ module "kvm-host" {
   base_configuration = module.base.configuration
   product_version = "uyuni-master"
   name = "min-kvm"
-  image = "opensuse151"
+  image = "opensuse153o"
   server_configuration = module.server.configuration
   // see modules/virthost/variables.tf for possible values
 }
@@ -84,7 +84,7 @@ module "xen-host" {
   base_configuration = module.base.configuration
   product_version = "uyuni-master"
   name = "min-xen"
-  image = "opensuse151"
+  image = "opensuse153o"
   server_configuration = module.server.configuration
   // see modules/virthost/variables.tf for possible values
 }

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -65,6 +65,6 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse150o", "opensuse151o", "opensuse152o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
   type        = set(string)
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -31,7 +31,7 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse150o", "opensuse151o", "opensuse152o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
 }
 
 variable "mirror" {

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -8,7 +8,7 @@ variable "images" {
     "4.1-nightly"    = "sles15sp2o"
     "4.2-beta"       = "sles15sp3o"
     "head"           = "sles15sp3o"
-    "uyuni-master"   = "opensuse152o"
+    "uyuni-master"   = "opensuse153o"
     "uyuni-released" = "opensuse152o"
   }
 }

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -8,7 +8,7 @@ variable "images" {
     "4.1-nightly"    = "sles15sp2o"
     "4.2-beta"       = "sles15sp3o"
     "head"           = "sles15sp3o"
-    "uyuni-master"   = "opensuse152o"
+    "uyuni-master"   = "opensuse153o"
     "uyuni-released" = "opensuse152o"
   }
 }


### PR DESCRIPTION
## What does this PR change?

Next Uyuni version is going to be Leap 15.3

Change Server and Proxy to openSUSE Leap 15.3, as well as the examples.

WARNING: ci-pr image is not ready yet, @jordimassaguerpla is having a look (https://build.opensuse.org/package/show/systemsmanagement:sumaform:images:libvirt/opensuse153-ci-pr)