### PR TITLE
Fix broken link to use proper AlmaLinux8 qcow2 image name

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -2,7 +2,7 @@
 locals {
   images_used = var.use_shared_resources ? [] : var.images
   image_urls = {
-    almalinux8o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://repo.almalinux.org"}/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.4-20210616.x86_64.qcow2"
+    almalinux8o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://repo.almalinux.org"}/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-latest.x86_64.qcow2"
     centos6o        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2"
     centos7         = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/moio/sumaform-images/releases/download/4.3.0/centos7.qcow2"
     centos7o        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"


### PR DESCRIPTION
## What does this PR change?

This PR fixes a broken link for the AlmaLinux8 image source. Since AlmaLinux 8.5 was released the link changed and it is not raising 404.

This changed to the link to the generic name pointing to latest release of AlmaLinux 8.