### PR TITLE
Allow Jenkins VMs

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -116,6 +116,38 @@ module "suse-minion" {
 
 This will create 10 minions connected to the `server`.
 
+## Jenkins (PoC)
+
+If you are running `sumaform` for Uyuni and you want Continuous Integration, you can a setup a Jenkins instance using the `jenkins` module.
+
+For now, the module provides Jenkins with the following plugins enabled:
+
+- swarm
+- git
+- git-client
+- workflow-aggregator
+- extended-choice-parameter
+- timestamper
+- htmlpublisher
+- rebuild
+- http_request
+- ansicolor
+- greenballs
+
+Authentication is enabled, and a user `admin` is created. The password can be found at `/var/lib/jenkins/secrets/initialAdminPassword` at the Jenkins instance.
+
+To enable Jenkins, use the following definition.
+
+```hcl
+module "jenkins" {
+  source             = "./modules/jenkins"
+  base_configuration = module.base.configuration
+}
+```
+
+Usually you will want to use this on public clouds, but if you want to use this in libvirt, you are encouraged to use a separate pool, as explained for the mirror below.
+
+
 ## Mirror
 
 If you are using `sumaform` outside of the SUSE Nuremberg network you should use a special extra virtual machine named `mirror` that will cache packages downloaded from the SUSE engineering network for faster access and lower bandwidth consumption.

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -17,6 +17,7 @@ locals {
     contains(var.roles, "controller") ? { instance_type = "t2.medium" } : {},
     contains(var.roles, "grafana") ? { instance_type = "t2.medium" } : {},
     contains(var.roles, "virthost") ? { instance_type = "t2.medium" } : {},
+    contains(var.roles, "jenkins") ? { instance_type = "t3.xlarge" } : {},
   var.provider_settings)
 
   public_subnet_id                     = var.base_configuration.public_subnet_id
@@ -211,7 +212,7 @@ resource "null_resource" "host_salt_configuration" {
         connect_to_additional_network = var.connect_to_additional_network
         reset_ids                     = true
         ipv6                          = var.ipv6
-        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") ? "xvdf" : null
+        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "xvdf" : null
       },
     var.grains))
     destination = "/tmp/grains"

--- a/backend_modules/azure/host/main.tf
+++ b/backend_modules/azure/host/main.tf
@@ -16,6 +16,7 @@ locals {
     contains(var.roles, "controller") ? { vm_size = "Standard_B2s" } : {},
     contains(var.roles, "grafana") ? { vm_size = "Standard_B2s" } : {},
     contains(var.roles, "virthost") ? { vm_size = "Standard_B1ms" } : {},
+    contains(var.roles, "jenkins") ? { vm_size = "Standard_B4ms" } : {},
   var.provider_settings)
   public_subnet_id                     = var.base_configuration.public_subnet_id
   private_subnet_id                    = var.base_configuration.private_subnet_id
@@ -200,7 +201,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
         connect_to_additional_network = var.connect_to_additional_network
         reset_ids                     = true
         ipv6                          = var.ipv6
-        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") ? "sdc" : null
+        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "sdc" : null
       },
     var.grains))
     destination = "/tmp/grains"

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -16,6 +16,7 @@ locals {
     contains(var.roles, "controller") ? { memory = 2048 } : {},
     contains(var.roles, "grafana") ? { memory = 4096 } : {},
     contains(var.roles, "virthost") ? { memory = 3072, vcpu = 3 } : {},
+    contains(var.roles, "jenkins") ? { memory = 16384, vcpu = 4 } : {},
     var.provider_settings,
     contains(var.roles, "virthost") ? { cpu_model = "host-passthrough", xslt = file("${path.module}/sysinfos.xsl") } : {},
     contains(var.roles, "pxe_boot") ? { xslt = file("${path.module}/pxe.xsl") } : {})
@@ -221,7 +222,7 @@ resource "null_resource" "provisioning" {
         connect_to_additional_network = var.connect_to_additional_network
         reset_ids                     = true
         ipv6                          = var.ipv6
-        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") ? "vdb" : null
+        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdb" : null
         provider                      = "libvirt"
       },
     var.grains))

