### PR TITLE
Drop openSUSE 15.0 and 15.1

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -194,7 +194,7 @@ The generated virtual host will be setup with:
 * a `default` virtual storage pool of `dir` type targeting `/var/lib/libvirt/images`
 * and a VM template disk image located in `/var/testsuite-data/disk-image-template.qcow2`.
 
-The template disk image is the `opensuse151` image used by sumaform and is downloaded when applying the highstate on the virtual host.
+The template disk image is the `opensuse153` image used by sumaform and is downloaded when applying the highstate on the virtual host.
 In order to use another or a cached image, use the `hvm_disk_image` variable.
 If the `hvm_disk_image` is set to the empty string, no image will be copied in `/var/testsuite-data/`.
 For example, to use a local image copy it in `salt/virthost/` folder and set `hvm_disk_image = "salt://virthost/imagename.qcow2"`

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -19,27 +19,6 @@ locals {
   additional_network = lookup(var.provider_settings, "additional_network", "172.16.2.0/24")
 }
 
-data "aws_ami" "opensuse150" {
-  most_recent = true
-  name_regex  = "^openSUSE-Leap-15-v"
-  owners      = ["679593333241"]
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
 data "aws_ami" "opensuse151" {
   most_recent = true
   name_regex  = "^openSUSE-Leap-15-1-v"
@@ -433,7 +412,6 @@ locals {
     ami_info = {
       opensuse152 = { ami = data.aws_ami.opensuse152.image_id },
       opensuse151 = { ami = data.aws_ami.opensuse151.image_id },
-      opensuse150 = { ami = data.aws_ami.opensuse150.image_id },
       sles15      = { ami = data.aws_ami.sles15.image_id },
       sles15sp1   = { ami = data.aws_ami.sles15sp1.image_id },
       sles15sp2o   = { ami = data.aws_ami.sles15sp2o.image_id },

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -19,27 +19,6 @@ locals {
   additional_network = lookup(var.provider_settings, "additional_network", "172.16.2.0/24")
 }
 
-data "aws_ami" "opensuse151" {
-  most_recent = true
-  name_regex  = "^openSUSE-Leap-15-1-v"
-  owners      = ["679593333241"]
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
 data "aws_ami" "opensuse152" {
   most_recent = true
   name_regex  = "^openSUSE-Leap-15-2-v"
@@ -411,7 +390,6 @@ locals {
     key_file = local.key_file
     ami_info = {
       opensuse152 = { ami = data.aws_ami.opensuse152.image_id },
-      opensuse151 = { ami = data.aws_ami.opensuse151.image_id },
       sles15      = { ami = data.aws_ami.sles15.image_id },
       sles15sp1   = { ami = data.aws_ami.sles15sp1.image_id },
       sles15sp2o   = { ami = data.aws_ami.sles15sp2o.image_id },
@@ -443,7 +421,7 @@ module "bastion" {
   source                        = "../host"
   quantity                      = local.create_network ? 1 : 0
   base_configuration            = local.configuration_output
-  image                         = "opensuse151"
+  image                         = "opensuse152"
   name                          = "bastion"
   connect_to_additional_network = true
   provider_settings = {

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -10,7 +10,7 @@ chpasswd:
     root:linux
 %{ endif }
 
-%{ if image == "opensuse152" || image == "opensuse151" }
+%{ if image == "opensuse152" }
 packages: ["salt-minion"]
 
 runcmd:

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -10,7 +10,7 @@ chpasswd:
     root:linux
 %{ endif }
 
-%{ if image == "opensuse152" || image == "opensuse151" || image == "opensuse150"}
+%{ if image == "opensuse152" || image == "opensuse151" }
 packages: ["salt-minion"]
 
 runcmd:

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -6,8 +6,6 @@ locals {
     centos7      = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2"
     centos7o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"
     centos8o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/8/x86_64/images/CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2"
-    opensuse151  = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse151.x86_64.qcow2"
-    opensuse151o = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2"
     opensuse152-ci-pr  = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse152-ci-pr.x86_64.qcow2"
     opensuse152o = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2"
     opensuse153-ci-pr  = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse153-ci-pr.x86_64.qcow2"

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -6,8 +6,6 @@ locals {
     centos7      = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2"
     centos7o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"
     centos8o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/8/x86_64/images/CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2"
-    opensuse150  = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse150.x86_64.qcow2"
-    opensuse150o = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.0/jeos/openSUSE-Leap-15.0-JeOS.x86_64-15.0.1-OpenStack-Cloud-Snapshot21.14.qcow2"
     opensuse151  = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse151.x86_64.qcow2"
     opensuse151o = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2"
     opensuse152-ci-pr  = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse152-ci-pr.x86_64.qcow2"

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -104,13 +104,6 @@ yum_repos:
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 
-%{ if image == "opensuse151o" }
-packages: ["qemu-guest-agent"]
-
-runcmd:
-  - zypper removerepo --all
-%{ endif }
-
 %{ if image == "opensuse152o" }
 packages: ["qemu-guest-agent"]
 

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -104,13 +104,6 @@ yum_repos:
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 
-%{ if image == "opensuse150o" }
-packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
-
-runcmd:
-  - zypper removerepo --all
-%{ endif }
-
 %{ if image == "opensuse151o" }
 packages: ["qemu-guest-agent"]
 

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -65,6 +65,6 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
   type        = set(string)
 }

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -65,6 +65,6 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
   type        = set(string)
 }

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -65,6 +65,6 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
   type        = set(string)
 }

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -65,6 +65,6 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
   type        = set(string)
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -31,7 +31,7 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
 }
 
 variable "mirror" {

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -31,7 +31,7 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse150o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse151o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
 }
 
 variable "mirror" {

--- a/modules/locust/main.tf
+++ b/modules/locust/main.tf
@@ -14,7 +14,7 @@ module "locust" {
     locust_slave_count = var.slave_quantity
   }
 
-  image   = "opensuse151"
+  image   = "opensuse152"
   provider_settings = var.provider_settings
 }
 
@@ -34,7 +34,7 @@ module "locust-slave" {
     locust_master_host = length(module.locust.configuration["hostnames"]) > 0 ? module.locust.configuration["hostnames"][0] : null
   }
 
-  image   = "opensuse151"
+  image   = "opensuse152"
   provider_settings = var.provider_settings
 }
 

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -99,7 +99,7 @@ variable "hypervisor" {
 }
 
 variable "image" {
-  description = "One of: sles15, sles15sp1, sles15sp2, sles15sp2o, sles15sp3o, opensuse150, opensuse151 or opensuse152o"
+  description = "One of: sles15, sles15sp1, sles15sp2, sles15sp2o, sles15sp3o, opensuse151 or opensuse152o"
   type        = string
 }
 

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -85,12 +85,12 @@ variable "hvm_disk_image_hash" {
 
 variable "xen_disk_image" {
   description = "URL to the disk image to use for Xen PV guests"
-  default     = "https://download.opensuse.org/distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-XEN-Current.qcow2"
+  default     = "https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
 }
 
 variable "xen_disk_image_hash" {
   description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
-  default     = "https://download.opensuse.org/distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-XEN-Current.qcow2.sha256"
+  default     = "https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
 }
 
 variable "hypervisor" {
@@ -99,7 +99,7 @@ variable "hypervisor" {
 }
 
 variable "image" {
-  description = "One of: sles15, sles15sp1, sles15sp2, sles15sp2o, sles15sp3o, opensuse151 or opensuse152o"
+  description = "One of: sles15, sles15sp1, sles15sp2, sles15sp2o, sles15sp3o or opensuse152o"
   type        = string
 }
 

--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -424,11 +424,6 @@ http:
     archs: [amd64]
 
   # openSUSE Leap
-  - url: http://download.opensuse.org/distribution/leap/15.0/repo/oss
-    archs: [x86_64]
-  - url: http://download.opensuse.org/update/leap/15.0/oss
-    archs: [x86_64]
-
   - url: http://download.opensuse.org/distribution/leap/15.1/repo/oss
     archs: [x86_64]
   - url: http://download.opensuse.org/update/leap/15.1/oss

--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -424,11 +424,6 @@ http:
     archs: [amd64]
 
   # openSUSE Leap
-  - url: http://download.opensuse.org/distribution/leap/15.1/repo/oss
-    archs: [x86_64]
-  - url: http://download.opensuse.org/update/leap/15.1/oss
-    archs: [x86_64]
-
   - url: http://download.opensuse.org/distribution/leap/15.2/repo/oss
     archs: [x86_64]
   - url: http://download.opensuse.org/update/leap/15.2/oss

--- a/salt/mirror/etc/mirror-images.conf
+++ b/salt/mirror/etc/mirror-images.conf
@@ -1,5 +1,4 @@
 https://github.com/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2
-http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse150.x86_64.qcow2
 http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse151.x86_64.qcow2
 http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15.x86_64.qcow2
 http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp1.x86_64.qcow2

--- a/salt/mirror/etc/mirror-images.conf
+++ b/salt/mirror/etc/mirror-images.conf
@@ -1,5 +1,4 @@
 https://github.com/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2
-http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse151.x86_64.qcow2
 http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15.x86_64.qcow2
 http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp1.x86_64.qcow2
 http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp2.x86_64.qcow2
@@ -9,8 +8,6 @@ http://github.com/moio/sumaform-images/releases/download/4.4.0/ubuntu1804.qcow2
 http://cloud.centos.org/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2
 http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
 http://cloud.centos.org/centos/8/x86_64/images/CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2
-http://download.opensuse.org/distribution/leap/15.0/jeos/openSUSE-Leap-15.0-JeOS.x86_64-15.0.1-OpenStack-Cloud-Current.qcow2
-http://download.opensuse.org/distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-15.1.0-OpenStack-Cloud-Current.qcow2
 http://download.opensuse.org/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2
 http://download.suse.de/install/SLE-15-JeOS-GM/SLES15-JeOS.x86_64-15.0-OpenStack-Cloud-GM.qcow2
 http://download.suse.de/install/SLE-15-SP1-JeOS-QU2/SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU2.qcow2


### PR DESCRIPTION
This drops the unsupported distro, to lighten up mirrors a bit.

Builds on top of https://github.com/uyuni-project/sumaform/pull/896 (is best merged after that one)