### PR TITLE
Add custom pillar for "testsuite" to enable Salt Bundle when doing bootstrapping

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -77,6 +77,7 @@ testsuite_salt_packages:
     - require:
       - sls: repos
 
+{% if 'uyuni' in grains.get('product_version') | default('', true) %}
 {% if grains['install_salt_bundle'] %}
 create_pillar_top_sls_to_assign_salt_bundle_config:
   file.managed:
@@ -93,6 +94,7 @@ custom_pillar_to_force_salt_bundle:
         mgr_force_venv_salt_minion: True
     - require:
       - file: create_pillar_top_sls_to_assign_salt_bundle_config
+{% endif %}
 {% endif %}
 
 enable_salt_content_staging_window:

--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -77,6 +77,24 @@ testsuite_salt_packages:
     - require:
       - sls: repos
 
+{% if grains['install_salt_bundle'] %}
+create_pillar_top_sls_to_assign_salt_bundle_config:
+  file.managed:
+    - name: /srv/pillar/top.sls
+    - contents: |
+        base:
+          '*':
+            - salt_bundle
+
+custom_pillar_to_force_salt_bundle:
+  file.managed:
+    - name: /srv/pillar/salt_bundle.sls
+    - contents: |
+        mgr_force_venv_salt_minion: True
+    - require:
+      - file: create_pillar_top_sls_to_assign_salt_bundle_config
+{% endif %}
+
 enable_salt_content_staging_window:
   file.replace:
     - name: /etc/rhn/rhn.conf


### PR DESCRIPTION
## What does this PR change?

This PR makes the server role to define a custom pillar `mgr_force_venv_salt_minion: True` for all minions in order make the bootstrap state during Uyuni testsuite execution to use the `venv-salt-minion` package (even if this is not available in the bootstrap repository).

See how this pillar data affects bootstrapping here: https://github.com/uyuni-project/uyuni/pull/4497

Without this change, since the testsuite is not syncing the client tools for the different systems, then `venv-salt-minion` is not part of the bootstrap repo (but it's installed on the system), the bootstrapping is using "salt-minion" and not "venv-salt-minion" as we would expect.
