### PR TITLE
Add Alma linux 8 client support to libvirt

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -2,6 +2,7 @@
 locals {
   images_used = var.use_shared_resources ? [] : var.images
   image_urls = {
+    almalinuxo   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://repo.almalinux.org"}/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.4-20210616.x86_64.qcow2"
     centos6o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2"
     centos7      = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2"
     centos7o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -2,7 +2,7 @@
 locals {
   images_used = var.use_shared_resources ? [] : var.images
   image_urls = {
-    almalinuxo   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://repo.almalinux.org"}/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.4-20210616.x86_64.qcow2"
+    almalinux8o   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://repo.almalinux.org"}/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.4-20210616.x86_64.qcow2"
     centos6o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2"
     centos7      = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2"
     centos7o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -333,35 +333,35 @@ packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-htt
 yum_repos:
   # repo for salt
   tools_pool_repo:
-    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
     failovermethod: priority
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
     priority: 98
   # repo for nss-mdns
-  salt-repo-almalinux:
-    baseurl: http://${ use_mirror_images ? mirror : "repo.saltproject.io"}/py3/redhat/8/x86_64/3003
-    failovermethod: priority
-    enabled: true
-    gpgcheck: false
-    priority: 99
-    name: salt-repo-almalinux
+#   salt-repo-almalinux:
+#     baseurl: http://${ use_mirror_images ? mirror : "repo.saltproject.io"}/py3/redhat/8/x86_64/3003
+#     failovermethod: priority
+#     enabled: true
+#     gpgcheck: false
+#     priority: 99
+#     name: salt-repo-almalinux
   epel:
-    baseurl: http://download.fedoraproject.org/pub/epel/7/$basearch
-    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+    baseurl: http://download.fedoraproject.org/pub/epel/8/$basearch
+    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch
     failovermethod: priority
     enabled: true
     gpgcheck: false
     priority: 99
     name: epel
 
-packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+packages: ["avahi", "nss-mdns", "qemu-guest-agent, salt-minion"]
 
-runcmd:
-  #   HACK: cloud-init in Debian 10 does not take care of the following
-  - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
-  - systemctl restart sshd
-  - systemctl start qemu-guest-agent
-  - [ yum, install, -y, --nobest, salt-minion ]
+# runcmd:
+#   #   HACK: cloud-init in Debian 10 does not take care of the following
+#   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+#   - systemctl restart sshd
+#   - systemctl start qemu-guest-agent
+#   - [ yum, install, -y, --nobest, salt-minion ]
 %{ endif }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -341,7 +341,7 @@ yum_repos:
     priority: 98
   # repo for nss-mdns
   salt-repo-almalinux:
-    baseurl: http://${ use_mirror_images ? mirror : "repo.saltproject.io"}/py3/redhat/8/x86_64/3003.repo
+    baseurl: http://${ use_mirror_images ? mirror : "repo.saltproject.io"}/py3/redhat/8/x86_64/3003
     failovermethod: priority
     enabled: true
     gpgcheck: false

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -363,5 +363,5 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
-  - [ yum, install, -y, --disablerepo=epel, salt-minion ]
+  - [ yum, install, -y, --no-best, salt-minion ]
 %{ endif }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -363,5 +363,5 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
-  - [ yum, install, -y, --no-best, salt-minion ]
+  - [ yum, install, -y, --nobest, salt-minion ]
 %{ endif }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -328,3 +328,40 @@ runcmd:
 
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
 %{ endif }
+
+%{ if image == "almalinuxo" }
+yum_repos:
+  # repo for salt
+  tools_pool_repo:
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    name: tools_pool_repo
+    priority: 98
+  # repo for nss-mdns
+  salt-repo-amazon:
+    baseurl: http://${ use_mirror_images ? mirror : "repo.saltproject.io"}/py3/amazon/2/x86_64/3000
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: salt-repo-amazon
+  epel:
+    baseurl: http://download.fedoraproject.org/pub/epel/7/$basearch
+    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: epel
+
+packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+
+runcmd:
+  #   HACK: cloud-init in Debian 10 does not take care of the following
+  - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+  - systemctl restart sshd
+  - systemctl start qemu-guest-agent
+  - [ yum, install, -t, -y, --disablerepo=epel, salt-minion ]
+%{ endif }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -356,7 +356,7 @@ yum_repos:
     priority: 99
     name: epel
 
-packages: ["avahi", "nss-mdns", "qemu-guest-agent, salt-minion"]
+packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
 
 # runcmd:
 #   #   HACK: cloud-init in Debian 10 does not take care of the following

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -329,7 +329,7 @@ runcmd:
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
 %{ endif }
 
-%{ if image == "almalinuxo" }
+%{ if image == "almalinux8o" }
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -340,13 +340,13 @@ yum_repos:
     name: tools_pool_repo
     priority: 98
   # repo for nss-mdns
-  salt-repo-amazon:
-    baseurl: http://${ use_mirror_images ? mirror : "repo.saltproject.io"}/py3/amazon/2/x86_64/3000
+  salt-repo-almalinux:
+    baseurl: http://${ use_mirror_images ? mirror : "repo.saltproject.io"}/py3/redhat/8/x86_64/3003.repo
     failovermethod: priority
     enabled: true
     gpgcheck: false
     priority: 99
-    name: salt-repo-amazon
+    name: salt-repo-almalinux
   epel:
     baseurl: http://download.fedoraproject.org/pub/epel/7/$basearch
     mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -340,13 +340,6 @@ yum_repos:
     name: tools_pool_repo
     priority: 98
   # repo for nss-mdns
-#   salt-repo-almalinux:
-#     baseurl: http://${ use_mirror_images ? mirror : "repo.saltproject.io"}/py3/redhat/8/x86_64/3003
-#     failovermethod: priority
-#     enabled: true
-#     gpgcheck: false
-#     priority: 99
-#     name: salt-repo-almalinux
   epel:
     baseurl: http://download.fedoraproject.org/pub/epel/8/$basearch
     mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch
@@ -358,10 +351,4 @@ yum_repos:
 
 packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
 
-# runcmd:
-#   #   HACK: cloud-init in Debian 10 does not take care of the following
-#   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
-#   - systemctl restart sshd
-#   - systemctl start qemu-guest-agent
-#   - [ yum, install, -y, --nobest, salt-minion ]
 %{ endif }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -363,5 +363,5 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
-  - [ yum, install, -t, -y, --disablerepo=epel, salt-minion ]
+  - [ yum, install, -y, --disablerepo=epel, salt-minion ]
 %{ endif }

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -65,7 +65,7 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o", "almalinuxo"]
   type        = set(string)
 }
 

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -65,7 +65,7 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o", "almalinuxo"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o", "almalinux8o"]
   type        = set(string)
 }
 

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -65,7 +65,7 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o", "almalinuxo"]
   type        = set(string)
 }
 

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -65,7 +65,7 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o", "almalinuxo"]
+  default     = ["centos6o", "centos7o", "centos8o", "opensuse152o", "opensuse153o", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1604o", "ubuntu1804o", "ubuntu2004o", "almalinux8o"]
   type        = set(string)
 }
 


### PR DESCRIPTION
## What does this PR change?

This PR is created to add Alma Linux 8 to client for libvirt provider.

Currently, it has to be describe with the option `auto_register` set to `false`.

Packages to install spacewalk are missing in centos 8 repositories.
