### PR TITLE
systemd utility can be at various places

### DIFF
--- a/salt/default/ids.sls
+++ b/salt/default/ids.sls
@@ -2,13 +2,13 @@ systemd_machine_id:
   cmd.run:
     - name: rm -f /etc/machine-id && rm -f /var/lib/dbus/machine-id && dbus-uuidgen --ensure && systemd-machine-id-setup && touch /etc/machine-id-already-setup
     - creates: /etc/machine-id-already-setup
-    - onlyif: test -f /usr/bin/systemd-machine-id-setup
+    - onlyif: test -f /usr/bin/systemd-machine-id-setup -o -f /bin/systemd-machine-id-setup
 
 dbus_machine_id:
   cmd.run:
     - name: rm -f /var/lib/dbus/machine-id && dbus-uuidgen --ensure
     - creates: /var/lib/dbus/machine-id
-    - unless: test -f /usr/bin/systemd-machine-id-setup
+    - unless: test -f /usr/bin/systemd-machine-id-setup -o -f /bin/systemd-machine-id-setup
 
 minion_id_cleared:
   file.absent:


### PR DESCRIPTION
## What does this PR change?

This PR makes two states more independant of location of systemd's utilities:
```
root@suma-bv-42-min-debian9:~# which systemd-machine-id-setup
/bin/systemd-machine-id-setup

root@suma-bv-42-min-debian10:~# which systemd-machine-id-setup
/usr/bin/systemd-machine-id-setup
```
