### PR TITLE
Fix: Use the right variable for the definition of terminal grains inside the controller

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -96,13 +96,13 @@ module "controller" {
     debian10_minion      = length(var.debian10_minion_configuration["hostnames"]) > 0 ? var.debian10_minion_configuration["hostnames"][0] : null
     debian10_sshminion   = length(var.debian10_sshminion_configuration["hostnames"]) > 0 ? var.debian10_sshminion_configuration["hostnames"][0] : null
     sle11sp4_buildhost   = length(var.sle11sp4_buildhost_configuration["hostnames"]) > 0 ? var.sle11sp4_buildhost_configuration["hostnames"][0] : null
-    sle11sp3_terminal    = length(var.terminal_configuration["hostnames"]) > 0 ? var.terminal_configuration["hostnames"][0] : null
+    sle11sp3_terminal    = length(var.sle11sp3_terminal_configuration["hostnames"]) > 0 ? var.sle11sp3_terminal_configuration["hostnames"][0] : null
     sle12sp4_buildhost   = length(var.sle12sp4_buildhost_configuration["hostnames"]) > 0 ? var.sle12sp4_buildhost_configuration["hostnames"][0] : null
-    sle12sp4_terminal    = length(var.terminal_configuration["hostnames"]) > 0 ? var.terminal_configuration["hostnames"][0] : null
+    sle12sp4_terminal    = length(var.sle12sp4_terminal_configuration["hostnames"]) > 0 ? var.sle12sp4_terminal_configuration["hostnames"][0] : null
     sle12sp5_buildhost   = length(var.sle12sp5_buildhost_configuration["hostnames"]) > 0 ? var.sle12sp5_buildhost_configuration["hostnames"][0] : null
-    sle12sp5_terminal    = length(var.terminal_configuration["hostnames"]) > 0 ? var.terminal_configuration["hostnames"][0] : null
+    sle12sp5_terminal    = length(var.sle12sp5_terminal_configuration["hostnames"]) > 0 ? var.sle12sp5_terminal_configuration["hostnames"][0] : null
     sle15sp2_buildhost   = length(var.sle15sp2_buildhost_configuration["hostnames"]) > 0 ? var.sle15sp2_buildhost_configuration["hostnames"][0] : null
-    sle15sp2_terminal    = length(var.terminal_configuration["hostnames"]) > 0 ? var.terminal_configuration["hostnames"][0] : null
+    sle15sp2_terminal    = length(var.sle15sp2_terminal_configuration["hostnames"]) > 0 ? var.sle15sp2_terminal_configuration["hostnames"][0] : null
   }
 
 


### PR DESCRIPTION
## What does this PR change?

Fix: Use the right variable for the definition of terminal grains inside the controller