### PR TITLE
additional grains on cucumber testsuite module

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -143,6 +143,7 @@ Each of the hosts (including `server` and `controller` which are always present)
  - `provider_settings`: Map of provider-specific settings for the host, see the backend-specific README file
  - `additional_repos` to add software repositories (see [README_ADVANCED.md](README_ADVANCED.md))
  - `additional_packages` to add software packages (see [README_ADVANCED.md](README_ADVANCED.md))
+ - `additional_grains` to add or overwrite salt grains on salt minions. Map of key value
  - `image` to use a different base image
 
 A libvirt example follows:
@@ -242,3 +243,26 @@ module "cucumber_testsuite" {
    ...
 }
 ```
+## Virtual host
+
+User may need to change the kvm/xem image download. To do it, one can use the `additional_grains` property:
+
+host_settings = {
+    kvm-host = {
+        additional_grains = {
+            hvm_disk_image = ".."
+            hvm_disk_image_hash = "..."
+            xen_disk_image = "..."
+            xen_disk_image_hash = "..."
+        }
+    }
+    xen-host = {
+        additional_grains = {
+            hvm_disk_image = ".."
+            hvm_disk_image_hash = "..."
+            xen_disk_image = "..."
+            xen_disk_image_hash = "..."
+        }
+    }
+}
+    ```

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -26,6 +26,8 @@ locals {
     host_key => lookup(var.host_settings[host_key], "additional_repos", {}) if var.host_settings[host_key] != null }
   additional_packages       = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "additional_packages", []) if var.host_settings[host_key] != null }
+  additional_grains       = { for host_key in local.hosts :
+  host_key => lookup(var.host_settings[host_key], "additional_grains", {}) if var.host_settings[host_key] != null }
   images                    = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "image", "default") if var.host_settings[host_key] != null ? contains(keys(var.host_settings[host_key]), "image") : false }
   names                     = { for host_key in local.hosts :
@@ -135,6 +137,7 @@ module "suse-minion" {
 
   additional_repos  = lookup(local.additional_repos, "suse-minion", {})
   additional_packages = lookup(local.additional_packages, "suse-minion", [])
+  additional_grains = lookup(local.additional_grains, "suse-minion", {})
   provider_settings = lookup(local.provider_settings_by_host, "suse-minion", {})
 }
 
@@ -157,6 +160,7 @@ module "build-host" {
 
   additional_repos  = lookup(local.additional_repos, "build-host", {})
   additional_packages = lookup(local.additional_packages, "build-host", [])
+  additional_grains = lookup(local.additional_grains, "build-host", {})
   provider_settings = lookup(local.provider_settings_by_host, "build-host", {})
 }
 
@@ -177,6 +181,7 @@ module "suse-sshminion" {
 
   additional_repos  = lookup(local.additional_repos, "suse-sshminion", {})
   additional_packages = lookup(local.additional_packages, "suse-sshminion", [])
+  additional_grains = lookup(local.additional_grains, "suse-sshminion", {})
   provider_settings = lookup(local.provider_settings_by_host, "suse-sshminion", {})
 }
 
@@ -197,6 +202,7 @@ module "redhat-minion" {
 
   additional_repos  = lookup(local.additional_repos, "redhat-minion", {})
   additional_packages = lookup(local.additional_packages, "redhat-minion", [])
+  additional_grains = lookup(local.additional_grains, "redhat-minion", {})
   provider_settings = lookup(local.provider_settings_by_host, "redhat-minion", {})
 }
 
@@ -217,6 +223,7 @@ module "debian-minion" {
 
   additional_repos  = lookup(local.additional_repos, "debian-minion", {})
   additional_packages = lookup(local.additional_packages, "debian-minion", [])
+  additional_grains = lookup(local.additional_grains, "debian-minion", {})
   provider_settings = lookup(local.provider_settings_by_host, "debian-minion", {})
 }
 
@@ -250,6 +257,7 @@ module "kvm-host" {
 
   additional_repos  = lookup(local.additional_repos, "kvm-host", {})
   additional_packages = lookup(local.additional_packages, "kvm-host", [])
+  additional_grains = lookup(local.additional_grains, "kvm-host", {})
   provider_settings = lookup(local.provider_settings_by_host, "kvm-host", {})
 }
 
@@ -273,6 +281,7 @@ module "xen-host" {
 
   additional_repos  = lookup(local.additional_repos, "xen-host", {})
   additional_packages = lookup(local.additional_packages, "xen-host", [])
+  additional_grains = lookup(local.additional_grains, "xen-host", {})
   provider_settings = lookup(local.provider_settings_by_host, "xen-host", {})
 }
 

--- a/modules/virthost/main.tf
+++ b/modules/virthost/main.tf
@@ -17,13 +17,13 @@ module "virthost" {
   ssh_key_path              = var.ssh_key_path
   ipv6                      = var.ipv6
   roles                     = ["minion", "virthost"]
-  additional_grains = {
+  additional_grains = merge({
     hvm_disk_image      = var.hvm_disk_image
     hvm_disk_image_hash = var.hvm_disk_image_hash
     xen_disk_image      = var.xen_disk_image
     xen_disk_image_hash = var.xen_disk_image_hash
     hypervisor = var.hypervisor
-  }
+  },var.additional_grains)
 
   image     = var.image
   provider_settings =var.provider_settings

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -104,6 +104,11 @@ variable "image" {
   type        = string
 }
 
+variable "additional_grains" {
+  description = "custom grain string to be added to this minion's configuration"
+  default     = {}
+}
+
 variable "provider_settings" {
   description = "Map of provider-specific settings, see the backend-specific README file"
   default     = {}


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

implementation of: https://github.com/SUSE/spacewalk/issues/16660

Give the possibility to add or overwrite additional grains on the testsuite module.
It only applies to salt minions.

This is needed because we should be able to overwrite the xen/kvm image download location. `vhost` have a property to do it, but in the context os the `cucumber_testsuite` module it cannot be used, since we cannot have a variable be conditionally passed to a module, which would be the scenario when the user didn't provide any different URL on cucumber testsuite configuration

To support this behavior on the virtual host module we would need to get it completely dirty. 

With this implementation we support overwrite this grains and at the same time support any other grains that needs to be changed/added in the future.