### PR TITLE
Fake virt-what on virtual hosts

### DIFF
--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -57,6 +57,12 @@ fake_systemd_detect_virt:
     - source: salt://virthost/systemd-detect-virt
     - mode: 655
 
+fake_virt_what:
+  file.managed:
+    - name: /usr/sbin/virt-what
+    - mode: 655
+    - contents: "# Fake from sumaform to mock physical machine"
+
 {% if grains['hvm_disk_image'] %}
 disk-image-template.qcow2:
   file.managed:


### PR DESCRIPTION
## What does this PR change?

Now that tuned is installed on the virtual host machines, virt-what is
automatically installed and causes Salt and Uyuni to think the VM is a
VM.

In order to properly test the virtualization features, we need Uyuni to
think the virtual hosts to be physical machines even if it's not true...
Replacing /usr/sbin/virt-what by an empty script mimics the bare metal
machine case.
