### PR TITLE
Add scc proxy support for AWS

### DIFF
--- a/backend_modules/aws/README.md
+++ b/backend_modules/aws/README.md
@@ -45,8 +45,8 @@ Available provider settings for the base module:
 | key_file                 | string | `null`          | ssh key file                                                                                                   |
 | bastion_host             | string | `null`          | bastian host use to connect machines in private network                                                        |
 | additional_network       | string | `172.16.2.0/24` | A network mask for the additional network (needs to follow the pattern 172.16.X.Y/24, where X cannot be 0 or 1)|
-| server_registration_code | string | `null`          | Add your SUMA SCC server registration code to use SCC repositories and disable internal repositories           |
-| proxy_registration_code  | string | `null`          | Add your SUMA SCC proxy registration code to use SCC repositories and disable internal repositories            |
+| server_registration_code | string | `null`          | SUMA SCC server registration code to use SCC repositories and disable internal repositories                    |
+| proxy_registration_code  | string | `null`          | SUMA SCC proxy registration code to use SCC repositories and disable internal repositories                     |
 
 
 An example follows:

--- a/backend_modules/aws/README.md
+++ b/backend_modules/aws/README.md
@@ -46,6 +46,8 @@ Available provider settings for the base module:
 | bastion_host             | string | `null`          | bastian host use to connect machines in private network                                                        |
 | additional_network       | string | `172.16.2.0/24` | A network mask for the additional network (needs to follow the pattern 172.16.X.Y/24, where X cannot be 0 or 1)|
 | server_registration_code | string | `null`          | Add your SUMA SCC server registration code to use SCC repositories and disable internal repositories           |
