### PR TITLE
AlmaLinux 8.4 - fix qcow url

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -2,7 +2,7 @@
 locals {
   images_used = var.use_shared_resources ? [] : var.images
   image_urls = {
-    almalinux8o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://repo.almalinux.org"}/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.4-20210616.x86_64.qcow2"
+    almalinux8o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://repo.almalinux.org"}/almalinux/8.4/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.4-20210616.x86_64.qcow2"
     centos6o        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2"
     centos7         = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2"
     centos7o        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"


### PR DESCRIPTION
it seems the old url (the `/8/`directory) points to the version 8.5 now. Fixed by explicitly stating `8.4`.
