### PR TITLE
Remove opensuse153 waiting for it to be available on AWS

### DIFF
--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -82,27 +82,6 @@ data "aws_ami" "opensuse152" {
   }
 }
 
-data "aws_ami" "opensuse153" {
-  most_recent = true
-  name_regex  = "^openSUSE-Leap-15-3-v"
-  owners      = ["679593333241"]
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
 data "aws_ami" "sles15" {
   most_recent = true
   name_regex  = "^suse-sles-15-byos-v"
@@ -431,7 +410,6 @@ locals {
     key_name = local.key_name
     key_file = local.key_file
     ami_info = {
-      opensuse153 = { ami = data.aws_ami.opensuse153.image_id },
       opensuse152 = { ami = data.aws_ami.opensuse152.image_id },
       opensuse151 = { ami = data.aws_ami.opensuse151.image_id },
       opensuse150 = { ami = data.aws_ami.opensuse150.image_id },


### PR DESCRIPTION
## What does this PR change?

Remove opensuse153 for aws backend because the ami is not available. Without ami matching opensuse153 search, it blocks sumaform deployment.

