### PR TITLE
Support dmacvicar/libvirt when defining multiple providers

### DIFF
--- a/modules/base/versions.tf
+++ b/modules/base/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/client/versions.tf
+++ b/modules/client/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/controller/versions.tf
+++ b/modules/controller/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/cucumber_testsuite/versions.tf
+++ b/modules/cucumber_testsuite/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/grafana/versions.tf
+++ b/modules/grafana/versions.tf
@@ -1,4 +1,10 @@
 
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/host/versions.tf
+++ b/modules/host/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/jenkins/versions.tf
+++ b/modules/jenkins/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
   required_version = ">= 1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/locust/versions.tf
+++ b/modules/locust/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/minion/versions.tf
+++ b/modules/minion/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/mirror/versions.tf
+++ b/modules/mirror/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/proxy/versions.tf
+++ b/modules/proxy/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/pxe_boot/versions.tf
+++ b/modules/pxe_boot/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/registry/versions.tf
+++ b/modules/registry/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/server/versions.tf
+++ b/modules/server/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/sshminion/versions.tf
+++ b/modules/sshminion/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }

--- a/modules/virthost/versions.tf
+++ b/modules/virthost/versions.tf
@@ -1,4 +1,9 @@
-
 terraform {
   required_version = "1.0.10"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
 }


### PR DESCRIPTION
## What does this PR change?

Allow us to define multiple providers (with their aliases) and use the libvirt provider that suppports latest terraform.

This is only a temporary solution that must not be merged.
@rjmateus will come with a proper solution.