### PR TITLE
Use a more stable image for the controller image

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -9,6 +9,7 @@ locals {
     centos8o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/8/x86_64/images/CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2"
     amazonlinux2o = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cdn.amazonlinux.com"}/os-images/2.0.20210721.2/kvm/amzn2-kvm-2.0.20210721.2-x86_64.xfs.gpt.qcow2"
     opensuse152-ci-pr  = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse152-ci-pr.x86_64.qcow2"
+    controller-image  = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse152.x86_64.qcow2"
     opensuse152o = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2"
     opensuse153-ci-pr  = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse153-ci-pr.x86_64.qcow2"
     opensuse153-ci-pr-client  = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse153-ci-pr-client.x86_64.qcow2"

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -107,7 +107,7 @@ module "controller" {
   }
 
 
-  image   = "opensuse152o"
+  image   = "controller-image"
   provider_settings = var.provider_settings
 }
 


### PR DESCRIPTION
## What does this PR change?

opensuse 15.2 images get updated very frequently. This goes to the
openSUSE mirrors. From time to time, images are not available in the
mirrors. This causes a failure when running sumaform.

Let's use a more stable image, that is not updated and, so it is available
most of the time, plus an image that is specific for the
controller, which its build is being disabled.

Moreover, this will make a run reproduceable. If we use an image that is
continuously being updated, runs are not reproduceable.


