### PR TITLE
Revert "do not use updates on "head" to workaround kernel update problems

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -55,7 +55,7 @@ module "server" {
   disable_download_tokens        = false
   forward_registration           = false
   monitored                      = true
-  use_os_released_updates        = var.product_version == "head" ? false : true
+  use_os_released_updates        = true
   install_salt_bundle            = lookup(local.install_salt_bundle, "server", false)
   ssh_key_path                   = "./salt/controller/id_rsa.pub"
   from_email                     = var.from_email
@@ -84,7 +84,7 @@ module "proxy" {
   auto_configure            = false
   generate_bootstrap_script = false
   publish_private_ssl_key   = false
-  use_os_released_updates   = var.product_version == "head" ? false : true
+  use_os_released_updates   = true
   ssh_key_path              = "./salt/controller/id_rsa.pub"
   install_salt_bundle = lookup(local.install_salt_bundle, "proxy", false)
 


### PR DESCRIPTION
This reverts commit 58da0910e325703f15a02b673a56a48c1bf8e56c.

## What does this PR change?

Revert temp change to not apply updates on server and proxy when running the testsuite for "head".
Installing beta kernel caused file conflicts.
We should enable it again when this is fixed.
