### PR TITLE
Add a http_proxy to Jenkins, required by the Uyuni testsuite

### DIFF
--- a/salt/jenkins/http_proxy.sls
+++ b/salt/jenkins/http_proxy.sls
@@ -1,0 +1,11 @@
+http_proxy:
+   cmd.run:
+       - name: /usr/bin/podman run -d -p 3128:3128 --restart always --name http_proxy registry.opensuse.org/systemsmanagement/uyuni/master/docker/containers/proxy
+       - unless: podman ps -a --filter "name=http_proxy" --format json|grep '"Id"'
+       - runas: podman
+       - requires:
+           - sls: jenkins.podman
+   cron.present:
+       - name: /usr/bin/podman start http_proxy
+       - user: podman
+       - special: '@reboot'

--- a/salt/jenkins/init.sls
+++ b/salt/jenkins/init.sls
@@ -1,3 +1,5 @@
 include:
   - default
   - jenkins.configuration
+  - jenkins.podman
+  - jenkins.http_proxy

--- a/salt/jenkins/podman.sls
+++ b/salt/jenkins/podman.sls
@@ -1,0 +1,17 @@
+podman:
+  pkg.installed:
+    - name: podman
+    - require:
+      - sls: default
+  user.present:
+    - name: podman
+    - fullname: podman
+    - usergroup: true
+    - shell: /bin/nologin
+    - home: /var/lib/podman
+    - system: true
+  cmd.run:
+    - name: usermod --add-subuids 200000-201000 --add-subgids 200000-201000 podman
+    - user: root
+    - require:
+      - user: podman


### PR DESCRIPTION
## What does this PR change?

Add a http_proxy to Jenkins, required by the Uyuni testsuite

It uses a new container, defined at https://build.opensuse.org/package/show/systemsmanagement:Uyuni:Master:Docker/proxy, which is basically the same thing as the proxy we have for the tests at the internal infra.

I deployed this, and works, this is a test from the bastion to the http proxy at Jenkins:
```
ec2-user@ip-172-16-0-82:~> telnet 172.16.1.252 3128
Trying 172.16.1.252...
Connected to 172.16.1.252.
Escape character is '^]'.
^CConnection closed by foreign host.
```
