### PR TITLE
Use an untrusted repo for a pull request testing

### DIFF
--- a/salt/repos/additional.sls
+++ b/salt/repos/additional.sls
@@ -4,9 +4,14 @@
   pkgrepo.managed:
     - humanname: {{ label }}
   {%- if grains['os_family'] == 'Debian' %}
+  {%- if 'uyuni-pr' in grains.get('product_version', '') %}
+    - name: deb [trusted=yes] {{ url }} /
+    - file: /etc/apt/sources.list.d/sumaform_additional_repos.list
+  {%- else %}
     - name: deb {{ url }} /
     - file: /etc/apt/sources.list.d/sumaform_additional_repos.list
     - key_url: {{ url }}/Release.key
+  {%- endif %}
   {%- else %}
     - baseurl: {{ url }}
     - priority: 95


### PR DESCRIPTION
The repo generated for pull request testing is not signed. Thus, for
this particular case, we need to trust the repo.

Partial fix for: https://github.com/SUSE/spacewalk/issues/15846