+| proxy_registration_code  | string | `null`          | Add your SUMA SCC proxy registration code to use SCC repositories and disable internal repositories            |
+
 
 An example follows:
 ```hcl-terraform

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -368,19 +368,20 @@ module "network" {
 
 locals {
   configuration_output = merge({
-    cc_username          = var.cc_username
-    cc_password          = var.cc_password
-    timezone             = var.timezone
-    use_ntp              = var.use_ntp
-    ssh_key_path         = var.ssh_key_path
-    mirror               = var.mirror
-    use_mirror_images    = var.use_mirror_images
-    use_avahi            = var.use_avahi
-    domain               = var.domain
-    name_prefix          = var.name_prefix
-    use_shared_resources = var.use_shared_resources
-    testsuite            = var.testsuite
+    cc_username              = var.cc_username
+    cc_password              = var.cc_password
+    timezone                 = var.timezone
+    use_ntp                  = var.use_ntp
+    ssh_key_path             = var.ssh_key_path
+    mirror                   = var.mirror
+    use_mirror_images        = var.use_mirror_images
+    use_avahi                = var.use_avahi
+    domain                   = var.domain
+    name_prefix              = var.name_prefix
+    use_shared_resources     = var.use_shared_resources
+    testsuite                = var.testsuite
     server_registration_code = var.server_registration_code
+    proxy_registration_code  = var.proxy_registration_code
 
     additional_network = local.additional_network
 

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -38,10 +38,11 @@ data "template_file" "user_data" {
   count    = var.quantity > 0 ? var.quantity : 0
   template = file("${path.module}/user_data.yaml")
   vars = {
-    image                = var.image
-    public_instance      = local.provider_settings["public_instance"]
-    mirror_url           = var.base_configuration["mirror"]
-    server_registration_code = var.base_configuration["server_registration_code"] != null ? var.base_configuration["server_registration_code"]: ""
+    image                    = var.image
+    public_instance          = local.provider_settings["public_instance"]
+    mirror_url               = var.base_configuration["mirror"]
+    server_registration_code = var.base_configuration["server_registration_code"] != null && contains(var.roles, "server") ? var.base_configuration["server_registration_code"] : ""
+    proxy_registration_code  = var.base_configuration["proxy_registration_code"] != null && contains(var.roles, "proxy") ? var.base_configuration["proxy_registration_code"] : ""
   }
 }
 

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -61,7 +61,7 @@ runcmd:
   - SUSEConnect -p sle-module-basesystem/15.2/x86_64
   - SUSEConnect -p sle-module-python2/15.2/x86_64
   - SUSEConnect -p sle-module-server-applications/15.2/x86_64
-  - SUSEConnect -p sle-module-web-scripting/15.1/x86_64
+  - SUSEConnect -p sle-module-web-scripting/15.2/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.1/x86_64
   - zypper in -y salt-minion
 %{ endif }

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -34,32 +34,62 @@ zypper:
 packages: ["salt-minion"]
 %{ endif }
 
-%{ if server_registration_code != "" }
-
 %{ if image == "sles15sp1o" }
 runcmd:
-  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code}
+%{ if server_registration_code != "" }
+  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code} -p SUSE-Manager-Server/4.0/x86_64
+  - SUSEConnect -p sle-module-basesystem/15.1/x86_64
   - SUSEConnect -p sle-module-python2/15.1/x86_64
+  - SUSEConnect -p sle-module-server-applications/15.1/x86_64
   - SUSEConnect -p sle-module-web-scripting/15.1/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.0/x86_64
   - zypper in -y salt-minion
 %{ endif }
+%{ if proxy_registration_code != "" }
+  - SUSEConnect --url https://scc.suse.com -r ${proxy_registration_code} -p SUSE-Manager-Proxy/4.0/x86_64
+  - SUSEConnect -p sle-module-basesystem/15.1/x86_64
+  - SUSEConnect -p sle-module-server-applications/15.1/x86_64
+  - SUSEConnect -p sle-module-suse-manager-proxy/4.0/x86_64
+  - zypper in -y salt-minion
+%{ endif }
+%{ endif }
 
 %{ if image == "sles15sp2o" }
 runcmd:
-  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code}
+%{ if server_registration_code != "" }
+  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code} -p SUSE-Manager-Server/4.1/x86_64
+  - SUSEConnect -p sle-module-basesystem/15.2/x86_64
   - SUSEConnect -p sle-module-python2/15.2/x86_64
-  - SUSEConnect -p sle-module-web-scripting/15.2/x86_64
+  - SUSEConnect -p sle-module-server-applications/15.2/x86_64
+  - SUSEConnect -p sle-module-web-scripting/15.1/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.1/x86_64
   - zypper in -y salt-minion
+%{ endif }
+%{ if proxy_registration_code != "" }
+  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code} -p SUSE-Manager-Proxy/4.1/x86_64
+  - SUSEConnect -p sle-module-basesystem/15.2/x86_64
+  - SUSEConnect -p sle-module-server-applications/15.2/x86_64
+  - SUSEConnect -p sle-module-suse-manager-proxy/4.1/x86_64
+  - zypper in -y salt-minion
+%{ endif }
 %{ endif }
 
 %{ if image == "sles15sp3o" }
 runcmd:
-  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code}
+%{ if server_registration_code != "" }
+  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code} -p SUSE-Manager-Server/4.2/x86_64
+  - SUSEConnect -p sle-module-basesystem/15.3/x86_64
   - SUSEConnect -p sle-module-python2/15.3/x86_64
+  - SUSEConnect -p sle-module-server-applications/15.3/x86_64
   - SUSEConnect -p sle-module-web-scripting/15.3/x86_64
   - SUSEConnect -p sle-module-suse-manager-server/4.2/x86_64
+  - zypper in -y salt-minion
+%{ endif }
+%{ if proxy_registration_code != "" }
+  - SUSEConnect --url https://scc.suse.com -r ${server_registration_code} -p SUSE-Manager-Proxy/4.2/x86_64
+  - SUSEConnect -p sle-module-basesystem/15.3/x86_64
+  - SUSEConnect -p sle-module-server-applications/15.3/x86_64
+  - SUSEConnect -p sle-module-suse-manager-proxy/4.2/x86_64
   - zypper in -y salt-minion
 %{ endif }
 

--- a/backend_modules/null/base/main.tf
+++ b/backend_modules/null/base/main.tf
@@ -17,6 +17,7 @@ resource "null_resource" "base" {
     provider_settings    = yamlencode(var.provider_settings)
     images               = yamlencode(var.images)
     server_registration_code = var.server_registration_code
+    proxy_registration_code = var.proxy_registration_code
   }
 }
 
@@ -35,5 +36,6 @@ output "configuration" {
     use_shared_resources = var.use_shared_resources
     testsuite            = var.testsuite
     server_registration_code = var.server_registration_code
+    proxy_registration_code = var.proxy_registration_code
   }
 }

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -70,6 +70,11 @@ variable "images" {
 }
 
 variable "server_registration_code" {
-  description = "Use SUMA SCC registration code to enable the SLES and SUMA repositories"
+  description = "Use Server SUMA SCC registration code to enable the SLES and SUMA repositories for server"
+  default     = null
+}
+
+variable "proxy_registration_code" {
+  description = "Use Proxy SUMA SCC registration code to enable the SLES and SUMA repositories for proxy"
   default     = null
 }

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -70,11 +70,11 @@ variable "images" {
 }
 
 variable "server_registration_code" {
-  description = "Use Server SUMA SCC registration code to enable the SLES and SUMA repositories for server"
+  description = "SUMA SCC registration code to enable the SLES and SUMA repositories for server"
   default     = null
 }
 
 variable "proxy_registration_code" {
-  description = "Use Proxy SUMA SCC registration code to enable the SLES and SUMA repositories for proxy"
+  description = "SUMA SCC registration code to enable the SLES and SUMA repositories for proxy"
   default     = null
 }

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -1,37 +1,39 @@
 module "base_backend" {
   source = "../backend/base"
 
-  cc_username          = var.cc_username
-  cc_password          = var.cc_password
-  timezone             = var.timezone
-  use_ntp              = var.use_ntp
-  ssh_key_path         = var.ssh_key_path
-  mirror               = var.mirror
-  use_mirror_images    = var.use_mirror_images
-  use_avahi            = var.use_avahi
-  domain               = var.domain
-  name_prefix          = var.name_prefix
-  use_shared_resources = var.use_shared_resources
-  testsuite            = var.testsuite
-  provider_settings    = var.provider_settings
-  images               = var.images
+  cc_username              = var.cc_username
+  cc_password              = var.cc_password
+  timezone                 = var.timezone
+  use_ntp                  = var.use_ntp
+  ssh_key_path             = var.ssh_key_path
+  mirror                   = var.mirror
+  use_mirror_images        = var.use_mirror_images
+  use_avahi                = var.use_avahi
+  domain                   = var.domain
+  name_prefix              = var.name_prefix
+  use_shared_resources     = var.use_shared_resources
+  testsuite                = var.testsuite
+  provider_settings        = var.provider_settings
+  images                   = var.images
   server_registration_code = var.server_registration_code
+  proxy_registration_code  = var.proxy_registration_code
 }
 
 output "configuration" {
   value = merge({
-    cc_username          = var.cc_username
-    cc_password          = var.cc_password
-    timezone             = var.timezone
-    use_ntp              = var.use_ntp
-    ssh_key_path         = var.ssh_key_path
-    mirror               = var.mirror
-    use_mirror_images    = var.use_mirror_images
-    use_avahi            = var.use_avahi
-    domain               = var.domain
-    name_prefix          = var.name_prefix
-    use_shared_resources = var.use_shared_resources
-    testsuite            = var.testsuite
+    cc_username              = var.cc_username
+    cc_password              = var.cc_password
+    timezone                 = var.timezone
+    use_ntp                  = var.use_ntp
+    ssh_key_path             = var.ssh_key_path
+    mirror                   = var.mirror
+    use_mirror_images        = var.use_mirror_images
+    use_avahi                = var.use_avahi
+    domain                   = var.domain
+    name_prefix              = var.name_prefix
+    use_shared_resources     = var.use_shared_resources
+    testsuite                = var.testsuite
     server_registration_code = var.server_registration_code
+    proxy_registration_code  = var.proxy_registration_code
   }, module.base_backend.configuration)
 }

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -71,6 +71,10 @@ variable "images" {
 
 variable "server_registration_code" {
   description = "Use scc register"
-  type        = string
-  default     = ""
+  default     = null
+}
+
+variable "proxy_registration_code" {
+  description = "Use Proxy SUMA SCC registration code to enable the SLES and SUMA repositories for proxy"
+  default     = null
 }

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -70,11 +70,11 @@ variable "images" {
 }
 
 variable "server_registration_code" {
-  description = "Use scc register"
+  description = "SUMA SCC registration code to enable the SLES and SUMA repositories for server"
   default     = null
 }
 
 variable "proxy_registration_code" {
-  description = "Use Proxy SUMA SCC registration code to enable the SLES and SUMA repositories for proxy"
+  description = "SUMA SCC registration code to enable the SLES and SUMA repositories for proxy"
   default     = null
 }

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -47,6 +47,7 @@ module "proxy" {
     generate_bootstrap_script = var.generate_bootstrap_script
     publish_private_ssl_key   = var.publish_private_ssl_key
     repository_disk_size      = var.repository_disk_size
+    proxy_registration_code   = var.base_configuration["proxy_registration_code"]
   }
 
   image                    = var.image == "default" || var.product_version == "head" ? var.images[var.product_version] : var.image

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -77,7 +77,7 @@ module "server" {
     saltapi_tcpdump                = var.saltapi_tcpdump
     repository_disk_size           = var.repository_disk_size
     forward_registration           = var.forward_registration
-    server_registration_code           = var.base_configuration["server_registration_code"]
+    server_registration_code       = var.base_configuration["server_registration_code"]
   }
 
 

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -345,7 +345,7 @@ test_update_repo:
 {% endif %}
 {% endif %} {# '15' == grains['osrelease'] #}
 
-{% if '15.1' == grains['osrelease'] and grains.get('server_registration_code', '') == '' %}
+{% if '15.1' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') ) %}
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/
@@ -360,7 +360,7 @@ os_ltss_repo:
 
 {% endif %} {# '15.1' == grains['osrelease'] #}
 
-{% if '15.2' == grains['osrelease'] and grains.get('server_registration_code', '') == '' %}
+{% if '15.2' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') ) %}
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
@@ -376,7 +376,7 @@ os_ltss_repo:
 
 {% endif %} {# '15.2' == grains['osrelease'] #}
 
-{% if '15.3' == grains['osrelease'] %}
+{% if '15.3' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') ) %}
 
 os_pool_repo:
   pkgrepo.managed:

--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -12,7 +12,7 @@ proxy_update_repo:
     - priority: 97
 {% endif %}
 
-{% if '4.0' in grains['product_version'] %}
+{% if '4.0' in grains['product_version'] and not grains.get('proxy_registration_code') %}
 proxy_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Proxy/4.0/x86_64/product/
@@ -38,7 +38,7 @@ module_server_applications_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/
 {% endif %}
 
-{% if '4.1' in grains['product_version'] %}
+{% if '4.1' in grains['product_version'] and not grains.get('proxy_registration_code')%}
 proxy_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Proxy/4.1/x86_64/product/
@@ -64,7 +64,7 @@ module_server_applications_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/
 {% endif %}
 
-{% if '4.2' in grains['product_version'] %}
+{% if '4.2' in grains['product_version'] and not grains.get('proxy_registration_code') %}
 proxy_product_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Proxy/4.2/x86_64/product/

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -27,7 +27,7 @@ server_packages:
       - sls: repos
       - sls: server.firewall
 
-{% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' and grains.get('server_registration_code', '') == '' %}
+{% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' and not grains.get('server_registration_code') %}
 product_package_installed:
    cmd.run:
      - name: zypper --non-interactive install --auto-agree-with-licenses --force-resolution -t product SUSE-Manager-Server

--- a/salt/server/rhn.sls
+++ b/salt/server/rhn.sls
@@ -12,7 +12,7 @@ package_import_skip_changelog_reposync:
 
 {% endif %}
 
-{% if grains.get('browser_side_less') and 'released' not in grains['product_version'] %}
+{% if grains.get('browser_side_less') and 'released' not in grains['product_version'] and not grains.get('server_registration_code') %}
 
 browser_side_less_configuration:
   file.append:


### PR DESCRIPTION
## What does this PR change?

I added the proxy deployment support using SCC. I needed to rewrite some parts of the code and I have some instability aloso with the bastion deployment.

Just to explain why I copy / paste the SUSEConnect commands : I have to first register the server and then add the repositories in a specific order. Indeed suse proxy and server manager depends on specific repositories. So it 's impossible to use group of code to declare the repositories.