### PR TITLE
Temporary replace the npm of cucumber-html-reporter

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -81,9 +81,16 @@ install_npm:
     - name: npm8
 
 # https://github.com/gkushang/cucumber-html-reporter
-install_cucumber_html_reporter_via_npm:
+#install_cucumber_html_reporter_via_npm:
+#  cmd.run:
+#    - name: npm install cucumber-html-reporter@5.2.0 --save-dev
+#    - require:
+#      - pkg: install_npm
+
+# Temporary using a personal fork until this commit is publicly released
+install_cucumber_html_reporter_via_git:
   cmd.run:
-    - name: npm install cucumber-html-reporter@5.2.0 --save-dev
+    - name: npm install github:srbarrios/cucumber-html-reporter#788ef843796aa76bfa33bb4dc4de04eb7c00c0ed
     - require:
       - pkg: install_npm
 
@@ -95,7 +102,7 @@ fix_cucumber_html_reporter_style:
             width: 100%;
         }
     - require:
-      - cmd: install_cucumber_html_reporter_via_npm
+      - cmd: install_cucumber_html_reporter_via_git
 
 git_config:
   file.append:


### PR DESCRIPTION
## What does this PR change?

In order to support the latest version of cucumber-ruby gem, we need to fix cucumber-html-reporter.
As the new output from the internal reporter is slightly different, so the hooks we have in place that contains the screenshots and logs of a failed scenario are stored differently, so we need to parse them differently.

As the external reporter has not many updates, it will probably take long time to have a new release.
So, as temporary solution, I would like to use my personal fork that includes the fix.