### PR TITLE
Optional parameter to accept a greater range of SSL protocol versions

### DIFF
--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -51,6 +51,7 @@ module "proxy" {
     publish_private_ssl_key   = var.publish_private_ssl_key
     repository_disk_size      = var.repository_disk_size
     proxy_registration_code   = var.proxy_registration_code
+    accept_all_ssl_protocols  = var.accept_all_ssl_protocols
   }
 
   image                    = var.image == "default" || var.product_version == "head" ? var.images[var.product_version] : var.image

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -138,3 +138,8 @@ variable "proxy_registration_code" {
   description = "SUMA SCC registration code to enable the SLES and SUMA repositories for proxy"
   default     = null
 }
+
+variable "accept_all_ssl_protocols" {
+  description = "Turn to true to force Apache to accept a greater range of protocol versions"
+  default     = false
+}

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -75,6 +75,7 @@ module "server" {
     repository_disk_size           = var.repository_disk_size
     forward_registration           = var.forward_registration
     server_registration_code       = var.server_registration_code
+    accept_all_ssl_protocols       = var.accept_all_ssl_protocols
   }
 
 

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -254,3 +254,8 @@ variable "server_registration_code" {
   description = "SUMA SCC registration code to enable the SLES and SUMA repositories for server"
   default     = null
 }
+
+variable "accept_all_ssl_protocols" {
+  description = "Turn to true to force Apache to accept a greater range of protocol versions"
+  default     = false
+}

--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -57,6 +57,15 @@ squid-configuration-unknown-nameservers:
 
 {% endif %}
 
+{% if grains.get('accept_all_ssl_protocols') %}
+proxy_substitute_sslprotocols:
+  file.replace:
+    - name: /etc/apache2/ssl-global.conf
+    - pattern: SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+    - repl: SSLProtocol all -SSLv2 -SSLv3
+    - require:
+      - proxy-packages
+{% endif %}
 
 {% if grains.get('auto_register') %}
 

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -70,6 +70,16 @@ substitute_email_sender_address:
         - cmd: server_setup
 {% endif %}
 
+{% if grains.get('accept_all_ssl_protocols') %}
+server_substitute_sslprotocols:
+  file.replace:
+    - name: /etc/apache2/ssl-global.conf
+    - pattern: SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+    - repl: SSLProtocol all -SSLv2 -SSLv3
+    - require:
+        - cmd: server_setup
+{% endif %}
+
 {% if grains.get('traceback_email') %}
 substitute_email_traceback_address:
   file.replace:


### PR DESCRIPTION
## What does this PR change?

As our server and proxy has a default Apache configuration that doesn't allow old SSL Protocols, our SLES11SP4 or CentOS6 systems will require to manually that config. This parameter automated it for us.

See also https://github.com/SUSE/spacewalk/issues/15659 