### PR TITLE
version files as symbolic link to backend in use

### DIFF
--- a/modules/base/versions.tf
+++ b/modules/base/versions.tf
@@ -1,3 +1,1 @@
-terraform {
-  required_version = "1.0.10"
-}
+../backend/base/versions.tf

--- a/modules/client/versions.tf
+++ b/modules/client/versions.tf
@@ -1,3 +1,1 @@
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/controller/versions.tf
+++ b/modules/controller/versions.tf
@@ -1,3 +1,1 @@
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/cucumber_testsuite/versions.tf
+++ b/modules/cucumber_testsuite/versions.tf
@@ -1,3 +1,1 @@
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/grafana/versions.tf
+++ b/modules/grafana/versions.tf
@@ -1,4 +1,1 @@
-
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/host/versions.tf
+++ b/modules/host/versions.tf
@@ -1,3 +1,1 @@
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/jenkins/versions.tf
+++ b/modules/jenkins/versions.tf
@@ -1,4 +1,1 @@
-
-terraform {
-  required_version = ">= 1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/locust/versions.tf
+++ b/modules/locust/versions.tf
@@ -1,4 +1,1 @@
-
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/minion/versions.tf
+++ b/modules/minion/versions.tf
@@ -1,4 +1,1 @@
-
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/mirror/versions.tf
+++ b/modules/mirror/versions.tf
@@ -1,4 +1,1 @@
-
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/proxy/versions.tf
+++ b/modules/proxy/versions.tf
@@ -1,4 +1,1 @@
-
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/pxe_boot/versions.tf
+++ b/modules/pxe_boot/versions.tf
@@ -1,4 +1,1 @@
-
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/registry/versions.tf
+++ b/modules/registry/versions.tf
@@ -1,3 +1,1 @@
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/server/versions.tf
+++ b/modules/server/versions.tf
@@ -1,4 +1,1 @@
-
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/sshminion/versions.tf
+++ b/modules/sshminion/versions.tf
@@ -1,4 +1,1 @@
-
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf

--- a/modules/virthost/versions.tf
+++ b/modules/virthost/versions.tf
@@ -1,4 +1,1 @@
-
-terraform {
-  required_version = "1.0.10"
-}
+../backend/host/versions.tf


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

If we use multiple libvirt providers definitions it needs each module that doesn't use the default.
Since each provider independent module doesn't define the provider namespace in use, terraform tries to resolve the same to `hashicorp/libvirt` instead of using the name space defined in the root main tf file.

With this change, all provider indepoendent module version file is now a symbolic link to the provider in use. With this approach we make sure all needed providers are defined for each module and we maintain compatibility with all backend providers.

@srbarrios ping