### PR TITLE
Salt Bundle: Do not show confusing messages from Zypper while removing normal Salt

### DIFF
--- a/salt/post_provisioning_cleanup.sh
+++ b/salt/post_provisioning_cleanup.sh
@@ -27,11 +27,11 @@ fi
 
 echo "Removing Salt packages, except Salt Bundle (venv-salt-minion) ..."
 if [[ "$INSTALLER" == "zypper" ]]; then
-zypper -q --non-interactive remove salt salt-minion python3-salt python2-salt 2&>1 /dev/null ||:
+zypper -q --non-interactive remove salt salt-minion python3-salt python2-salt 2>&1 /dev/null ||:
 elif [[ "$INSTALLER" == "yum" ]]; then
-yum -y remove salt salt-minion python3-salt python2-salt 2&>1 /dev/null ||:
+yum -y remove salt salt-minion python3-salt python2-salt 2>&1 /dev/null ||:
 elif [[ "$INSTALLER" == "apt" ]]; then
-apt-get --yes purge salt-common 2&>1 /dev/null ||:
+apt-get --yes purge salt-common 2>&1 /dev/null ||:
 fi
 
 echo "Done!"

--- a/salt/post_provisioning_cleanup.sh
+++ b/salt/post_provisioning_cleanup.sh
@@ -27,11 +27,11 @@ fi
 
 echo "Removing Salt packages, except Salt Bundle (venv-salt-minion) ..."
 if [[ "$INSTALLER" == "zypper" ]]; then
-zypper -q --non-interactive remove salt salt-minion python3-salt python2-salt ||:
+zypper -q --non-interactive remove salt salt-minion python3-salt python2-salt 2&>1 /dev/null ||:
 elif [[ "$INSTALLER" == "yum" ]]; then
-yum -y remove salt salt-minion python3-salt python2-salt ||:
+yum -y remove salt salt-minion python3-salt python2-salt 2&>1 /dev/null ||:
 elif [[ "$INSTALLER" == "apt" ]]; then
-apt-get --yes purge salt-common ||:
+apt-get --yes purge salt-common 2&>1 /dev/null ||:
 fi
 
 echo "Done!"


### PR DESCRIPTION
## What does this PR change?

As a final steps for instances with `install_salt_bundle = True`, sumafom performs the execution of a bash script to remove any "salt" package that got installed during sumaform deployment in order to make the instance to only contain `venv-salt-minion` package installed after deployment.

During this cleanup, the messages coming from zypper/yum/apt when removing the packages, particularly in case any python2-salt is not installed, the message error messages shown are confusing, since it seems the deployment fail during the cleanup while it was not the case.

This PR simply hides the raw output from the cleanup and the confusing messages do not appear
