### PR TITLE
Fix miscontructed piping for stdout and stderr

### DIFF
--- a/salt/post_provisioning_cleanup.sh
+++ b/salt/post_provisioning_cleanup.sh
@@ -27,11 +27,11 @@ fi
 
 echo "Removing Salt packages, except Salt Bundle (venv-salt-minion) ..."
 if [[ "$INSTALLER" == "zypper" ]]; then
-zypper -q --non-interactive remove salt salt-minion python3-salt python2-salt 2>&1 /dev/null ||:
+zypper -q --non-interactive remove salt salt-minion python3-salt python2-salt > /dev/null 2>&1 ||:
 elif [[ "$INSTALLER" == "yum" ]]; then
-yum -y remove salt salt-minion python3-salt python2-salt 2>&1 /dev/null ||:
+yum -y remove salt salt-minion python3-salt python2-salt > /dev/null 2>&1 ||:
 elif [[ "$INSTALLER" == "apt" ]]; then
-apt-get --yes purge salt-common 2>&1 /dev/null ||:
+apt-get --yes purge salt-common > /dev/null 2>&1 ||:
 fi
 
 echo "Done!"


### PR DESCRIPTION
## What does this PR change?

Fix miscontructed pipes to `/dev/null`. The current issue is not making the deployments to fail but it does not work as expected.