### PR TITLE
Support mirror in testsuite wrapper

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -125,7 +125,22 @@ module "mirror" {
 }
 ```
 
-Note you are encouraged to specify an additional libvirt storage pool name (`data` in the example above). Downloaded content will be placed on a separate disk in this pool - it helps SUSE Manager performance significantly if the pool is mapped onto a different physical disk. You can configure a pool with `virt-manager` like in the following image:
+Alternatively, if you use the `cucumber_testsuite` module, the latter can become:
+```hcl
+module "cucumber_testsuite" {
+  (...)
+  host_settings = {
+    (...)
+    mirror = {
+      volume_provider_settings = {
+        pool = "data"
+      }
+    }
+  }
+}
+```
+
+Note you are encouraged to specify an additional libvirt storage pool name (`data` in the examples above). Downloaded content will be placed on a separate disk in this pool - it helps SUSE Manager performance significantly if the pool is mapped onto a different physical disk. You can configure a pool with `virt-manager` like in the following image:
 
 ![data pool configuration in virt-manager](/help/data-pool-configuration.png)
 

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -92,6 +92,16 @@ locals {
   minimal_configuration = { hostname = contains(local.hosts, "proxy") ? local.proxy_full_name : local.server_full_name }
 }
 
+module "mirror" {
+  source = "../mirror"
+
+  quantity = contains(local.hosts, "mirror") ? 1 : 0
+  base_configuration = module.base.configuration
+
+  provider_settings        = lookup(local.provider_settings_by_host, "mirror", {})
+  volume_provider_settings = lookup(var.host_settings["mirror"], "volume_provider_settings", {})
+}
+
 module "suse-client" {
   source             = "../client"
 

--- a/modules/mirror/main.tf
+++ b/modules/mirror/main.tf
@@ -4,6 +4,7 @@ module "mirror" {
 
   base_configuration      = var.base_configuration
   name                    = "mirror"
+  quantity                = var.quantity
   use_os_released_updates = var.use_os_released_updates
   additional_repos        = var.additional_repos
   additional_packages     = var.additional_packages
@@ -19,7 +20,7 @@ module "mirror" {
     data_disk_fstype  = var.data_disk_fstype
   }
 
-  image = "opensuse151"
+  image = "opensuse152o"
 
   provider_settings        = var.provider_settings
   additional_disk_size     = var.repository_disk_size

--- a/modules/mirror/variables.tf
+++ b/modules/mirror/variables.tf
@@ -17,6 +17,11 @@ variable "additional_packages" {
   default     = []
 }
 
+variable "quantity" {
+  description = "number of hosts like this one"
+  default     = 0
+}
+
 variable "swap_file_size" {
   description = "Swap file size in MiB, or 0 for none"
   default     = 0


### PR DESCRIPTION
## What does this PR change?

So far, we could only use a mirror with old "modules" syntax.

This PR makes it possible to use the new "cucumber_testsuite" syntax.

It also switches the base image of mirrors from opensuse 15.1 to opensuse 15.2 "official".
