### PR TITLE
Force installing salt packages from server_devel_repo

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -33,10 +33,11 @@ another_test_repo:
 test_repo_debian_updates:
   cmd.script:
     - name: salt://server/download_ubuntu_repo.sh
-    - args: "TestRepoDebUpdates {{ grains.get('mirror') | default('download.opensuse.org', true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb/"
+    - args: "TestRepoDebUpdates {{ grains.get('mirror') | default('download.opensuse.org', true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb"
     - creates: /srv/www/htdocs/pub/TestRepoDebUpdates/Release
     - require:
       - pkg: testsuite_packages
+      - pkg: testsuite_salt_packages
 
 # modify cobbler to be executed from remote-machines..
 
@@ -61,9 +62,16 @@ testsuite_packages:
     - pkgs:
       - expect
       - aaa_base-extras
-      - salt-ssh
       - wget
       - OpenIPMI
+    - require:
+      - sls: repos
+
+testsuite_salt_packages:
+  pkg.installed:
+    - pkgs:
+      - salt-ssh
+    - fromrepo: server_devel_repo
     - require:
       - sls: repos
 


### PR DESCRIPTION
## What does this PR change?

Force the installation of salt-ssh and its dependencies from our internal repository.
This tries to solve the current issue deploying Uyuni CI:

```
 uyuni-master-srv:~/salt/server # zypper in expect aaa_base-extras salt-ssh wget OpenIPMI
Loading repository data...
Reading installed packages...
'wget' is already installed.
No update candidate for 'wget-1.20.3-3.12.1.x86_64'. The highest available version is already installed.
'aaa_base-extras' is already installed.
No update candidate for 'aaa_base-extras-84.87+git20180409.04c9dae-3.45.1.x86_64'. The highest available version is already installed.
Resolving package dependencies...

Problem: the to be installed salt-ssh-3002.2-26.8.uyuni1.x86_64 requires 'salt = 3002.2-26.8.uyuni1', but this requirement cannot be provided
  not installable providers: salt-3002.2-26.8.uyuni1.x86_64[server_devel_repo]
 Solution 1: Following actions will be done:
  downgrade of salt-3002.2-50.1.9.1.x86_64 to salt-3002.2-26.8.uyuni1.x86_64
  downgrade of salt-master-3002.2-50.1.9.1.x86_64 to salt-master-3002.2-26.8.uyuni1.x86_64
  downgrade of salt-api-3002.2-50.1.9.1.x86_64 to salt-api-3002.2-26.8.uyuni1.x86_64
  downgrade of salt-minion-3002.2-50.1.9.1.x86_64 to salt-minion-3002.2-26.8.uyuni1.x86_64
  downgrade of python3-salt-3002.2-50.1.9.1.x86_64 to python3-salt-3002.2-26.8.uyuni1.x86_64
 Solution 2: do not install salt-ssh-3002.2-26.8.uyuni1.x86_64
 Solution 3: break salt-ssh-3002.2-26.8.uyuni1.x86_64 by ignoring some of its dependencies
```
