### PR TITLE
Fix 15sp2 and sp3 LTSS repos when coming from mirror, as we still are…

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -362,7 +362,7 @@ os_update_repo:
 # Already made in advance but empty now:
 os_ltss_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
 
 {% endif %} {# '15.2' == grains['osrelease'] #}
 
@@ -386,7 +386,7 @@ os_update_repo:
 # Already made in advance but empty now:
 os_ltss_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/x86_64/update/
 
 {% endif %} {# '15.3' == grains['osrelease'] #}
 


### PR DESCRIPTION
## What does this PR change?

Fix 15sp2 and sp3 LTSS repos when coming from mirror.
As we still are not able to sync them from scc, we need to sync them from the same ibs repo via http section in minima.
