### PR TITLE
Create module for build hosts

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -589,11 +589,33 @@ module "vanilla" {
 ```
 
 
+## Build hosts
+
+Build hosts have more repositories, so they can build Docker container and Kiwi images.
+
+Building Kiwi images is needed for starting PXE boot hosts (see below) in Retail context.
+
+An example follows:
+
+```hcl
+module "build-host"
+{
+  source = "./modules/build_host"
+  base_configuration = module.base.configuration
+
+  name = "buildhost"
+  image = "sles15sp3o"
+}
+```
+
+
 ## PXE boot hosts
 
 PXE boot hosts are unprovisioned hosts that are capable of booting from their networking card. Additionally, they have a hardware type of "Genuine Intel" to make provisioning via SUSE Manager for Retail easier.
 
 "unprovisioned" means that they are completly unprepared: no SSH keys, no initialization at all.
+
+SUSE Manager makes use of PXE booting in two use cases: cobbler, and Retail.
 
 An example follows:
 

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -111,13 +111,13 @@ host_settings = {
   }
   suse-minion = {
   }
-  build-host = {
-  }
   suse-sshminion = {
   }
   redhat-minion = {
   }
   debian-minion = {
+  }
+  build-host = {
   }
   pxeboot-minion = {
   }

--- a/modules/build_host/main.tf
+++ b/modules/build_host/main.tf
@@ -1,0 +1,35 @@
+module "build_host" {
+  source = "../host"
+
+  base_configuration            = var.base_configuration
+  name                          = var.name
+  quantity                      = var.quantity
+  use_os_released_updates       = var.use_os_released_updates
+  use_os_unreleased_updates     = var.use_os_unreleased_updates
+  install_salt_bundle           = var.install_salt_bundle
+  additional_repos              = var.additional_repos
+  additional_packages           = var.additional_packages
+  gpg_keys                      = var.gpg_keys
+  swap_file_size                = var.swap_file_size
+  ssh_key_path                  = var.ssh_key_path
+  ipv6                          = var.ipv6
+  connect_to_base_network       = true
+  connect_to_additional_network = true
+  roles                         = ["build_host"]
+  disable_firewall              = var.disable_firewall
+  grains = {
+    product_version = var.product_version
+    mirror          = var.base_configuration["mirror"]
+    server                 = var.server_configuration["hostname"]
+    auto_connect_to_master = var.auto_connect_to_master
+    avahi_reflector        = var.avahi_reflector
+  }
+
+
+  image             = var.image
+  provider_settings = var.provider_settings
+}
+
+output "configuration" {
+  value = module.build_host.configuration
+}

--- a/modules/build_host/variables.tf
+++ b/modules/build_host/variables.tf
@@ -1,0 +1,110 @@
+variable "base_configuration" {
+  description = "use module.base.configuration, see the main.tf example file"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "product_version" {
+  description = "A valid SUSE Manager version (eg. 4.2-nightly, head) see README_ADVANCED.md"
+  default     = "released"
+}
+
+variable "server_configuration" {
+  description = "use module.<SERVER_NAME>.configuration, see the main.tf example file"
+}
+
+variable "auto_connect_to_master" {
+  description = "whether this minion should automatically connect to the Salt Master upon deployment"
+  default     = true
+}
+
+variable "use_os_released_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise repos"
+  default     = false
+}
+
+variable "use_os_unreleased_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
+  default     = false
+}
+
+variable "avahi_reflector" {
+  description = "if using avahi, let the daemon be a reflector"
+  default     = false
+}
+
+variable "disable_firewall" {
+  description = "whether to disable the built-in firewall, opening up all ports"
+  default     = true
+}
+
+variable "additional_repos" {
+  description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
+  default     = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages to install, see README_ADVANCED.md"
+  default     = []
+}
+
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = false
+}
+
+variable "quantity" {
+  description = "number of hosts like this one"
+  default     = 1
+}
+
+variable "grains" {
+  description = "custom grain map to be added to this host's configuration"
+  default     = {}
+}
+
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default     = 0
+}
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default     = null
+}
+
+variable "gpg_keys" {
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
+  default     = []
+}
+
+variable "ipv6" {
+  description = "IPv6 tuning: enable it, accept the RAs"
+  default = {
+    enable    = true
+    accept_ra = true
+  }
+}
+
+variable "connect_to_base_network" {
+  description = "true if you want a card connected to the main network, see README_ADVANCED.md"
+  default     = true
+}
+
+variable "connect_to_additional_network" {
+  description = "true if you want a card connected to the additional network (if any), see README_ADVANCED.md"
+  default     = false
+}
+
+variable "image" {
+  description = "An image name, e.g. sles11sp4 or opensuse152o"
+  type        = string
+}
+
+variable "provider_settings" {
+  description = "Map of provider-specific settings, see the modules/libvirt/README.md"
+  default     = {}
+}

--- a/modules/build_host/versions.tf
+++ b/modules/build_host/versions.tf
@@ -1,0 +1,1 @@
+../backend/host/versions.tf

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -141,29 +141,6 @@ module "suse-minion" {
   provider_settings = lookup(local.provider_settings_by_host, "suse-minion", {})
 }
 
-module "build-host" {
-  source = "../minion"
-
-  quantity           = contains(local.hosts, "build-host") ? 1 : 0
-  base_configuration = module.base.configuration
-  product_version    = var.product_version
-  image              = lookup(local.images, "build-host", "sles15sp2o")
-  name               = lookup(local.names, "build-host", "min-build")
-
-  server_configuration = local.minimal_configuration
-
-  auto_connect_to_master  = false
-  use_os_released_updates = true
-  ssh_key_path            = "./salt/controller/id_rsa.pub"
-  avahi_reflector         = var.avahi_reflector
-  install_salt_bundle     = lookup(local.install_salt_bundle, "build-host", false)
-
-  additional_repos  = lookup(local.additional_repos, "build-host", {})
-  additional_packages = lookup(local.additional_packages, "build-host", [])
-  additional_grains = lookup(local.additional_grains, "build-host", {})
-  provider_settings = lookup(local.provider_settings_by_host, "build-host", {})
-}
-
 module "suse-sshminion" {
   source = "../sshminion"
 
@@ -195,6 +172,7 @@ module "redhat-minion" {
   name               = lookup(local.names, "redhat-minion", "min-centos7")
 
   server_configuration   = local.minimal_configuration
+
   auto_connect_to_master = false
   ssh_key_path           = "./salt/controller/id_rsa.pub"
   install_salt_bundle    = lookup(local.install_salt_bundle, "redhat-minion", false)
@@ -216,6 +194,7 @@ module "debian-minion" {
   name               = lookup(local.names, "debian-minion", "min-ubuntu2004")
 
   server_configuration   = local.minimal_configuration
+
   auto_connect_to_master = false
   ssh_key_path           = "./salt/controller/id_rsa.pub"
   install_salt_bundle    = lookup(local.install_salt_bundle, "debian-minion", false)
@@ -226,14 +205,36 @@ module "debian-minion" {
   provider_settings = lookup(local.provider_settings_by_host, "debian-minion", {})
 }
 
+module "build-host" {
+  source = "../build_host"
+
+  quantity           = contains(local.hosts, "build-host") ? 1 : 0
+  base_configuration = module.base.configuration
+  product_version    = var.product_version
+  image              = lookup(local.images, "build-host", "sles15sp2o")
+  name               = lookup(local.names, "build-host", "min-build")
+
+  server_configuration = local.minimal_configuration
+
+  auto_connect_to_master  = false
+  use_os_released_updates = true
+  ssh_key_path            = "./salt/controller/id_rsa.pub"
+  avahi_reflector         = var.avahi_reflector
+  install_salt_bundle     = lookup(local.install_salt_bundle, "build-host", false)
+
+  additional_repos  = lookup(local.additional_repos, "build-host", {})
+  additional_packages = lookup(local.additional_packages, "build-host", [])
+  provider_settings = lookup(local.provider_settings_by_host, "build-host", {})
+}
+
 module "pxeboot-minion" {
   source = "../pxe_boot"
 
   quantity = contains(local.hosts, "pxeboot-minion") ? 1 : 0
-
   base_configuration = module.base.configuration
   image              = lookup(local.images, "pxeboot-minion", "sles15sp3o")
   name               = lookup(local.names, "pxeboot-minion", "min-pxeboot")
+
   provider_settings  = lookup(local.provider_settings_by_host, "pxeboot-minion", {})
 }
 
@@ -293,10 +294,10 @@ module "controller" {
   proxy_configuration     = contains(local.hosts, "proxy") ? module.proxy.configuration : { hostname = null }
   client_configuration    = contains(local.hosts, "suse-client") ? module.suse-client.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
   minion_configuration    = contains(local.hosts, "suse-minion") ? module.suse-minion.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
-  buildhost_configuration = contains(local.hosts, "build-host") ? module.build-host.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
   sshminion_configuration = contains(local.hosts, "suse-sshminion") ? module.suse-sshminion.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
   redhat_configuration    = contains(local.hosts, "redhat-minion") ? module.redhat-minion.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
   debian_configuration    = contains(local.hosts, "debian-minion") ? module.debian-minion.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
+  buildhost_configuration = contains(local.hosts, "build-host") ? module.build-host.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
   pxeboot_configuration   = contains(local.hosts, "pxeboot-minion") ? module.pxeboot-minion.configuration : { macaddr = null, image = null }
   kvmhost_configuration   = contains(local.hosts, "kvm-host") ? module.kvm-host.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
   xenhost_configuration   = contains(local.hosts, "xen-host") ? module.xen-host.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
@@ -325,10 +326,10 @@ output "configuration" {
     proxy = module.proxy.configuration
     suse-client = module.suse-client.configuration
     suse-minion = module.suse-minion.configuration
-    build-host = module.build-host.configuration
     suse-sshminion = module.suse-sshminion.configuration
     redhat-minion = module.redhat-minion.configuration
     debian-minion = module.debian-minion.configuration
+    build-host = module.build-host.configuration
     pxeboot-minion = module.pxeboot-minion.configuration
     kvm-host = module.kvm-host.configuration
     xen-host = module.xen-host.configuration

--- a/salt/repos/build_host.sls
+++ b/salt/repos/build_host.sls
@@ -1,0 +1,61 @@
+{% if 'build_host' in grains.get('roles') and grains.get('testsuite') | default(false, true) and grains['osfullname'] == 'SLES' %}
+
+{% if '12' in grains['osrelease'] %}
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/12/x86_64/product/
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/12/x86_64/update/
+
+{% endif %}
+
+{% if '15' in grains['osrelease'] %}
+
+{% if grains['osrelease'] == '15' %}
+{% set sle_version_path = '15' %}
+{% elif grains['osrelease'] == '15.1' %}
+{% set sle_version_path = '15-SP1' %}
+{% elif grains['osrelease'] == '15.2' %}
+{% set sle_version_path = '15-SP2' %}
+{% elif grains['osrelease'] == '15.3' %}
+{% set sle_version_path = '15-SP3' %}
+{% elif grains['osrelease'] == '15.4' %}
+{% set sle_version_path = '15-SP4' %}
+{% endif %}
+
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/{{ sle_version_path }}/x86_64/product/
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/{{ sle_version_path }}/x86_64/update/
+
+devel_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/product/
+
+devel_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/update/
+
+{# The following "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" module #}
+desktop_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/product/
+
+{# The following "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" module #}
+desktop_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
+
+{% endif %}
+
+
+{% endif %}
+
+# WORKAROUND: see github:saltstack/salt#10852
+{{ sls }}_nop:
+  test.nop: []

--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -4,8 +4,9 @@ include:
   - repos.minion
   - repos.proxy
   - repos.server
-  - repos.testsuite
+  - repos.build_host
   - repos.virthost
+  - repos.testsuite
   - repos.tools
   - repos.jenkins
   {% endif %}

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -1,16 +1,5 @@
 {% if 'minion' in grains.get('roles') and grains.get('testsuite') | default(false, true) and grains['osfullname'] == 'SLES' %}
 
-{% if '12' in grains['osrelease'] %}
-containers_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/12/x86_64/product/
-
-containers_updates_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/12/x86_64/update/
-
-{% endif %}
-
 {% if '15' in grains['osrelease'] %}
 
 {% if grains['osrelease'] == '15' %}
@@ -24,32 +13,6 @@ containers_updates_repo:
 {% elif grains['osrelease'] == '15.4' %}
 {% set sle_version_path = '15-SP4' %}
 {% endif %}
-
-containers_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/{{ sle_version_path }}/x86_64/product/
-
-containers_updates_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/{{ sle_version_path }}/x86_64/update/
-
-devel_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/product/
-
-devel_updates_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ sle_version_path }}/x86_64/update/
-
-{# The following "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" module #}
-desktop_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/product/
-
-{# The following "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" module #}
-desktop_updates_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
 
 {% if '4.0-nightly' in grains.get('product_version') %}
 python2_pool_repo:


### PR DESCRIPTION
## What does this PR change?

We don't need container module nor development tools module on normal minions. Worse, these modules are now creating problems during client migration.

Create a module of its own for build hosts.


## Links

Fixes SUSE/spacewalk#16770 .
See also SUSE/susemanager-ci#443