### PR TITLE
Update default images in testsuite module

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -98,8 +98,8 @@ module "suse-client" {
   quantity = contains(local.hosts, "suse-client") ? 1 : 0
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "suse-client", "sles12sp5o")
-  name               = lookup(local.names, "suse-client", "cli-sles12")
+  image              = lookup(local.images, "suse-client", "sles15sp2o")
+  name               = lookup(local.names, "suse-client", "cli-sles15")
 
   server_configuration = local.minimal_configuration
 
@@ -118,8 +118,8 @@ module "suse-minion" {
   quantity = contains(local.hosts, "suse-minion") ? 1 : 0
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "suse-minion", "sles12sp5o")
-  name               = lookup(local.names, "suse-minion", "min-sles12")
+  image              = lookup(local.images, "suse-minion", "sles15sp2o")
+  name               = lookup(local.names, "suse-minion", "min-sles15")
 
   server_configuration = local.minimal_configuration
 
@@ -138,7 +138,7 @@ module "build-host" {
   quantity           = contains(local.hosts, "build-host") ? 1 : 0
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "build-host", "sles12sp5o")
+  image              = lookup(local.images, "build-host", "sles15sp2o")
   name               = lookup(local.names, "build-host", "min-build")
 
   server_configuration = local.minimal_configuration
@@ -160,8 +160,8 @@ module "suse-sshminion" {
 
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "suse-sshminion", "sles12sp5o")
-  name               = lookup(local.names, "suse-sshminion", "minssh-sles12")
+  image              = lookup(local.images, "suse-sshminion", "sles15sp2o")
+  name               = lookup(local.names, "suse-sshminion", "minssh-sles15")
 
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
@@ -198,8 +198,8 @@ module "debian-minion" {
 
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "debian-minion", "ubuntu1804o")
-  name               = lookup(local.names, "debian-minion", "min-ubuntu1804")
+  image              = lookup(local.images, "debian-minion", "ubuntu2004o")
+  name               = lookup(local.names, "debian-minion", "min-ubuntu2004")
 
   server_configuration   = local.minimal_configuration
   auto_connect_to_master = false
@@ -216,7 +216,7 @@ module "pxeboot-minion" {
   quantity = contains(local.hosts, "pxeboot-minion") ? 1 : 0
 
   base_configuration = module.base.configuration
-  image              = lookup(local.images, "pxeboot-minion", "sles12sp3")
+  image              = lookup(local.images, "pxeboot-minion", "sles15sp3o")
   name               = lookup(local.names, "pxeboot-minion", "min-pxeboot")
   provider_settings  = lookup(local.provider_settings_by_host, "pxeboot-minion", {})
 }
@@ -228,7 +228,7 @@ module "kvm-host" {
 
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "kvm-host", "sles15sp1o")
+  image              = lookup(local.images, "kvm-host", "sles15sp3o")
   name               = lookup(local.names, "kvm-host", "min-kvm")
 
   server_configuration = local.minimal_configuration
@@ -249,7 +249,7 @@ module "xen-host" {
 
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "xen-host", "sles15sp1")
+  image              = lookup(local.images, "xen-host", "sles15sp3o")
   name               = lookup(local.names, "xen-host", "min-xen")
   hypervisor         = "xen"
 


### PR DESCRIPTION
## What does this PR change?

Update default images in test suite module.

Following the values we use in our SUSE Manager 4.2 CI, as if we don't set those new values, a user deploying with default values will have a failed test suite (the test suite expect these concrete versions):
``` 
module "cucumber_testsuite" {
  source = "./modules/cucumber_testsuite"

  product_version = "4.2-nightly"

  // Cucumber repository configuration for the controller
  git_username = var.GIT_USER
  git_password = var.GIT_PASSWORD
  git_repo     = var.CUCUMBER_GITREPO
  branch       = var.CUCUMBER_BRANCH

  cc_username = var.SCC_USER
  cc_password = var.SCC_PASSWORD

  images = ["centos7o", "opensuse152o", "sles15sp2o", "sles15sp3o", "ubuntu2004o"]

  use_avahi = false
  name_prefix = "suma-42-"
  domain = "mgr.prv.suse.net"
  from_email = "root@suse.de"

  no_auth_registry = "registry.mgr.prv.suse.net"
  auth_registry = "registry.mgr.prv.suse.net:5000/cucutest"
  auth_registry_username = "cucutest"
  auth_registry_password = "cucusecret"
  git_profiles_repo = "https://github.com/uyuni-project/uyuni.git#:testsuite/features/profiles/internal_prv"

  mirror = "minima-mirror.mgr.prv.suse.net"
  use_mirror_images = true
  server_http_proxy = "galaxy-proxy.mgr.prv.suse.net:3128"

  host_settings = {
    controller = {
      provider_settings = {
        mac = "aa:b2:92:03:00:c0"
      }
    }
    server = {
      provider_settings = {
        mac = "aa:b2:92:03:00:c1"
      }
    }
    proxy = {
      provider_settings = {
        mac = "aa:b2:92:03:00:c2"
      }
    }
    suse-client = {
      image = "sles15sp2o"
      name = "cli-sles15"
      provider_settings = {
        mac = "aa:b2:92:03:00:c4"
      }
    }
    suse-minion = {
      image = "sles15sp2o"
      name = "min-sles15"
      provider_settings = {
        mac = "aa:b2:92:03:00:c6"
      }
    }
    suse-sshminion = {
      image = "sles15sp2o"
      name = "minssh-sles15"
      provider_settings = {
        mac = "aa:b2:92:03:00:c8"
      }
    }
    redhat-minion = {
      image = "centos7o"
      provider_settings = {
        mac = "aa:b2:92:03:00:c9"
        // Openscap cannot run with less than 1.25 GB of RAM
        memory = 1280
      }
    }
    debian-minion = {
      name = "min-ubuntu2004"
      image = "ubuntu2004o"
      provider_settings = {
        mac = "aa:b2:92:03:00:cc"
      }
    }
    build-host = {
      image = "sles15sp2o"
      provider_settings = {
        mac = "aa:b2:92:03:00:cd"
      }
    }
    pxeboot-minion = {
      image = "sles15sp3o"
    }
    kvm-host = {
      image = "sles15sp3o"
      provider_settings = {
        mac = "aa:b2:92:03:00:ce"
      }
    }
    xen-host = {
      image = "sles15sp3o"
      provider_settings = {
        mac = "aa:b2:92:03:00:cf"
      }
    }
  }
  provider_settings = {
    pool = "ssd"
    network_name = null
    bridge = "br1"
    additional_network = "192.168.42.0/24"
  }
}

output "configuration" {
  value = module.cucumber_testsuite.configuration
}
```