### PR TITLE
Terminals are known only by their MAC address

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -99,16 +99,12 @@ module "controller" {
     debian10_sshminion   = length(var.debian10_sshminion_configuration["hostnames"]) > 0 ? var.debian10_sshminion_configuration["hostnames"][0] : null
     debian11_minion      = length(var.debian11_minion_configuration["hostnames"]) > 0 ? var.debian11_minion_configuration["hostnames"][0] : null
     debian11_sshminion   = length(var.debian11_sshminion_configuration["hostnames"]) > 0 ? var.debian11_sshminion_configuration["hostnames"][0] : null
-    sle11sp4_buildhost   = length(var.sle11sp4_buildhost_configuration["hostnames"]) > 0 ? var.sle11sp4_buildhost_configuration["hostnames"][0] : null
-    sle11sp3_terminal    = length(var.terminal_configuration["hostnames"]) > 0 ? var.terminal_configuration["hostnames"][0] : null
-    sle12sp4_buildhost   = length(var.sle12sp4_buildhost_configuration["hostnames"]) > 0 ? var.sle12sp4_buildhost_configuration["hostnames"][0] : null
-    sle12sp4_terminal    = length(var.terminal_configuration["hostnames"]) > 0 ? var.terminal_configuration["hostnames"][0] : null
-    sle12sp5_buildhost   = length(var.sle12sp5_buildhost_configuration["hostnames"]) > 0 ? var.sle12sp5_buildhost_configuration["hostnames"][0] : null
-    sle12sp5_terminal    = length(var.terminal_configuration["hostnames"]) > 0 ? var.terminal_configuration["hostnames"][0] : null
-    sle15sp2_buildhost   = length(var.sle15sp2_buildhost_configuration["hostnames"]) > 0 ? var.sle15sp2_buildhost_configuration["hostnames"][0] : null
-    sle15sp2_terminal    = length(var.terminal_configuration["hostnames"]) > 0 ? var.terminal_configuration["hostnames"][0] : null
-    sle15sp3_buildhost   = length(var.sle15sp3_buildhost_configuration["hostnames"]) > 0 ? var.sle15sp3_buildhost_configuration["hostnames"][0] : null
-    sle15sp3_terminal    = length(var.terminal_configuration["hostnames"]) > 0 ? var.terminal_configuration["hostnames"][0] : null
+    sle11sp4_buildhost    = length(var.sle11sp4_buildhost_configuration["hostnames"]) > 0 ? var.sle11sp4_buildhost_configuration["hostnames"][0] : null
+    sle11sp3_terminal_mac = length(var.sle11sp3_terminal_configuration["macaddrs"]) > 0 ? var.sle11sp3_terminal_configuration["macaddrs"][0] : null
+    sle12sp5_buildhost    = length(var.sle12sp5_buildhost_configuration["hostnames"]) > 0 ? var.sle12sp5_buildhost_configuration["hostnames"][0] : null
+    sle12sp5_terminal_mac = length(var.sle12sp5_terminal_configuration["macaddrs"]) > 0 ? var.sle12sp5_terminal_configuration["macaddrs"][0] : null
+    sle15sp3_buildhost    = length(var.sle15sp3_buildhost_configuration["hostnames"]) > 0 ? var.sle15sp3_buildhost_configuration["hostnames"][0] : null
+    sle15sp3_terminal_mac = length(var.sle15sp3_terminal_configuration["macaddrs"]) > 0 ? var.sle15sp3_terminal_configuration["macaddrs"][0] : null
     opensuse153arm_minion = length(var.opensuse153arm_minion_configuration["hostnames"]) > 0 ? var.opensuse153arm_minion_configuration["hostnames"][0] : null
   }
 

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -90,15 +90,6 @@ variable "pxeboot_configuration" {
   }
 }
 
