### PR TITLE
virthost: schedule reboot after two minutes to allow cleanup script to finish

### DIFF
--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -131,7 +131,7 @@ rebuild_grub_cfg:
 reboot:
   module.run:
     - name: system.reboot
-    - at_time: +1
+    - at_time: +2
     - onchanges:
         - pkg: no_kernel_default_base
         {% if grains['hypervisor']|lower() == 'xen' %}

--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -137,3 +137,4 @@ reboot:
         {% if grains['hypervisor']|lower() == 'xen' %}
         - cmd: rebuild_grub_cfg
         {% endif %}
+    - order: last


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue that we have seen already happening in some of our deployments where "virthost" is involved.

One of the latest steps during configuration of the instance is to schedule a reboot of the system:

https://github.com/uyuni-project/sumaform/blob/master/salt/virthost/init.sls#L131-L139

Then sometime it happens that the `post_provisioning_cleanup.sh` cleanup script is running while the reboot is done, so terraform raises an error:

```
01:50:34  │ Error: remote-exec provisioner error
01:50:34  │ 
01:50:34  │   with module.kvm-minion.module.virthost.module.minion.module.host.null_resource.provisioning[0],
01:50:34  │   on /home/jenkins/jenkins-build/workspace/uyuni-master-infra-reference-NUE/results/sumaform/backend_modules/libvirt/host/main.tf line 239, in resource "null_resource" "provisioning":
01:50:34  │  239:   provisioner "remote-exec" {
01:50:34  │ 
01:50:34  │ error executing "/tmp/terraform_1599922263.sh": wait: remote command exited
01:50:34  │ without exit status or exit signal
```