--- a/backend_modules/ssh/host/main.tf
+++ b/backend_modules/ssh/host/main.tf
@@ -96,7 +96,7 @@ resource "null_resource" "provisioning" {
         connect_to_additional_network = var.connect_to_additional_network
         reset_ids                     = true
         ipv6                          = var.ipv6
-        data_disk_device              = contains(var.roles, "suse_manager_server") || contains(var.roles, "suse_manager_proxy") || contains(var.roles, "mirror") ? "vdb" : null
+        data_disk_device              = contains(var.roles, "suse_manager_server") || contains(var.roles, "suse_manager_proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdb" : null
       },
     var.grains))
     destination = "/etc/salt/grains"

--- a/modules/jenkins/main.tf
+++ b/modules/jenkins/main.tf
@@ -1,0 +1,28 @@
+
+module "jenkins" {
+  source = "../host"
+
+  base_configuration      = var.base_configuration
+  name                    = "jenkins"
+  use_os_released_updates = var.use_os_released_updates
+  additional_repos        = var.additional_repos
+  additional_packages     = var.additional_packages
+  swap_file_size          = var.swap_file_size
+  ssh_key_path            = var.ssh_key_path
+  roles                   = ["jenkins"]
+
+  grains = {
+    mirror                  = var.base_configuration["mirror"]
+    data_disk_fstype        = var.data_disk_fstype
+  }
+
+  image = var.image
+
+  provider_settings        = var.provider_settings
+  additional_disk_size     = var.data_disk_size
+  volume_provider_settings = var.volume_provider_settings
+}
+
+output "configuration" {
+  value = module.jenkins.configuration
+}

--- a/modules/jenkins/variables.tf
+++ b/modules/jenkins/variables.tf
@@ -1,0 +1,54 @@
+variable "base_configuration" {
+  description = "use module.base.configuration, see the main.tf example file"
+}
+
+variable "use_os_released_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise repos"
+  default     = true
+}
+
+variable "additional_repos" {
+  description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
+  default     = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages to install, see README_ADVANCED.md"
+  default     = []
+}
+
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default     = 0
+}
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default     = null
+}
+
+variable "provider_settings" {
+  description = "Map of provider-specific settings, see the backend-specific README file"
+  default     = {}
+}
+
+variable "data_disk_size" {
+  description = "Size of an aditional disk for the /var/lib/jenkins partition, defined in GiB"
+  default     = 1024
+}
+
+variable "data_disk_fstype" {
+  description = "Data disk file system type"
+  default     = "ext4"
+}
+
+variable "volume_provider_settings" {
+  description = "Map of volume-provider-specific settings, see the backend-specific README file"
+  default     = {}
+}
+
+variable "image" {
+  description = "An image name, e.g. sles15sp2o or opensuse153o"
+  type        = string
+  default = "opensuse153o"
+}

--- a/modules/jenkins/versions.tf
+++ b/modules/jenkins/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 1.0.10"
+}

--- a/salt/jenkins/basic-security.groovy
+++ b/salt/jenkins/basic-security.groovy
@@ -1,0 +1,32 @@
+#!groovy
+
+import jenkins.model.*
+import hudson.security.*
+import static jenkins.model.Jenkins.instance as jenkins
+import jenkins.install.InstallState
+
+def instance = Jenkins.getInstance()
+def hudsonRealm = new HudsonPrivateSecurityRealm(false)
+String randomPassword = org.apache.commons.lang.RandomStringUtils.randomAscii(30)
+
+println "Writing the password to /var/lib/jenkins/secrets/initialAdminPassword"
+File file = new File("/var/lib/jenkins/secrets/initialAdminPassword")
+file.write randomPassword + "\n"
+
+println "Creating the user 'admin"
+hudsonRealm.createAccount('admin',randomPassword)
+
+println "Enabling the integrated database authentication"
+instance.setSecurityRealm(hudsonRealm)
+def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
+instance.setAuthorizationStrategy(strategy)
+
+if (!jenkins.installState.isSetupComplete()) {
+  println "Skipping the Setup Wizard"
+  InstallState.INITIAL_SETUP_COMPLETED.initializeState()
+}
+
+instance.setInstallState(InstallState.INITIAL_SETUP_COMPLETED)
+
+println "Saving all changes"
+instance.save()

