### PR TITLE
Install Salt bundle based on 'install_salt_bundle' base config

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -158,7 +158,6 @@ resource "null_resource" "provisioning" {
       {
         domain                    = var.base_configuration["domain"]
         use_avahi                 = var.base_configuration["use_avahi"]
-        product_version           = var.base_configuration["product_version"]
         timezone                  = var.base_configuration["timezone"]
         use_ntp                   = var.base_configuration["use_ntp"]
         testsuite                 = var.base_configuration["testsuite"]
@@ -201,7 +200,6 @@ resource "null_resource" "provisioning" {
         hostname                  = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
         domain                    = var.base_configuration["domain"]
         use_avahi                 = var.base_configuration["use_avahi"]
-        product_version           = var.base_configuration["product_version"]
         additional_network        = var.base_configuration["additional_network"]
         timezone                  = var.base_configuration["timezone"]
         use_ntp                   = var.base_configuration["use_ntp"]

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -26,9 +26,10 @@ locals {
 data "template_file" "user_data" {
   template = file("${path.module}/user_data.yaml")
   vars = {
-    image             = var.image
-    use_mirror_images = var.base_configuration["use_mirror_images"]
-    mirror            = var.base_configuration["mirror"]
+    image               = var.image
+    use_mirror_images   = var.base_configuration["use_mirror_images"]
+    mirror              = var.base_configuration["mirror"]
+    install_salt_bundle = var.base_configuration["install_salt_bundle"]
   }
 }
 

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -28,7 +28,6 @@ data "template_file" "user_data" {
   vars = {
     image             = var.image
     use_mirror_images = var.base_configuration["use_mirror_images"]
-    product_version   = var.base_configuration["product_version"]
     mirror            = var.base_configuration["mirror"]
   }
 }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -47,7 +47,7 @@ yum_repos:
     priority: 99
     name: CentOS-Updates_backup
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -82,7 +82,7 @@ yum_repos:
     priority: 99
     name: epel
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -109,7 +109,7 @@ yum_repos:
     priority: 99
     name: epel
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -117,7 +117,7 @@ packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 
 %{ if image == "opensuse152o" }
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "qemu-guest-agent"]
 %{ else }
 packages: ["qemu-guest-agent"]
@@ -128,7 +128,7 @@ runcmd:
 %{ endif }
 
 %{ if image == "opensuse153o" || image == "opensuse153-ci-pr" || image == "opensuse153-ci-pr-client" }
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns"]
 %{ else }
 packages: ["avahi", "nss-mdns"]
@@ -147,7 +147,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -163,7 +163,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -185,7 +185,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -210,7 +210,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -235,7 +235,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -255,7 +255,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -275,7 +275,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -325,7 +325,7 @@ runcmd:
   - "sed -i -e's/prohibit-password/yes/' /etc/ssh/sshd_config"
   - systemctl restart sshd
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
@@ -339,7 +339,7 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
@@ -381,7 +381,7 @@ runcmd:
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
@@ -394,7 +394,7 @@ runcmd:
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
 %{ else }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
@@ -406,7 +406,7 @@ runcmd:
   - echo '\nPermitRootLogin yes' >> /etc/ssh/sshd_config
   - systemctl restart sshd
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
 %{ else }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
@@ -434,7 +434,7 @@ yum_repos:
     priority: 99
     name: epel
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -462,7 +462,7 @@ yum_repos:
     priority: 99
     name: epel
 
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
@@ -471,7 +471,7 @@ packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
 %{ endif }
 
 %{ if image == "opensuse153armo" }
-%{ if product_version in ["uyuni-master", "uyuni-released"] }
+%{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion"]
 %{ else }
 packages: ["salt-minion"]

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -47,7 +47,7 @@ yum_repos:
     priority: 99
     name: CentOS-Updates_backup
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -82,7 +82,7 @@ yum_repos:
     priority: 99
     name: epel
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -109,7 +109,7 @@ yum_repos:
     priority: 99
     name: epel
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -117,7 +117,7 @@ packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 
 %{ if image == "opensuse152o" }
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "qemu-guest-agent"]
 %{ else }
 packages: ["qemu-guest-agent"]
@@ -128,7 +128,7 @@ runcmd:
 %{ endif }
 
 %{ if image == "opensuse153o" || image == "opensuse153-ci-pr" || image == "opensuse153-ci-pr-client" }
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "avahi", "nss-mdns"]
 %{ else }
 packages: ["avahi", "nss-mdns"]
@@ -147,7 +147,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -163,7 +163,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -185,7 +185,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -210,7 +210,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -235,7 +235,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -255,7 +255,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -275,7 +275,7 @@ zypper:
       enabled: 1
       autorefresh: 1
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
@@ -325,7 +325,7 @@ runcmd:
   - "sed -i -e's/prohibit-password/yes/' /etc/ssh/sshd_config"
   - systemctl restart sshd
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
@@ -339,7 +339,7 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
@@ -381,7 +381,7 @@ runcmd:
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
@@ -394,7 +394,7 @@ runcmd:
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
 %{ else }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
@@ -406,7 +406,7 @@ runcmd:
   - echo '\nPermitRootLogin yes' >> /etc/ssh/sshd_config
   - systemctl restart sshd
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
 %{ else }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
@@ -434,7 +434,7 @@ yum_repos:
     priority: 99
     name: epel
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -462,7 +462,7 @@ yum_repos:
     priority: 99
     name: epel
 
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
@@ -471,7 +471,7 @@ packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
 %{ endif }
 
 %{ if image == "opensuse153armo" }
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
+%{ if product_version in ["uyuni-master", "uyuni-released"] }
 packages: ["venv-salt-minion", "salt-minion"]
 %{ else }
 packages: ["salt-minion"]

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -38,11 +38,6 @@ variable "use_avahi" {
   default     = true
 }
 
-variable "product_version" {
-  description = "One of: 4.0-nightly, 4.0-released, 4.1-nightly, 4.1-released, 4.2-nightly, 4.2-released, 4.3-nightly, 4.3-released, 4.3-beta, head, test, uyuni-master, uyuni-released, uyuni-pr"
-  type        = string
-}
-
 variable "domain" {
   description = "hostname's domain"
   default     = "tf.local"

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -38,6 +38,11 @@ variable "use_avahi" {
   default     = true
 }
 
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = false
+}
+
 variable "domain" {
   description = "hostname's domain"
   default     = "tf.local"

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -8,6 +8,7 @@ module "base_backend" {
   ssh_key_path             = var.ssh_key_path
   mirror                   = var.mirror
   use_mirror_images        = var.use_mirror_images
+  install_salt_bundle      = var.install_salt_bundle
   use_avahi                = var.use_avahi
   domain                   = var.domain
   name_prefix              = var.name_prefix
@@ -26,6 +27,7 @@ output "configuration" {
     ssh_key_path             = var.ssh_key_path
     mirror                   = var.mirror
     use_mirror_images        = var.use_mirror_images
+    install_salt_bundle      = var.install_salt_bundle
     use_avahi                = var.use_avahi
     domain                   = var.domain
     name_prefix              = var.name_prefix

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -9,7 +9,6 @@ module "base_backend" {
   mirror                   = var.mirror
   use_mirror_images        = var.use_mirror_images
   use_avahi                = var.use_avahi
-  product_version          = var.product_version
   domain                   = var.domain
   name_prefix              = var.name_prefix
   use_shared_resources     = var.use_shared_resources
@@ -28,7 +27,6 @@ output "configuration" {
     mirror                   = var.mirror
     use_mirror_images        = var.use_mirror_images
     use_avahi                = var.use_avahi
-    product_version          = var.product_version
     domain                   = var.domain
     name_prefix              = var.name_prefix
     use_shared_resources     = var.use_shared_resources

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -5,6 +5,7 @@ module "base" {
   cc_username          = var.cc_username
   cc_password          = var.cc_password
   use_avahi            = var.use_avahi
+  install_salt_bundle  = var.install_salt_bundle
   domain               = var.domain
   name_prefix          = var.name_prefix
   images               = var.images

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -14,6 +14,11 @@ variable "use_avahi" {
   default     = true
 }
 
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = false
+}
+
 variable "avahi_reflector" {
   description = "if using avahi, allow one minion to have a reflector configured"
   default     = false


### PR DESCRIPTION
## What does this PR change?

This PR fix the current issues caused by previous commit in order to enable the `venv-salt-minion` installation. 

This PR introduces a new configuration parameter for the "base" configuration named `install_salt_bundle` (default: false).