### PR TITLE
Allow refresing salt states for AWS and Azure

### DIFF
--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -220,6 +220,7 @@ resource "null_resource" "host_salt_configuration" {
   provisioner "remote-exec" {
     inline = [
       "sudo mv /tmp/grains /etc/salt/grains",
+      "sudo rm -rf /root/salt",
       "sudo mv /tmp/salt /root",
       "sudo bash /root/salt/first_deployment_highstate.sh"
     ]

--- a/backend_modules/azure/host/main.tf
+++ b/backend_modules/azure/host/main.tf
@@ -209,6 +209,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
   provisioner "remote-exec" {
     inline = [
       "sudo mv /tmp/grains /etc/salt/grains",
+      "sudo rm -rf /root/salt",
       "sudo mv /tmp/salt /root",
       "sudo bash /root/salt/first_deployment_highstate.sh"
     ]


### PR DESCRIPTION
## What does this PR change?

Before this:
```
module.jenkins.module.jenkins.module.host.null_resource.host_salt_configuration[0] (remote-exec): mv: cannot move '/tmp/salt' to '/root/salt': File exists
```
After this:
The states are refreshed at `/root/salt`
