### PR TITLE
Add "basesystem overlay" testing repo to the proxy

### DIFF
--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -125,6 +125,18 @@ server_devel_releasenotes_repo:
     - priority: 96
 {% endif %}
 
+{% if grains['osfullname'] == 'Leap' %}
+opensuse_overlay_devel_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images/repo/openSUSE-Overlay-POOL-x86_64-Media1/
+    - priority: 96
+{% else %}
+basesystem_overlay_devel_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Server-Basesystem-Overlay-Testing-Head-POOL-x86_64-Media1/
+    - priority: 96
+{% endif %}
+
 {% if grains['osfullname'] != 'Leap' %}
 # Moving target, only until SLE15SP3 GA is ready
 module_server_applications_movingtarget_repo:

--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -195,6 +195,11 @@ server_devel_releasenotes_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.2:/ToSLE/SLE_15_SP3/
     - priority: 96
+
+basesystem_overlay_devel_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.2/images/repo/SLE-Module-SUSE-Manager-Server-Basesystem-Overlay-Testing-Head-POOL-x86_64-Media1/
+    - priority: 96
 {% endif %}
 
 {% endif %}

--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -198,7 +198,7 @@ server_devel_releasenotes_repo:
 
 basesystem_overlay_devel_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.2/images/repo/SLE-Module-SUSE-Manager-Server-Basesystem-Overlay-Testing-Head-POOL-x86_64-Media1/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.2/images/repo/SLE-Module-SUSE-Manager-Server-Basesystem-Overlay-Testing-4.2-POOL-x86_64-Media1/
     - priority: 96
 {% endif %}
 


### PR DESCRIPTION
## What does this PR change?

This PR adds a new repository in the proxy systems in order to get devel packages for those that are not part of SUMA Proxy channels, like "salt".

These new repositories "Basesystem-Overlay" and "openSUSE-Overlay" currently contains the Salt package + some new dependencies which are not part of SLE.

This way, the deployed proxy will have the devel testing package for Salt and not the latest released Salt in SLE or Leap.  