### PR TITLE
Increase RAM in dom0 on XEN Hypervisor

### DIFF
--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -112,7 +112,7 @@ lower_dom0_memory:
   file.replace:
     - name: /etc/default/grub
     - pattern: ^GRUB_CMDLINE_XEN="[^"]*"
-    - repl: GRUB_CMDLINE_XEN="dom0_mem=819200"
+    - repl: GRUB_CMDLINE_XEN="dom0_mem=1024000"
 
 rebuild_grub_cfg:
   cmd.run:


### PR DESCRIPTION
## What does this PR change?

Increase RAM in dom0 on XEN Hypervisor.
So we fix an issue caused by the OOM Killer killing a zypper refresh while bootstrapping through salt-ssh.