### PR TITLE
Skip 'update-ca-certificates' run if the certs are updated automatically

### DIFF
--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -42,13 +42,19 @@ suse_certificate:
     - makedirs: True
 
 update_ca_truststore:
-  cmd.wait:
+  cmd.run:
     - name: /usr/sbin/update-ca-certificates
-    - watch:
+    - onchanges:
       - file: registry_certificate
       - file: suse_certificate
     - require:
       - pkg: suse_minion_cucumber_requisites
+{%- if grains['saltversioninfo'][0] >= 3002 %} # Workaround for bsc#1188641
+    - unless:
+      - fun: service.status
+        args:
+          - ca-certificates.path
+{%- endif %}
 
 {% endif %}
 

--- a/salt/repos/additional.sls
+++ b/salt/repos/additional.sls
@@ -42,7 +42,14 @@
 
 {% if grains['os'] == 'SUSE' %}
 update-ca-certificates:
-  cmd.run
+  cmd.run:
+    - name: /usr/sbin/update-ca-certificates
+{%- if grains['saltversioninfo'][0] >= 3002 %} # Workaround for bsc#1188641
+    - unless:
+      - fun: service.status
+        args:
+          - ca-certificates.path
+{%- endif %}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
In SLES15SP3, the directory `/etc/pki/trust/anchors` is watched via the `ca-certificates.path` systemd unit, and as soon as its contents changed, the system-wide certificates are updated automatically. In `certs` state, we run `update-ca-certificates` right after deploying certs. These two processes create a race condition that in rare cases leads to an error.

This PR updates the `certs` state to run `update-ca-certificates` only if this systemd unit does not exist or is not running.

See https://bugzilla.suse.com/1188500