### PR TITLE
Do not run update-ca-certificates on SLE15

### DIFF
--- a/salt/build_host/init.sls
+++ b/salt/build_host/init.sls
@@ -4,8 +4,13 @@ certificate_authority_certificate:
     - source: salt://build_host/certs/ca.cert.pem
     - makedirs: True
 
+{# Do not run update-ca-certificates on SLE15 because there is a#}
+{# systemd unit that watches for changes and runs it already: #}
+{#   /usr/lib/systemd/system/ca-certificates.path #}
+{% if '15' not in grains['osrelease'] %}
 update_ca_truststore_registry_build_host:
   cmd.run:
     - name: /usr/sbin/update-ca-certificates
     - onchanges:
       - file: certificate_authority_certificate
+{% endif %}


### PR DESCRIPTION
## What does this PR change?

because there is a systemd unit that watches for changes and runs it
already:
   /usr/lib/systemd/system/ca-certificates.path

If we try to run it, it fails with an error because it runs twice
at the same time.


