### PR TITLE
Fix opensuse153's avahi

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -125,6 +125,13 @@ runcmd:
   - zypper removerepo --all
 %{ endif }
 
+%{ if image == "opensuse153o" }
+packages: ["avahi", "nss-mdns"]
+
+runcmd:
+  - zypper removerepo --all
+%{ endif }
+
 %{ if image == "sles12sp4o" }
 zypper:
   repos:

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -65,6 +65,6 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse150o", "opensuse151o", "opensuse152o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
   type        = set(string)
 }


### PR DESCRIPTION
I tried to install Uyuni Master on libvirt with a mirror and one of the problems is that opensuse153 does not come with avahi preinstalled.

This patch fixes it.
