### PR TITLE
Revert "Skip 'update-ca-certificates' run if the certs are updated automatically"

### DIFF
--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -42,17 +42,13 @@ suse_certificate:
     - makedirs: True
 
 update_ca_truststore:
-  cmd.run:
+  cmd.wait:
     - name: /usr/sbin/update-ca-certificates
-    - onchanges:
+    - watch:
       - file: registry_certificate
       - file: suse_certificate
     - require:
       - pkg: suse_minion_cucumber_requisites
-    - unless:
-      - fun: service.status
-        args:
-          - ca-certificates.path
 
 {% endif %}
 

--- a/salt/repos/additional.sls
+++ b/salt/repos/additional.sls
@@ -42,12 +42,7 @@
 
 {% if grains['os'] == 'SUSE' %}
 update-ca-certificates:
-  cmd.run:
-    - name: /usr/sbin/update-ca-certificates
-    - unless:
-      - fun: service.status
-        args:
-          - ca-certificates.path
+  cmd.run
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Reverts uyuni-project/sumaform#926 due to a python exception during initialization of the minion.