-variable "terminal_configuration" {
-  description = "use module.<TERMINAL_NAME>.configuration, see main.tf.libvirt-testsuite.example"
-  default = {
-    hostnames = []
-    macaddr = null
-    image = null
-  }
-}
-
 variable "kvmhost_configuration" {
   description = "use module.<VIRTHOST_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
@@ -410,23 +401,7 @@ variable "sle15sp3_buildhost_configuration" {
 variable "sle15sp3_terminal_configuration" {
   description = "use module.<SLE15SP3_TERMINAL>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    macaddr = null
-    image = null
-  }
-}
-
-variable "sle15sp2_buildhost_configuration" {
-  description = "use module.<SLE15SP2_BUILDHOST>.configuration, see main.tf.libvirt-testsuite.example"
-  default = {
-    hostnames = []
-  }
-}
-
-variable "sle15sp2_terminal_configuration" {
-  description = "use module.<SLE15SP2_TERMINAL>.configuration, see main.tf.libvirt-testsuite.example"
-  default = {
-    macaddr = null
-    image = null
+    macaddrs = []
   }
 }
 
@@ -440,23 +415,7 @@ variable "sle12sp5_buildhost_configuration" {
 variable "sle12sp5_terminal_configuration" {
   description = "use module.<SLE12SP5_TERMINAL>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    macaddr = null
-    image = null
-  }
-}
-
-variable "sle12sp4_buildhost_configuration" {
-  description = "use module.<SLE12SP4_BUILDHOST>.configuration, see main.tf.libvirt-testsuite.example"
-  default = {
-    hostnames = []
-  }
-}
-
-variable "sle12sp4_terminal_configuration" {
-  description = "use module.<SLE12SP4_TERMINAL>.configuration, see main.tf.libvirt-testsuite.example"
-  default = {
-    macaddr = null
-    image = null
+    macaddrs = []
   }
 }
 
@@ -470,8 +429,7 @@ variable "sle11sp4_buildhost_configuration" {
 variable "sle11sp3_terminal_configuration" {
   description = "use module.<SLE11SP3_TERMINAL>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    macaddr = null
-    image = null
+    macaddrs = []
   }
 }
 

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -9,7 +9,7 @@ export SERVER="{{ grains.get('server') }}"
 {% if grains.get('ssh_minion') | default(false, true) %}export SSHMINION="{{ grains.get('ssh_minion') }}" {% else %}# no SSH minion defined {% endif %}
 {% if grains.get('redhat_minion') | default(false, true) %}export CENTOSMINION="{{ grains.get('redhat_minion') }}" {% else %}# no RedHat minion defined {% endif %}
 {% if grains.get('debian_minion') | default(false, true) %}export UBUNTUMINION="{{ grains.get('debian_minion') }}" {% else %}# no Debian minion defined {% endif %}
-{% if grains.get('pxeboot_mac') | default(false, true) %}export PXEBOOT_MAC="{{ grains.get('pxeboot_mac') }}" {% else %}# no JeOS minion defined {% endif %}
+{% if grains.get('pxeboot_mac') | default(false, true) %}export PXEBOOT_MAC="{{ grains.get('pxeboot_mac') }}" {% else %}# no PXE boot MAC defined {% endif %}
 {% if grains.get('kvm_host') | default(false, true) %}export VIRTHOST_KVM_URL="{{ grains.get('kvm_host') }}"
 export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 {% if grains.get('xen_host') | default(false, true) %}export VIRTHOST_XEN_URL="{{ grains.get('xen_host') }}"
@@ -62,15 +62,11 @@ export VIRTHOST_XEN_PASSWORD="linux" {% else %}# no Xen host defined {% endif %}
 {% if grains.get('debian11_minion') | default(false, true) %}export DEBIAN11_MINION="{{ grains.get('debian11_minion') }}" {% else %}# no DEBIAN11 minion defined {% endif %}
 {% if grains.get('debian11_sshminion') | default(false, true) %}export DEBIAN11_SSHMINION="{{ grains.get('debian11_sshminion') }}" {% else %}# no DEBIAN11 ssh minion defined {% endif %}
 {% if grains.get('sle15sp3_buildhost') | default(false, true) %}export SLE15SP3_BUILDHOST="{{ grains.get('sle15sp3_buildhost') }}" {% else %}# no SLE15SP3 buildhost defined {% endif %}
-{% if grains.get('sle15sp3_terminal') | default(false, true) %}export SLE15SP3_TERMINAL="{{ grains.get('sle15sp3_terminal') }}" {% else %}# no SLE15SP3 terminal defined {% endif %}
-{% if grains.get('sle15sp2_buildhost') | default(false, true) %}export SLE15SP2_BUILDHOST="{{ grains.get('sle15sp2_buildhost') }}" {% else %}# no SLE15SP2 buildhost defined {% endif %}
-{% if grains.get('sle15sp2_terminal') | default(false, true) %}export SLE15SP2_TERMINAL="{{ grains.get('sle15sp2_terminal') }}" {% else %}# no SLE15SP2 terminal defined {% endif %}
+{% if grains.get('sle15sp3_terminal_mac') | default(false, true) %}export SLE15SP3_TERMINAL_MAC="{{ grains.get('sle15sp3_terminal_mac') }}" {% else %}# no SLE15SP3 terminal MAC defined {% endif %}
 {% if grains.get('sle12sp5_buildhost') | default(false, true) %}export SLE12SP5_BUILDHOST="{{ grains.get('sle12sp5_buildhost') }}" {% else %}# no SLE12SP5 buildhost defined {% endif %}
-{% if grains.get('sle12sp5_terminal') | default(false, true) %}export SLE12SP5_TERMINAL="{{ grains.get('sle12sp5_terminal') }}" {% else %}# no SLE12SP5 terminal defined {% endif %}
-{% if grains.get('sle12sp4_buildhost') | default(false, true) %}export SLE12SP4_BUILDHOST="{{ grains.get('sle12sp4_buildhost') }}" {% else %}# no SLE12SP4 buildhost defined {% endif %}
-{% if grains.get('sle12sp4_terminal') | default(false, true) %}export SLE12SP4_TERMINAL="{{ grains.get('sle12sp4_terminal') }}" {% else %}# no SLE12SP4 terminal defined {% endif %}
+{% if grains.get('sle12sp5_terminal_mac') | default(false, true) %}export SLE12SP5_TERMINAL_MAC="{{ grains.get('sle12sp5_terminal_mac') }}" {% else %}# no SLE12SP5 terminal MAC defined {% endif %}
 {% if grains.get('sle11sp4_buildhost') | default(false, true) %}export SLE11SP4_BUILDHOST="{{ grains.get('sle11sp4_buildhost') }}" {% else %}# no SLE11SP4 buildhost defined {% endif %}
-{% if grains.get('sle11sp3_terminal') | default(false, true) %}export SLE11SP3_TERMINAL="{{ grains.get('sle11sp3_terminal') }}" {% else %}# no SLE11SP3 terminal defined {% endif %}
+{% if grains.get('sle11sp3_terminal_mac') | default(false, true) %}export SLE11SP3_TERMINAL_MAC="{{ grains.get('sle11sp3_terminal_mac') }}" {% else %}# no SLE11SP3 terminal MAC defined {% endif %}
 {% if grains.get('opensuse153arm_minion') | default(false, true) %}export OPENSUSE153ARM_MINION="{{ grains.get('opensuse153arm_minion') }}" {% else %}# no OPENSUSE153ARM minion defined {% endif %}
 
 # various test suite settings


### PR DESCRIPTION
## What does this PR change?

Correct generation of Retail information

See also uyuni-project/uyuni#4567

Tested to work on 4.1 BV.

This PR also removes build hosts and terminals for sles12sp4 and sles15sp2, forgotten in a previous PR. We now use sles12sp5 and sles15sp3.