### PR TITLE
Remove calls to update-ca-certificates

### DIFF
--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -78,6 +78,5 @@ export AUTH_REGISTRY_CREDENTIALS="{{ grains.get('auth_registry_username') }}|{{ 
 #### Generate certificates for Google Chrome
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then
   wget http://$SERVER/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$SERVER.cert
-  update-ca-certificates
   certutil -d sql:/root/.pki/nssdb -A -t TC -n "susemanager" -i  /etc/pki/trust/anchors/$SERVER.cert
 fi

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -41,15 +41,6 @@ suse_certificate:
     - source: salt://minion/certs/SUSE_Trust_Root.crt.pem
     - makedirs: True
 
-update_ca_truststore:
-  cmd.wait:
-    - name: /usr/sbin/update-ca-certificates
-    - watch:
-      - file: registry_certificate
-      - file: suse_certificate
-    - require:
-      - pkg: suse_minion_cucumber_requisites
-
 {% endif %}
 
 {% endif %}

--- a/salt/repos/additional.sls
+++ b/salt/repos/additional.sls
@@ -40,10 +40,6 @@
     - source: {{ url }}
     - source_hash: {{ url }}.sha512
 
-{% if grains['os'] == 'SUSE' %}
-update-ca-certificates:
-  cmd.run
-{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
## What does this PR change?

We currently hit this bug on SLE 15 SP3 minions:

https://bugzilla.suse.com/show_bug.cgi?id=1188500

From what I understand from https://www.mankier.com/8/update-ca-trust (but I am not a specialist), when you write files to `/etc/pki/trust/anchors/`, they are already at the right place, so you don't need to run `/usr/sbin/update-ca-certificates`. My impression is, our states to call it have always been unneeded.

This PR simply removes all calls to this utility.

@moio, opinion?
