### PR TITLE
Add new product version uyuni-pr

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -19,7 +19,14 @@ Legal values for work-in-progress software are:
  * `4.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.1)
  * `4.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.2)
  * `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, for `server` and `proxy`only works with SLE15SP3 image)
- * `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap 15.1 image)
+ * `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap image)
+
+Legal values for CI:
+
+`uyuni-pr` is a special product version used internally to test Pull Requests. Packages are under a subproject in systemsmanagement:Uyuni:Master:TEST and systemsmanagement:Uyuni:Master:PR.
+This is not meant to be used outside the Continous Integration system (CI).
+
+Because packages are under different subprojects for each CI run and each Pull Request, repositories will be added later as additional repositories.
 
 Note: the version of Salt on minions is determined by this value, as Salt is obtained from SUSE Manager Tools repos.
 

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -11,6 +11,7 @@ variable "testsuite-branch" {
     "head"           = "master"
     "uyuni-master"   = "master"
     "uyuni-released" = "master"
+    "uyuni-pr"       = "master"
   }
 }
 

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -62,7 +62,7 @@ variable "host_settings" {
 
 // server
 variable "product_version" {
-  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, 4.1-nightly, 4.1-released, 4.2-nightly, 4.2-released, head, test, uyuni-master, uyuni-released"
+  description = "One of: 3.2-nightly, 3.2-released, 4.0-nightly, 4.0-released, 4.1-nightly, 4.1-released, 4.2-nightly, 4.2-released, head, test, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -11,6 +11,7 @@ variable "images" {
     "head"           = "sles15sp3o"
     "uyuni-master"   = "opensuse153o"
     "uyuni-released" = "opensuse152o"
+    "uyuni-pr"       = "opensuse153o"
   }
 }
 

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, 4.1-released, 4.1-nightly, 4.2-released, 4.2-nightly, head, test, uyuni-master, uyuni-released"
+  description = "One of: 3.2-released, 3.2-nightly, 4.0-released, 4.0-nightly, 4.1-released, 4.1-nightly, 4.2-released, 4.2-nightly, head, test, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -11,6 +11,7 @@ variable "images" {
     "head"           = "sles15sp3o"
     "uyuni-master"   = "opensuse153o"
     "uyuni-released" = "opensuse152o"
+    "uyuni-pr"       = "opensuse153o"
   }
 }
 

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -39,7 +39,7 @@ tools_pool_repo:
     - gpgcheck: 1
     - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
     - priority: 98
-{% else %}
+{% elif not grains.get('product_version') or not 'uyuni-pr' in grains.get('product_version') | default('', true) %}
 tools_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
@@ -431,7 +431,7 @@ galaxy_key:
     - name: rpm --import /tmp/galaxy.key
     - watch:
       - file: galaxy_key
-{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-released' in grains.get('product_version', '') %}
+{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-released' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') %}
 uyuni_key:
   file.managed:
     - name: /tmp/uyuni.key


### PR DESCRIPTION
## What does this PR change?

We need this so we can not add the master repos, when testing Pull
Requests.

Repos will be added as additional repos, instead.

Each PR has a different repo, so it can not be added here, but instead
will be added to susemanager-ci sumaform config files.

I also changed the README to state "openSUSE Leap image" instead of "openSUSE Leap 15.2 image", because stating the version is outdated.