--- a/salt/jenkins/configuration.sls
+++ b/salt/jenkins/configuration.sls
@@ -1,0 +1,156 @@
+# base programs and services
+parted:
+  pkg.installed
+
+tar:
+  pkg.installed:
+    - require:
+      - sls: default
+
+# partitioning
+
+{% set fstype = grains.get('data_disk_fstype') | default('ext4', true) %}
+jenkins_partition:
+  cmd.run:
+    - name: /usr/sbin/parted -s /dev/{{grains['data_disk_device']}} mklabel gpt && /usr/sbin/parted -s /dev/{{grains['data_disk_device']}} mkpart primary 2048 100% && sleep 1 && /sbin/mkfs.{{fstype}} /dev/{{grains['data_disk_device']}}1
+    - unless: ls /dev//{{grains['data_disk_device']}}1
+    - require:
+      - pkg: parted
+
+jenkins_directory:
+  file.directory:
+    - name: /var/lib/jenkins
+    - mode: 775
+    - makedirs: True
+  mount.mounted:
+    - name: /var/lib/jenkins
+    - device: /dev/{{grains['data_disk_device']}}1
+    - fstype: {{fstype}}
+    - mkmnt: True
+    - persist: True
+    - opts:
+      - defaults
+    - require:
+      - cmd: jenkins_partition
+
+jenkins_install:
+  pkg.installed:
+    - name: jenkins-lts
+    - require:
+      - sls: default
+  file.directory:
+    - name: /var/lib/jenkins/secrets
+    - mode: 700
+    - user: jenkins
+    - group: jenkins
+
+# WORKAROUND: https://build.opensuse.org/package/show/devel:tools:building/jenkins-lts#comment-1543277
+# Remove this state when the problem is fixed
+jenkins_sysconfig:
+  file.managed:
+    - name: /etc/sysconfig/jenkins
+    - source: /usr/share/fillup-templates/sysconfig.jenkins
+    - require:
+      - pkg: jenkins-lts
+    - unless: ls /etc/sysconfig/jenkins
+# End of WORKAROUND
+
+jenkins_sysconfig_replace:
+  file.replace:
+    - name: /etc/sysconfig/jenkins
+    - pattern: '^JENKINS_JAVA_OPTIONS="(.*)"$'
+    - repl: 'JENKINS_JAVA_OPTIONS="\1 -Djenkins.install.runSetupWizard=false"'
+    - unless:
+      - grep '\-Djenkins.install.runSetupWizard=false' /etc/sysconfig/jenkins
+    - require:
+      # WORKAROUND: https://build.opensuse.org/package/show/devel:tools:building/jenkins-lts#comment-1543277
+      # Remove the next line, and uncomment the next one when the problem is fixed
+      - file: jenkins_sysconfig
+      #- package: jenkins-lts
+      # End of WORKAROUND
+
+# This and the sysconfig change is needed so the Setup Wizard does not run
+# and allow us the automated installation, while at the same time we still
+# enable authentication and create an admin user (password can be found at
+# /var/lib/jenkins/secrets/initialAdminPassword)
+jenkins_security:
+  file.managed:
+    - name: /var/lib/jenkins/init.groovy.d/basic-security.groovy
+    - source: salt://jenkins/basic-security.groovy
+    - makedirs: True
+    - dir_mode: 755
+    - user: jenkins
+    - group: jenkins
+    - require:
+      - pkg: jenkins-lts
+
+# Enforce downloading the plugin list to avoid jenkins-cli failing when Jenkins
+# already returns HTTP 200, but still didn't get the plugin list
+jenkins_plugin_list:
+  file.managed:
+    - name: /var/lib/jenkins/updates/default.json
+    - source: https://updates.jenkins-ci.org/update-center.json
+    - skip_verify: True
+    - makedirs: True
+    - dir_mode: 755
+    - user: jenkins
+    - group: jenkins
+    - require:
+      - pkg: jenkins-lts
+
+jenkins_plugin_list_fix:
+  file.replace:
+    - name: /var/lib/jenkins/updates/default.json
+    - pattern: '^(updateCenter.post\(|\);)$'
+    - repl: ''
+    - require:
+      - file: jenkins_plugin_list
+
+jenkins_service:
+  service.running:
+    - name: jenkins
+    - enable: True
+    - require:
+      - file: jenkins_sysconfig_replace
+      - file: jenkins_security
+      - file: jenkins_plugin_list
+
+jenkins_configure:
+  file.managed:
+    - name: /tmp/configure-jenkins.sh
+    - source: salt://jenkins/configure-jenkins.sh
+    - mode: 755
+    - require:
+      - service: jenkins
+  cmd.run:
+    - name: /tmp/configure-jenkins.sh
+    - require:
+      - file: /tmp/configure-jenkins.sh
+      - service: jenkins
+
+web_server:
+  pkg.installed:
+    - name: apache2
+    - require:
+      - sls: default
+  file.managed:
+    - name: /etc/apache2/vhosts.d/jenkins.conf
+    - source: salt://jenkins/etc/jenkins.conf
+    - require:
+      - pkg: apache2
+  apache_module.enabled:
+    - names:
+      - proxy
+      - proxy_http
+    - require:
+      - pkg: apache2
+  service.running:
+    - name: apache2
+    - enable: True
+    - require:
+      - file: /etc/apache2/vhosts.d/jenkins.conf
+      - apache_module: proxy
+      - apache_module: proxy_http
+      - service: jenkins
+    - watch:
+      - file: /etc/apache2/vhosts.d/jenkins.conf

