### PR TITLE
Fix propagation of "install_salt_bundle" after last refactor

### DIFF
--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -6,6 +6,7 @@ module "client" {
   quantity                      = var.quantity
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
+  install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_packages           = var.additional_packages
   gpg_keys                      = var.gpg_keys

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -46,6 +46,11 @@ variable "additional_packages" {
   default     = []
 }
 
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = false
+}
+
 variable "quantity" {
   description = "number of hosts like this one"
   default     = 1

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -30,6 +30,8 @@ locals {
     host_key => lookup(var.host_settings[host_key], "image", "default") if var.host_settings[host_key] != null ? contains(keys(var.host_settings[host_key]), "image") : false }
   names                     = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "name", null) if var.host_settings[host_key] != null ? contains(keys(var.host_settings[host_key]), "name") : false }
+  install_salt_bundle       = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "install_salt_bundle", false) if var.host_settings[host_key] != null }
 }
 
 module "server" {
@@ -52,6 +54,7 @@ module "server" {
   forward_registration           = false
   monitored                      = true
   use_os_released_updates        = true
+  install_salt_bundle            = lookup(local.install_salt_bundle, "server", false)
   ssh_key_path                   = "./salt/controller/id_rsa.pub"
   from_email                     = var.from_email
   additional_repos               = lookup(local.additional_repos, "server", {})
@@ -81,6 +84,7 @@ module "proxy" {
   publish_private_ssl_key   = false
   use_os_released_updates   = true
   ssh_key_path              = "./salt/controller/id_rsa.pub"
+  install_salt_bundle = lookup(local.install_salt_bundle, "proxy", false)
 
   additional_repos  = lookup(local.additional_repos, "proxy", {})
   additional_packages = lookup(local.additional_packages, "proxy", [])
@@ -106,6 +110,7 @@ module "suse-client" {
   auto_register           = false
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle     = lookup(local.install_salt_bundle, "suse-client", false)
 
   additional_repos  = lookup(local.additional_repos, "suse-client", {})
   additional_packages = lookup(local.additional_packages, "suse-client", [])
@@ -126,6 +131,7 @@ module "suse-minion" {
   auto_connect_to_master  = false
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle     = lookup(local.install_salt_bundle, "suse-minion", false)
 
   additional_repos  = lookup(local.additional_repos, "suse-minion", {})
   additional_packages = lookup(local.additional_packages, "suse-minion", [])
@@ -147,6 +153,7 @@ module "build-host" {
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   avahi_reflector         = var.avahi_reflector
+  install_salt_bundle     = lookup(local.install_salt_bundle, "build-host", false)
 
   additional_repos  = lookup(local.additional_repos, "build-host", {})
   additional_packages = lookup(local.additional_packages, "build-host", [])
@@ -166,6 +173,7 @@ module "suse-sshminion" {
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
+  install_salt_bundle     = lookup(local.install_salt_bundle, "suse-sshminion", false)
 
   additional_repos  = lookup(local.additional_repos, "suse-sshminion", {})
   additional_packages = lookup(local.additional_packages, "suse-sshminion", [])
@@ -185,6 +193,7 @@ module "redhat-minion" {
   server_configuration   = local.minimal_configuration
   auto_connect_to_master = false
   ssh_key_path           = "./salt/controller/id_rsa.pub"
+  install_salt_bundle    = lookup(local.install_salt_bundle, "redhat-minion", false)
 
   additional_repos  = lookup(local.additional_repos, "redhat-minion", {})
   additional_packages = lookup(local.additional_packages, "redhat-minion", [])
@@ -204,6 +213,7 @@ module "debian-minion" {
   server_configuration   = local.minimal_configuration
   auto_connect_to_master = false
   ssh_key_path           = "./salt/controller/id_rsa.pub"
+  install_salt_bundle    = lookup(local.install_salt_bundle, "debian-minion", false)
 
   additional_repos  = lookup(local.additional_repos, "debian-minion", {})
   additional_packages = lookup(local.additional_packages, "debian-minion", [])
@@ -236,6 +246,7 @@ module "kvm-host" {
   auto_connect_to_master  = false
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle     = lookup(local.install_salt_bundle, "kvm-host", false)
 
   additional_repos  = lookup(local.additional_repos, "kvm-host", {})
   additional_packages = lookup(local.additional_packages, "kvm-host", [])
@@ -258,6 +269,7 @@ module "xen-host" {
   auto_connect_to_master  = false
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
+  install_salt_bundle     = lookup(local.install_salt_bundle, "xen-host", false)
 
   additional_repos  = lookup(local.additional_repos, "xen-host", {})
   additional_packages = lookup(local.additional_packages, "xen-host", [])

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -7,6 +7,7 @@ module "host" {
   roles                         = var.roles
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
+  install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only
   additional_certs              = var.additional_certs

--- a/modules/minion/main.tf
+++ b/modules/minion/main.tf
@@ -6,6 +6,7 @@ module "minion" {
   quantity                      = var.quantity
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
+  install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_packages           = var.additional_packages
   gpg_keys                      = var.gpg_keys

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -71,6 +71,11 @@ variable "additional_packages" {
   default     = []
 }
 
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = false
+}
+
 variable "quantity" {
   description = "number of hosts like this one"
   default     = 1

--- a/modules/mirror/main.tf
+++ b/modules/mirror/main.tf
@@ -5,6 +5,7 @@ module "mirror" {
   base_configuration      = var.base_configuration
   name                    = "mirror"
   use_os_released_updates = var.use_os_released_updates
+  install_salt_bundle     = var.install_salt_bundle
   additional_repos        = var.additional_repos
   additional_packages     = var.additional_packages
   swap_file_size          = var.swap_file_size

--- a/modules/mirror/variables.tf
+++ b/modules/mirror/variables.tf
@@ -17,6 +17,11 @@ variable "additional_packages" {
   default     = []
 }
 
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = false
+}
+
 variable "swap_file_size" {
   description = "Swap file size in MiB, or 0 for none"
   default     = 0

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -24,6 +24,7 @@ module "proxy" {
   quantity                      = var.quantity
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
+  install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_packages           = var.additional_packages
   swap_file_size                = var.swap_file_size

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -81,6 +81,11 @@ variable "additional_packages" {
   default     = []
 }
 
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = false
+}
+
 variable "quantity" {
   description = "number of hosts like this one"
   default     = 1

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -23,6 +23,7 @@ module "server" {
   name                          = var.name
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
+  install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only
   additional_certs              = var.additional_certs

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -182,6 +182,11 @@ variable "additional_packages" {
   default     = []
 }
 
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = false
+}
+
 variable "traceback_email" {
   description = "recipient email address that will receive errors during usage"
   default     = null

--- a/modules/sshminion/main.tf
+++ b/modules/sshminion/main.tf
@@ -6,6 +6,7 @@ module "sshminion" {
   quantity                      = var.quantity
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
+  install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_packages           = var.additional_packages
   gpg_keys                      = var.gpg_keys

--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -42,6 +42,11 @@ variable "additional_packages" {
   default     = []
 }
 
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = false
+}
+
 variable "quantity" {
   description = "number of hosts like this one"
   default     = 1

--- a/modules/virthost/main.tf
+++ b/modules/virthost/main.tf
@@ -9,6 +9,7 @@ module "virthost" {
   auto_connect_to_master    = var.auto_connect_to_master
   use_os_released_updates   = var.use_os_released_updates
   use_os_unreleased_updates = var.use_os_unreleased_updates
+  install_salt_bundle       = var.install_salt_bundle
   additional_repos          = var.additional_repos
   additional_packages       = var.additional_packages
   quantity                  = var.quantity

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -46,6 +46,11 @@ variable "additional_packages" {
   default     = []
 }
 
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = false
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default     = null

--- a/salt/post_provisioning_cleanup.sh
+++ b/salt/post_provisioning_cleanup.sh
@@ -12,6 +12,9 @@ fi
 
 echo "This instance is configured to use Salt Bundle in /etc/salt/grains !"
 
+echo "Copying /etc/salt/grains to /etc/venv-salt-minion"
+cp /etc/salt/grains /etc/venv-salt-minion/grains
+
 if [ -x /usr/bin/dnf ]; then
     INSTALLER=yum
 elif [ -x /usr/bin/zypper ]; then


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem with newly introduced `install_salt_bundle` which is not working properly after the last refactor.

This also copies the `/etc/salt/grains` file deployed by sumaform to `/etc/venv-salt-minion/grains` in case `install_salt_bundle` is set.