### PR TITLE
Add again empty repos for 15sp2 and 15sp3 LTSS in advance

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -319,7 +319,6 @@ os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/
 
-uncomment when it goes LTSS
 os_ltss_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
@@ -336,7 +335,6 @@ os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/
 
-uncomment when it goes LTSS
 os_ltss_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/x86_64/update/

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -319,10 +319,10 @@ os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/
 
-# uncomment when it goes LTSS
-# os_ltss_repo:
-#   pkgrepo.managed:
-#     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
+uncomment when it goes LTSS
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
 
 {% endif %} {# '15.2' == grains['osrelease'] #}
 
@@ -336,10 +336,10 @@ os_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/
 
-# uncomment when it goes LTSS
-# os_ltss_repo:
-#   pkgrepo.managed:
-#     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/x86_64/update/
+uncomment when it goes LTSS
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/x86_64/update/
 
 {% endif %} {# '15.3' == grains['osrelease'] #}
 


### PR DESCRIPTION
## What does this PR change?

Add again empty repos for 15sp2 and 15sp3 LTSS in advance because in the testsuite we are using these. Across different branches 4.1 and 4.2 different products are used and 15sp1 in on ltss but not the rest yet. We can't simply remove the os_ltss_repo from the steps that use it because this step is run against different products, some need the LTSS some don't. Also in the future when the level of support changes for 15sp2 we will bump into this again.