### PR TITLE
Use https for opensuse 15.3 images

### DIFF
--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -71,22 +71,22 @@ variable "ipv6" {
 
 variable "hvm_disk_image" {
   description = "URL to the disk image to use for KVM guests"
-  default     = "http://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+  default     = "https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
 }
 
 variable "hvm_disk_image_hash" {
   description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
-  default     = "http://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+  default     = "https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
 }
 
 variable "xen_disk_image" {
   description = "URL to the disk image to use for Xen PV guests"
-  default     = "http://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
+  default     = "https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2"
 }
 
 variable "xen_disk_image_hash" {
   description = "Hash of the Xen PV disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
-  default     = "http://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
+  default     = "https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-15.3-kvm-and-xen-Current.qcow2.sha256"
 }
 
 variable "hypervisor" {


### PR DESCRIPTION
## What does this PR change?

Otherwise, these images are unavailable if we use http.
