### PR TITLE
Add SLE and backport updates for Leap >= 15.3

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -21,6 +21,16 @@ os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/oss/
 
+{% if grains['osrelease_info'][0] == 15 and grains['osrelease_info'][1] >= 3 %}
+sle_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/sle/
+
+backports_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/backports/
+{% endif %}
+
 {% if not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles')) %}
 {% if grains.get('product_version') and 'uyuni-master' in grains.get('product_version') | default('', true) %}
 tools_pool_repo:


### PR DESCRIPTION
## What does this PR change?

Leap 15.3 requires two new repos that are always present.

This PR is adding them. Please review if my evaluation of `osrelase_info` grain is correct.

This fixes the issue:
```
Run 1810:
module.cucumber_testsuite.module.server.module.server.module.host.null_resource.provisioning[0] (remote-exec): Problem: the to be installed firewalld-0.9.3-1.1.noarch requires 'python3-firewall = 0.9.3', but this requirement cannot be provided
module.cucumber_testsuite.module.server.module.server.module.host.null_resource.provisioning[0] (remote-exec):   not installable providers: python3-firewall-0.9.3-1.1.noarch[os_pool_repo]
module.cucumber_testsuite.module.server.module.server.module.host.null_resource.provisioning[0] (remote-exec):  Solution 1: downgrade of libfreebl3-3.53.1-3.53.1.x86_64 to libfreebl3-3.53.1-3.51.1.x86_64
module.cucumber_testsuite.module.server.module.server.module.host.null_resource.provisioning[0] (remote-exec):  Solution 2: do not install firewalld-0.9.3-1.1.noarch
module.cucumber_testsuite.module.server.module.server.module.host.null_resource.provisioning[0] (remote-exec):  Solution 3: break firewalld-0.9.3-1.1.noarch by ignoring some of its dependencies
```