### PR TITLE
Allow to set a custom ssh key in the cucumber test suite module

### DIFF
--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -105,7 +105,18 @@ Some roles such as `suse_manager` or `mirror` have specific defaults that overri
 
 ## Accessing VMs
 
-All machines come with user `root` with password `linux`. They are also accessible via your SSH public key (by default `~/.ssh/id_rsa.pub`) if you have one.
+All machines come with user `root` with password `linux`.
+
+They are also accessible via your SSH public key if you have one. By default the key `~/.ssh/id_rsa.pub` is used, but this value can be changed by specifying the variable `ssh_key_path`:
+
+```hcl
+module "base" {
+  source = "./modules/base"
+
+  ...
+  ssh_key_path = "~/.ssh/id_ed25519.pub"
+}
+```
 
 By default, the machines use Avahi (mDNS), and are configured on the `.tf.local` domain. Thus if your host is on the same network segment of the virtual machines you can simply use:
 

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -19,7 +19,7 @@ variable "use_ntp" {
 }
 
 variable "ssh_key_path" {
-  description = "path of pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of pub ssh key you want to use to access VMs, see backend_modules/libvirt/README.md"
   default     = "~/.ssh/id_rsa.pub"
 }
 
@@ -59,7 +59,7 @@ variable "testsuite" {
 }
 
 variable "provider_settings" {
-  description = "Map of provider-specific settings, see the modules/libvirt/README.md"
+  description = "Map of provider-specific settings, see the backend_modules/libvirt/README.md"
   default     = {}
 }
 

--- a/modules/base/variables.tf
+++ b/modules/base/variables.tf
@@ -19,7 +19,7 @@ variable "use_ntp" {
 }
 
 variable "ssh_key_path" {
-  description = "path of pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of pub ssh key you want to use to access VMs, see backend_modules/libvirt/README.md"
   default     = "~/.ssh/id_rsa.pub"
 }
 

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -11,6 +11,7 @@ module "base" {
   mirror               = var.mirror
   use_mirror_images    = var.use_mirror_images
   use_shared_resources = var.use_shared_resources
+  ssh_key_path         = var.ssh_key_path
   testsuite            = true
 
   provider_settings = var.provider_settings

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -19,6 +19,11 @@ variable "avahi_reflector" {
   default     = false
 }
 
+variable "ssh_key_path" {
+  description = "path of pub ssh key you want to use to access VMs, see libvirt/README.md"
+  default     = "~/.ssh/id_rsa.pub"
+}
+
 variable "domain" {
   description = "domain of all hosts in this testsuite"
   default     = "tf.local"

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -20,7 +20,7 @@ variable "avahi_reflector" {
 }
 
 variable "ssh_key_path" {
-  description = "path of pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of pub ssh key you want to use to access VMs, see backend_modules/libvirt/README.md"
   default     = "~/.ssh/id_rsa.pub"
 }
 


### PR DESCRIPTION
## What does this PR change?

This PR adds a configuration variable for the `cucumber_testsuite` module to allow setting an ssh key different from the default `~/.ssh/id_rsa.pub`. This prevents the `terraform apply` to fail due a different ssh key name.