### PR TITLE
Update opensuse152 name to be compatible with mirror

### DIFF
--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -19,7 +19,7 @@ locals {
   additional_network = lookup(var.provider_settings, "additional_network", "172.16.2.0/24")
 }
 
-data "aws_ami" "opensuse152" {
+data "aws_ami" "opensuse152o" {
   most_recent = true
   name_regex  = "^openSUSE-Leap-15-2-v"
   owners      = ["679593333241"]
@@ -391,7 +391,7 @@ locals {
     key_name = local.key_name
     key_file = local.key_file
     ami_info = {
-      opensuse152 = { ami = data.aws_ami.opensuse152.image_id },
+      opensuse152o = { ami = data.aws_ami.opensuse152o.image_id },
       sles15      = { ami = data.aws_ami.sles15.image_id },
       sles15sp1o   = { ami = data.aws_ami.sles15sp1o.image_id },
       sles15sp2o   = { ami = data.aws_ami.sles15sp2o.image_id },
@@ -423,7 +423,7 @@ module "bastion" {
   source                        = "../host"
   quantity                      = local.create_network ? 1 : 0
   base_configuration            = local.configuration_output
-  image                         = "opensuse152"
+  image                         = "opensuse152o"
   name                          = "bastion"
   connect_to_additional_network = true
   provider_settings = {


### PR DESCRIPTION
## What does this PR change?

Change opensuse152 name declaration in AWS to be compatible with mirror default image ( opensuse152o )
