### PR TITLE
Not add moving target repos in 4.3-beta for server and proxy

### DIFF
--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -106,13 +106,13 @@ proxy_module_pool_repo:
 proxy_module_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Proxy/4.3/x86_64/update/
-{% endif %}
 
 # WORKAROUND: Moving target, only until SLE15SP4 GA is ready. Remove this block when we start using GA.
 os_movingtarget_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP4:/GA:/TEST/images/repo/SLE-15-SP4-Module-Server-Applications-POOL-x86_64-Media1/
 # WORKAROUND: Moving target, only until SLE15SP4 GA is ready
+{% endif %}
 
 module_server_applications_pool_repo:
   pkgrepo.managed:

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -154,13 +154,19 @@ server_module_pool_repo:
 server_module_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Server/4.3/x86_64/update/
-{% endif %}
 
 # WORKAROUND: Moving target, only until SLE15SP4 GA is ready. Remove this block when we start using GA.
 os_movingtarget_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP4:/GA:/TEST/images/repo/SLE-15-SP4-Module-Server-Applications-POOL-x86_64-Media1/
 # WORKAROUND: Moving target, only until SLE15SP4 GA is ready
+
+# WORKAROUND: Moving target, only until SLE15SP4 GA is ready. Remove this block when we start using GA.
+web_scripting_os_movingtarget_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP4:/GA:/TEST/images/repo/SLE-15-SP4-Module-Web-Scripting-POOL-x86_64-Media1/
+# WORKAROUND: Moving target, only until SLE15SP4 GA is ready
+{% endif %}
 
 module_server_applications_pool_repo:
   pkgrepo.managed:
@@ -169,12 +175,6 @@ module_server_applications_pool_repo:
 module_server_applications_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP4/x86_64/update/
-
-# WORKAROUND: Moving target, only until SLE15SP4 GA is ready. Remove this block when we start using GA.
-os_movingtarget_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP4:/GA:/TEST/images/repo/SLE-15-SP4-Module-Web-Scripting-POOL-x86_64-Media1/
-# WORKAROUND: Moving target, only until SLE15SP4 GA is ready
 
 module_web_scripting_pool_repo:
   pkgrepo.managed:


### PR DESCRIPTION
## What does this PR change?

Trying to deploy server and proxy using product version 4.3-beta, I have two issues:

1)
```
[1mmodule.proxy.module.proxy.module.host.null_resource.provisioning[0] (remote-exec):[0m [0m    Detected conflicting IDs, SLS IDs need to be globally unique.
```
Fixing this by renaming the salt state.

2)
```
[1mmodule.server.module.server.module.host.null_resource.provisioning[0] (remote-exec):[0m [0m    Rendering SLS 'base:repos.server' failed: while constructing a mapping
[1mmodule.server.module.server.module.host.null_resource.provisioning[0] (remote-exec):[0m [0m  in "<unicode string>", line 10, column 1:
[1mmodule.server.module.server.module.host.null_resource.provisioning[0] (remote-exec):[0m [0m    server_product_pool_repo:
[1mmodule.server.module.server.module.host.null_resource.provisioning[0] (remote-exec):[0m [0m    ^
[1mmodule.server.module.server.module.host.null_resource.provisioning[0] (remote-exec):[0m [0mfound conflicting ID 'os_movingtarget_repo'
``` 
Fixing this by moving the movingtarget repos from a general statement in 4.3, to only available if we are not in beta.