### PR TITLE
Update KVM image, using a JeOS openstack qcow2

### DIFF
--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -71,12 +71,12 @@ variable "ipv6" {
 
 variable "hvm_disk_image" {
   description = "URL to the disk image to use for KVM guests"
-  default     = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse151.x86_64.qcow2"
+  default     = "https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
 }
 
 variable "hvm_disk_image_hash" {
   description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
-  default     = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse151.x86_64.qcow2.sha256"
+  default     = "https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
 }
 
 variable "xen_disk_image" {


### PR DESCRIPTION
## What does this PR change?

Updating the KVM qcow2 image to retrieve it from a official repository, using a OpenStack JeOS version.

**Note:** We need to discuss if we want the mirror option on them, so using:
 ```
"${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
``` 
as we do for **opensuse153o**