--- a/salt/jenkins/configure-jenkins.sh
+++ b/salt/jenkins/configure-jenkins.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+URL="http://localhost:8080"
+
+RETRIES=0
+while [ "$(curl -s -o /dev/null -w %{http_code} ${URL})" != "200" -a ${RETRIES} -lt 10 ]; do
+   sleep 10
+   RETRIES=$((RETRIES+1))
+done
+
+echo "[INFO] Downloading ${URL}/jnlpJars/jenkins-cli.jar"
+curl -s ${URL}/jnlpJars/jenkins-cli.jar -o /tmp/jenkins-cli.jar
+if [ ${?} -ne 0 ]; then
+   echo "[ERROR] Could not download ${URL}/jnlpJars/jenkins-cli.jar"
+   exit 1
+fi
+
+cli_call() {
+  echo "[INFO] Running CLI call with arguments: ${@}"
+  java -jar /tmp/jenkins-cli.jar -s ${URL} -auth admin:"$(cat /var/lib/jenkins/secrets/initialAdminPassword)" ${@}
+}
+
+# Only credential 2.6.1 is compatible with current LTS 2.303.3
+# For some reason using URL breaks the command if it's reapplied, so be sure
+# you removed credentials from thos command if you want to reapply
+cli_call install-plugin swarm https://updates.jenkins.io/download/plugins/credentials/2.6.1/credentials.hpi git git-client workflow-aggregator extended-choice-parameter timestamper htmlpublisher rebuild http_request ansicolor greenballs -deploy -restart
+

--- a/salt/jenkins/etc/jenkins.conf
+++ b/salt/jenkins/etc/jenkins.conf
@@ -1,0 +1,16 @@
+<VirtualHost *:80>
+    ErrorLog /var/log/apache2/jenkins_error_log
+    CustomLog /var/log/apache2/jenkins_access_log combined
+
+    # don't loose time with IP address lookups
+    HostnameLookups Off
+
+    # needed for named virtual hosts
+    UseCanonicalName Off
+
+    # configures the footer on server-generated documents
+    ServerSignature On
+
+    Proxypass / http://localhost:8080/
+    ProxypassReverse / http://localhost:8080/
+</VirtualHost>

--- a/salt/jenkins/init.sls
+++ b/salt/jenkins/init.sls
@@ -1,0 +1,3 @@
+include:
+  - default
+  - jenkins.configuration

