### PR TITLE
Add scc support for aws deployment

### DIFF
--- a/backend_modules/aws/README.md
+++ b/backend_modules/aws/README.md
@@ -36,15 +36,16 @@ Most modules have configuration settings specific to the AWS backend, those are 
 ### Base Module
 Available provider settings for the base module:
 
-| Variable name      | Type   | Default value   | Description                                                                                                    |
-|--------------------|--------|-----------------|----------------------------------------------------------------------------------------------------------------|
-| region             | string | `null`          | AWS region where infrastructure will be created                                                                |
-| availability_zone  | string | `null`          | AWS availability zone inside region                                                                            |
-| ssh_allowed_ips    | array  | `[]`            | Array of IP's to white list for ssh connection                                                                 |
-| key_name           | string | `null`          | ssh key name in AWS                                                                                            |
-| key_file           | string | `null`          | ssh key file                                                                                                   |
-| bastion_host       | string | `null`          | bastian host use to connect machines in private network                                                        |
-| additional_network | string | `172.16.2.0/24` | A network mask for the additional network (needs to follow the pattern 172.16.X.Y/24, where X cannot be 0 or 1) |
+| Variable name            | Type   | Default value   | Description                                                                                                    |
+|--------------------------|--------|-----------------|----------------------------------------------------------------------------------------------------------------|
+| region                   | string | `null`          | AWS region where infrastructure will be created                                                                |
+| availability_zone        | string | `null`          | AWS availability zone inside region                                                                            |
+| ssh_allowed_ips          | array  | `[]`            | Array of IP's to white list for ssh connection                                                                 |
+| key_name                 | string | `null`          | ssh key name in AWS                                                                                            |
+| key_file                 | string | `null`          | ssh key file                                                                                                   |
+| bastion_host             | string | `null`          | bastian host use to connect machines in private network                                                        |
+| additional_network       | string | `172.16.2.0/24` | A network mask for the additional network (needs to follow the pattern 172.16.X.Y/24, where X cannot be 0 or 1)|
+| server_registration_code | string | `null`          | Add your SUMA SCC server registration code to use SCC repositories and disable internal repositories           |
 
 An example follows:
 ```hcl-terraform

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -3,6 +3,7 @@ locals {
   region            = lookup(var.provider_settings, "region", null)
   ssh_allowed_ips   = lookup(var.provider_settings, "ssh_allowed_ips", [])
   name_prefix       = var.name_prefix
+  server_registry_code = var.server_registry_code
 
   key_name = lookup(var.provider_settings, "key_name", null)
   key_file = lookup(var.provider_settings, "key_file", null)
@@ -61,7 +62,7 @@ data "aws_ami" "sles15" {
   }
 }
 
-data "aws_ami" "sles15sp1" {
+data "aws_ami" "sles15sp1o" {
   most_recent = true
   name_regex  = "^suse-sles-15-sp1-byos-v"
   owners      = ["013907871322"]
@@ -392,7 +393,7 @@ locals {
     ami_info = {
       opensuse152 = { ami = data.aws_ami.opensuse152.image_id },
       sles15      = { ami = data.aws_ami.sles15.image_id },
-      sles15sp1   = { ami = data.aws_ami.sles15sp1.image_id },
+      sles15sp1o   = { ami = data.aws_ami.sles15sp1o.image_id },
       sles15sp2o   = { ami = data.aws_ami.sles15sp2o.image_id },
       sles12sp5   = { ami = data.aws_ami.sles12sp5.image_id },
       sles12sp4   = { ami = data.aws_ami.sles12sp4.image_id },

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -380,6 +380,7 @@ locals {
     name_prefix          = var.name_prefix
     use_shared_resources = var.use_shared_resources
     testsuite            = var.testsuite
+    server_registry_code = var.server_registry_code
 
     additional_network = local.additional_network
 

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -3,7 +3,6 @@ locals {
   region            = lookup(var.provider_settings, "region", null)
   ssh_allowed_ips   = lookup(var.provider_settings, "ssh_allowed_ips", [])
   name_prefix       = var.name_prefix
-  server_registry_code = var.server_registry_code
 
   key_name = lookup(var.provider_settings, "key_name", null)
   key_file = lookup(var.provider_settings, "key_file", null)
@@ -381,7 +380,7 @@ locals {
     name_prefix          = var.name_prefix
     use_shared_resources = var.use_shared_resources
     testsuite            = var.testsuite
-    server_registry_code = var.server_registry_code
+    server_registration_code = var.server_registration_code
 
     additional_network = local.additional_network
 

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -38,10 +38,10 @@ data "template_file" "user_data" {
   count    = var.quantity > 0 ? var.quantity : 0
   template = file("${path.module}/user_data.yaml")
   vars = {
-    image           = var.image
-    public_instance = local.provider_settings["public_instance"]
-    mirror_url      = var.base_configuration["mirror"]
-    server_registry_code             = var.base_configuration["server_registry_code"]
+    image                = var.image
+    public_instance      = local.provider_settings["public_instance"]
+    mirror_url           = var.base_configuration["mirror"]
+    server_registry_code = var.base_configuration["server_registry_code"]
   }
 }
 

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -41,6 +41,7 @@ data "template_file" "user_data" {
     image           = var.image
     public_instance = local.provider_settings["public_instance"]
     mirror_url      = var.base_configuration["mirror"]
+    server_registry_code             = var.base_configuration["server_registry_code"]
   }
 }
 

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -41,7 +41,7 @@ data "template_file" "user_data" {
     image                = var.image
     public_instance      = local.provider_settings["public_instance"]
     mirror_url           = var.base_configuration["mirror"]
-    server_registration_code = var.base_configuration["server_registration_code"]
+    server_registration_code = var.base_configuration["server_registration_code"] != null ? var.base_configuration["server_registration_code"]: ""
   }
 }
 

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -41,7 +41,7 @@ data "template_file" "user_data" {
     image                = var.image
     public_instance      = local.provider_settings["public_instance"]
     mirror_url           = var.base_configuration["mirror"]
-    server_registry_code = var.base_configuration["server_registry_code"]
+    server_registration_code = var.base_configuration["server_registration_code"]
   }
 }
 

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -23,7 +23,6 @@ runcmd:
 %{ endif }
 
 %{ if image == "sles15"}
-
 zypper:
   repos:
     - id: os_pool_repo
@@ -34,6 +33,17 @@ zypper:
 
 packages: ["salt-minion"]
 %{ endif }
+
+%{ if image == "sles15sp2o"}
+runcmd:
+  - SUSEConnect --url https://scc.suse.com -r ${server_registry_code}
+  - SUSEConnect -p sle-module-python2/15.2/x86_64
+  - SUSEConnect -p sle-module-web-scripting/15.2/x86_64
+  - SUSEConnect -p sle-module-suse-manager-server/4.1/x86_64
+  - zypper in -y salt-minion
+
+%{ endif }
+
 %{ if image == "sles12sp3"}
 zypper:
   repos:

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -34,13 +34,34 @@ zypper:
 packages: ["salt-minion"]
 %{ endif }
 
-%{ if image == "sles15sp2o"}
+%{ if server_registry_code != "null" }
+
+%{ if image == "sles15sp1o" }
+runcmd:
+  - SUSEConnect --url https://scc.suse.com -r ${server_registry_code}
+  - SUSEConnect -p sle-module-python2/15.1/x86_64
+  - SUSEConnect -p sle-module-web-scripting/15.1/x86_64
+  - SUSEConnect -p sle-module-suse-manager-server/4.0/x86_64
+  - zypper in -y salt-minion
+%{ endif }
+
+%{ if image == "sles15sp2o" }
 runcmd:
   - SUSEConnect --url https://scc.suse.com -r ${server_registry_code}
   - SUSEConnect -p sle-module-python2/15.2/x86_64
   - SUSEConnect -p sle-module-web-scripting/15.2/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.1/x86_64
   - zypper in -y salt-minion
+%{ endif }
+
+%{ if image == "sles15sp3o" }
+runcmd:
+  - SUSEConnect --url https://scc.suse.com -r ${server_registry_code}
+  - SUSEConnect -p sle-module-python2/15.3/x86_64
+  - SUSEConnect -p sle-module-web-scripting/15.3/x86_64
+  - SUSEConnect -p sle-module-suse-manager-server/4.2/x86_64
+  - zypper in -y salt-minion
+%{ endif }
 
 %{ endif }
 

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -35,32 +35,33 @@ packages: ["salt-minion"]
 %{ endif }
 
 %{ if server_registration_code != "null" }
-runcmd:
-  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code}
 
 %{ if image == "sles15sp1o" }
 runcmd:
+  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code}
   - SUSEConnect -p sle-module-python2/15.1/x86_64
   - SUSEConnect -p sle-module-web-scripting/15.1/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.0/x86_64
+  - zypper in -y salt-minion
 %{ endif }
 
 %{ if image == "sles15sp2o" }
 runcmd:
+  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code}
   - SUSEConnect -p sle-module-python2/15.2/x86_64
   - SUSEConnect -p sle-module-web-scripting/15.2/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.1/x86_64
+  - zypper in -y salt-minion
 %{ endif }
 
 %{ if image == "sles15sp3o" }
 runcmd:
+  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code}
   - SUSEConnect -p sle-module-python2/15.3/x86_64
   - SUSEConnect -p sle-module-web-scripting/15.3/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.2/x86_64
-%{ endif }
-
-runcmd:
   - zypper in -y salt-minion
+%{ endif }
 
 %{ endif }
 

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -34,7 +34,7 @@ zypper:
 packages: ["salt-minion"]
 %{ endif }
 
-%{ if server_registration_code != "null" }
+%{ if server_registration_code != "" }
 
 %{ if image == "sles15sp1o" }
 runcmd:

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -34,34 +34,33 @@ zypper:
 packages: ["salt-minion"]
 %{ endif }
 
-%{ if server_registry_code != "null" }
+%{ if server_registration_code != "null" }
+runcmd:
+  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code}
 
 %{ if image == "sles15sp1o" }
 runcmd:
-  - SUSEConnect --url https://scc.suse.com -r ${server_registry_code}
   - SUSEConnect -p sle-module-python2/15.1/x86_64
   - SUSEConnect -p sle-module-web-scripting/15.1/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.0/x86_64
-  - zypper in -y salt-minion
 %{ endif }
 
 %{ if image == "sles15sp2o" }
 runcmd:
-  - SUSEConnect --url https://scc.suse.com -r ${server_registry_code}
   - SUSEConnect -p sle-module-python2/15.2/x86_64
   - SUSEConnect -p sle-module-web-scripting/15.2/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.1/x86_64
-  - zypper in -y salt-minion
 %{ endif }
 
 %{ if image == "sles15sp3o" }
 runcmd:
-  - SUSEConnect --url https://scc.suse.com -r ${server_registry_code}
   - SUSEConnect -p sle-module-python2/15.3/x86_64
   - SUSEConnect -p sle-module-web-scripting/15.3/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.2/x86_64
-  - zypper in -y salt-minion
 %{ endif }
+
+runcmd:
+  - zypper in -y salt-minion
 
 %{ endif }
 

--- a/backend_modules/null/base/main.tf
+++ b/backend_modules/null/base/main.tf
@@ -16,6 +16,7 @@ resource "null_resource" "base" {
     testsuite            = var.testsuite
     provider_settings    = yamlencode(var.provider_settings)
     images               = yamlencode(var.images)
+    server_registry_code = var.server_registry_code
   }
 }
 
@@ -33,5 +34,6 @@ output "configuration" {
     name_prefix          = var.name_prefix
     use_shared_resources = var.use_shared_resources
     testsuite            = var.testsuite
+    server_registry_code = var.server_registry_code
   }
 }

--- a/backend_modules/null/base/main.tf
+++ b/backend_modules/null/base/main.tf
@@ -16,7 +16,7 @@ resource "null_resource" "base" {
     testsuite            = var.testsuite
     provider_settings    = yamlencode(var.provider_settings)
     images               = yamlencode(var.images)
-    server_registry_code = var.server_registry_code
+    server_registration_code = var.server_registration_code
   }
 }
 
@@ -34,6 +34,6 @@ output "configuration" {
     name_prefix          = var.name_prefix
     use_shared_resources = var.use_shared_resources
     testsuite            = var.testsuite
-    server_registry_code = var.server_registry_code
+    server_registration_code = var.server_registration_code
   }
 }

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -71,6 +71,5 @@ variable "images" {
 
 variable "server_registry_code" {
   description = "Use scc register"
-  type        = string
-  default = null
+  default     = "null"
 }

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -68,3 +68,9 @@ variable "images" {
   default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
   type        = set(string)
 }
+
+variable "server_registry_code" {
+  description = "Use scc register"
+  type        = string
+  default = null
+}

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -69,7 +69,7 @@ variable "images" {
   type        = set(string)
 }
 
-variable "server_registry_code" {
-  description = "Use scc register"
+variable "server_registration_code" {
+  description = "Use SUMA SCC registration code to enable the SLES and SUMA repositories"
   default     = "null"
 }

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -71,5 +71,5 @@ variable "images" {
 
 variable "server_registration_code" {
   description = "Use SUMA SCC registration code to enable the SLES and SUMA repositories"
-  default     = "null"
+  default     = null
 }

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -15,6 +15,7 @@ module "base_backend" {
   testsuite            = var.testsuite
   provider_settings    = var.provider_settings
   images               = var.images
+  server_registry_code = var.server_registry_code
 }
 
 output "configuration" {
@@ -31,5 +32,6 @@ output "configuration" {
     name_prefix          = var.name_prefix
     use_shared_resources = var.use_shared_resources
     testsuite            = var.testsuite
+    server_registry_code = var.server_registry_code
   }, module.base_backend.configuration)
 }

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -15,7 +15,7 @@ module "base_backend" {
   testsuite            = var.testsuite
   provider_settings    = var.provider_settings
   images               = var.images
-  server_registry_code = var.server_registry_code
+  server_registration_code = var.server_registration_code
 }
 
 output "configuration" {
@@ -32,6 +32,6 @@ output "configuration" {
     name_prefix          = var.name_prefix
     use_shared_resources = var.use_shared_resources
     testsuite            = var.testsuite
-    server_registry_code = var.server_registry_code
+    server_registration_code = var.server_registration_code
   }, module.base_backend.configuration)
 }

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -72,5 +72,5 @@ variable "images" {
 variable "server_registry_code" {
   description = "Use scc register"
   type        = string
-  default = null
+  default     = "null"
 }

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -68,3 +68,9 @@ variable "images" {
   default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
   type        = set(string)
 }
+
+variable "server_registry_code" {
+  description = "Use scc register"
+  type        = string
+  default = null
+}

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -69,7 +69,7 @@ variable "images" {
   type        = set(string)
 }
 
-variable "server_registry_code" {
+variable "server_registration_code" {
   description = "Use scc register"
   type        = string
   default     = "null"

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -77,7 +77,7 @@ module "server" {
     saltapi_tcpdump                = var.saltapi_tcpdump
     repository_disk_size           = var.repository_disk_size
     forward_registration           = var.forward_registration
-    server_registry_code           = var.server_registry_code
+    server_registry_code           = var.base_configuration["server_registry_code"]
   }
 
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -77,6 +77,7 @@ module "server" {
     saltapi_tcpdump                = var.saltapi_tcpdump
     repository_disk_size           = var.repository_disk_size
     forward_registration           = var.forward_registration
+    server_registry_code           = var.server_registry_code
   }
 
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -77,7 +77,7 @@ module "server" {
     saltapi_tcpdump                = var.saltapi_tcpdump
     repository_disk_size           = var.repository_disk_size
     forward_registration           = var.forward_registration
-    server_registry_code           = var.base_configuration["server_registry_code"]
+    server_registration_code           = var.base_configuration["server_registration_code"]
   }
 
 

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -274,9 +274,3 @@ variable "forward_registration" {
   description = "Forward client registrations to SCC"
   default     = false
 }
-
-variable "server_registry_code" {
-  description = "Use scc register"
-  type        = string
-  default = null
-}

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -274,3 +274,9 @@ variable "forward_registration" {
   description = "Forward client registrations to SCC"
   default     = false
 }
+
+variable "server_registry_code" {
+  description = "Use scc register"
+  type        = string
+  default = null
+}

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -335,7 +335,7 @@ test_update_repo:
 {% endif %}
 {% endif %} {# '15' == grains['osrelease'] #}
 
-{% if '15.1' == grains['osrelease'] %}
+{% if '15.1' == grains['osrelease'] and grains['server_registry_code'] == 'null' %}
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/
@@ -350,7 +350,7 @@ os_ltss_repo:
 
 {% endif %} {# '15.1' == grains['osrelease'] #}
 
-{% if '15.2' == grains['osrelease'] %}
+{% if '15.2' == grains['osrelease'] and grains['server_registry_code'] == 'null' %}
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -335,7 +335,7 @@ test_update_repo:
 {% endif %}
 {% endif %} {# '15' == grains['osrelease'] #}
 
-{% if '15.1' == grains['osrelease'] and grains['server_registry_code'] == 'null' %}
+{% if '15.1' == grains['osrelease'] and grains['server_registration_code'] == 'null' %}
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/
@@ -350,7 +350,7 @@ os_ltss_repo:
 
 {% endif %} {# '15.1' == grains['osrelease'] #}
 
-{% if '15.2' == grains['osrelease'] and grains['server_registry_code'] == 'null' %}
+{% if '15.2' == grains['osrelease'] and grains['server_registration_code'] == 'null' %}
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -54,7 +54,7 @@ module_python2_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/
 {% endif %}
 
-{% if '4.1' in grains['product_version'] %}
+{% if '4.1' in grains['product_version'] and grains['server_registry_code'] == 'null' %}
 server_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.1/x86_64/product/

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -12,7 +12,7 @@ server_update_repo:
     - priority: 97
 {% endif %}
 
-{% if '4.0' in grains['product_version'] %}
+{% if '4.0' in grains['product_version'] and not grains.get('server_registry_code') %}
 server_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.0/x86_64/product/
@@ -54,7 +54,7 @@ module_python2_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/
 {% endif %}
 
-{% if '4.1' in grains['product_version'] and grains['server_registry_code'] == 'null' %}
+{% if '4.1' in grains['product_version'] and not grains.get('server_registry_code') %}
 server_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.1/x86_64/product/
@@ -96,7 +96,7 @@ module_python2_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP2/x86_64/update/
 {% endif %}
 
-{% if '4.2' in grains['product_version'] %}
+{% if '4.2' in grains['product_version'] and not grains.get('server_registry_code') %}
 server_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.2/x86_64/product/

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -12,7 +12,7 @@ server_update_repo:
     - priority: 97
 {% endif %}
 
-{% if '4.0' in grains['product_version'] and not grains.get('server_registry_code') %}
+{% if '4.0' in grains['product_version'] and not grains.get('server_registration_code') %}
 server_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.0/x86_64/product/
@@ -54,7 +54,7 @@ module_python2_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/
 {% endif %}
 
-{% if '4.1' in grains['product_version'] and not grains.get('server_registry_code') %}
+{% if '4.1' in grains['product_version'] and not grains.get('server_registration_code') %}
 server_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.1/x86_64/product/
@@ -96,7 +96,7 @@ module_python2_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP2/x86_64/update/
 {% endif %}
 
-{% if '4.2' in grains['product_version'] and not grains.get('server_registry_code') %}
+{% if '4.2' in grains['product_version'] and not grains.get('server_registration_code') %}
 server_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.2/x86_64/product/

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -27,7 +27,7 @@ server_packages:
       - sls: repos
       - sls: server.firewall
 
-{% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' %}
+{% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' and grains['server_registry_code'] == 'null' %}
 product_package_installed:
    cmd.run:
      - name: zypper --non-interactive install --auto-agree-with-licenses --force-resolution -t product SUSE-Manager-Server

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -27,7 +27,7 @@ server_packages:
       - sls: repos
       - sls: server.firewall
 
-{% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' and grains['server_registry_code'] == 'null' %}
+{% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' and grains['server_registration_code'] == 'null' %}
 product_package_installed:
    cmd.run:
      - name: zypper --non-interactive install --auto-agree-with-licenses --force-resolution -t product SUSE-Manager-Server


### PR DESCRIPTION
## What does this PR change?

The use of internal repositories for public imply the use of mirror. The use of this mirror make the deployment very time consuming.

The idea of this PR is  to have the possibility to use SCC repositories when deploying on AWS. So when we want to test AWS deployment, we will only need to mirror repositories needed for the test and don't need to mirror all the default repositories.

The scc is an added behavior that change nothing  on default deployment. 

To use it, you need to add to module `base` the variable `server_registry_code` in your main.tf

The code has to be a Suse Manager Server activation code.