--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -525,6 +525,16 @@ http:
   - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3
     archs: [x86_64]
 
+  # Jenkins
+  - url: http://download.opensuse.org/repositories/devel:/tools:/building/SLE_15_SP1
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/devel:/tools:/building/SLE_15_SP2
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/devel:/tools:/building/openSUSE_Leap_15.2
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/devel:/tools:/building/openSUSE_Leap_15.3
+    archs: [x86_64]
+
   # Uyuni Master
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.3/
     archs: [x86_64]

--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -7,6 +7,7 @@ include:
   - repos.testsuite
   - repos.virthost
   - repos.tools
+  - repos.jenkins
   {% endif %}
   - repos.additional
 

--- a/salt/repos/jenkins.sls
+++ b/salt/repos/jenkins.sls
@@ -1,0 +1,21 @@
+{% if 'jenkins' in grains.get('roles') %}
+  {% if grains['os'] == 'SUSE' %}
+    {% if grains['osfullname'] == 'Leap' %}
+      {% set repo = 'openSUSE_Leap_' + grains['osrelease'] %}
+    {% elif grains['osfullname'] == 'SLES' %}
+      {% set slemajorver = grains['osrelease'].split('.')[0] %}
+      {% set slesp = grains['osrelease'].split('.')[1] %}
+      {% if slesp == '0' %}
+        {% set slever = 'SLE_' + slemajorver %}
+      {% else %}
+        {% set slever = 'SLE_' + slemajorver + '_' + slesp %}
+      {% endif %}
+    {% endif %}
+  {% endif %}
+jenkins_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org/", true) }}/repositories/devel:/tools:/building/{{ repo }}
+    - gpgcheck: 1
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org/", true) }}/repositories/devel:/tools:/building//{{ repo }}/repodata/repomd.xml.key
+{% endif %}
+

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -37,3 +37,7 @@ base:
   'roles:virthost':
     - match: grain
     - virthost
+
+  'roles:jenkins':
+    - match: grain
+    - jenkins


### PR DESCRIPTION
## What does this PR change?

Enable deployment of a Jenkins instance with sumaform that:
- Installs the latest LTS version from OBS
- Creates a user `admin` with a random password stored at `/var/lib/jenkins/secrets/initialAdminPassword`
- Enables default security for Jenkins (integrated DB)
- Installs the required plugin run an acceptance test pipeline, and swarm, so we can later add workers

# Workarounds

Since we don't have workers yet, I had to do some workarounds at Jenkins so it would also act as worker:
- Install sumaform
- Create `/home/jenkins`, `/home/jenkins/.ssh`, create a private/public keypair, and copy `/home/jenkins/.credentials` from the internal Jenkins-worker to the same location at the AWS Jenkins. This allowed us to have a pipeline that's no different from others
- Link `/home/jenkins/.ssh` at `/var/lib/jenkins` so sumaform doesn't complain, as it's the home for the `jenkins` user.
- Add a label `sumaform-cucumber` to the worker for Jenkins itself.
- Copy the public key to the controller, and create it as `uyuni-jenkins` at AWS, to be used by the pipeline later.

## For a a subsequent PR

- [ ] Configure Apache on Jenkins to use HTTPS and Let's encrypt certificates, redirect traffic from TCP 80 to TCP 443
- [ ] Configure Apache on Jenkins to work as a reverse http proxy
- [ ] Configure Jenkins itself to be able to work with the proxy
- [ ] Create a separate security group for Jenkins, and allow traffic for ports 80 and 443
- [ ] Provide Jenkins workers, with terraform installed. They should be able to start EC2 resources using a role, not access/secret keys. Consider creating a separate Jenkins user for the swarm onboarding.
- [ ] Needless to say, email notifications don't work. We could setup a SMTP server at Jenkins using `uyuni-project.org`, but still that's usually detected a a source of spam by email filters, so the best approach is using [AWS SES](https://aws.amazon.com/ses/).
- [ ] We should not pass though the controller, if we want to work from the AWS CI.

Related: https://github.com/SUSE/susemanager-ci/pull/370
