### PR TITLE
Add SLE Micro 5.1 support

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -34,7 +34,7 @@ locals {
     opensuse152-ci-pr        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse152-ci-pr.x86_64.qcow2"
     opensuse153-ci-pr        = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse153-ci-pr.x86_64.qcow2"
     opensuse153-ci-pr-client = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse153-ci-pr-client.x86_64.qcow2"
-    slemicro51o     = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_51/SUSE-MicroOS.x86_64-sumaform.qcow2"
+    slemicro51-ign  = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_51/SUSE-MicroOS.x86_64-sumaform.qcow2"
   }
   pool               = lookup(var.provider_settings, "pool", "default")
   network_name       = lookup(var.provider_settings, "network_name", "default")

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -34,6 +34,7 @@ locals {
     opensuse152-ci-pr        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse152-ci-pr.x86_64.qcow2"
     opensuse153-ci-pr        = "http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse153-ci-pr.x86_64.qcow2"
     opensuse153-ci-pr-client = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse153-ci-pr-client.x86_64.qcow2"
+    slemicro51o     = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_51/SUSE-MicroOS.x86_64-sumaform.qcow2"
   }
   pool               = lookup(var.provider_settings, "pool", "default")
   network_name       = lookup(var.provider_settings, "network_name", "default")

--- a/backend_modules/libvirt/host/config.ign
+++ b/backend_modules/libvirt/host/config.ign
@@ -1,0 +1,11 @@
+{
+  "ignition": { "version": "3.1.0" },
+  "passwd": {
+    "users": [
+      {
+        "name": "root",
+        "passwordHash": "ZIy6Ivgw8UdAs"
+      }
+    ]
+  }
+}

--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -5,7 +5,7 @@
 
 FILE_ROOT="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
-salt-call --local --file-root=$FILE_ROOT/ --log-level=quiet --output=quiet state.sls default.minimal ||:
+salt-call --local --file-root=$FILE_ROOT/ --module-executors='[direct_call]' --log-level=quiet --output=quiet state.sls default.minimal ||:
 
 NEXT_TRY=0
 until [ $NEXT_TRY -eq 10 ] || salt-call --local test.ping
@@ -20,6 +20,6 @@ then
         echo "ERROR: salt-call is not available after 10 retries";
 fi
 
-salt-call --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color state.highstate || exit 1
+salt-call --local --file-root=$FILE_ROOT/ --module-executors='[direct_call]' --log-level=info --retcode-passthrough --force-color state.highstate || exit 1
 
 chmod +x ${FILE_ROOT}/highstate.sh

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -620,7 +620,7 @@ tools_update_repo:
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS-BETA/x86_64/update/' %}
 {% elif 'released' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
-# We only have one shared Client Tools repository, so we are using 4.2 for 4.1 and 4.0
+# We only have one shared Client Tools repository, so we are using 4.2 for 4.1
 {% elif 'nightly' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.2:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
@@ -656,17 +656,6 @@ tools_update_repo_raised_priority:
             Pin: release l=Devel:Galaxy:Manager:4.2:Ubuntu{{ release }}-SUSE-Manager-Tools
             Pin-Priority: 800
 {% elif '4.1-released' in grains.get('product_version') | default('', true) %}
-    - contents: |
-            Package: *
-            Pin: release l=SUSE:Updates:Ubuntu:{{ release }}-CLIENT-TOOLS:x86_64:update
-            Pin-Priority: 800
-# We only have one shared Client Tools repository, so we are using 4.1 even for 4.0
-{% elif '4.0-nightly' in grains.get('product_version') | default('', true) %}
-    - contents: |
-            Package: *
-            Pin: release l=Devel:Galaxy:Manager:4.2:Ubuntu{{ release }}-SUSE-Manager-Tools
-            Pin-Priority: 800
-{% elif '4.0-released' in grains.get('product_version') | default('', true) %}
     - contents: |
             Package: *
             Pin: release l=SUSE:Updates:Ubuntu:{{ release }}-CLIENT-TOOLS:x86_64:update

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -14,18 +14,6 @@
 {% set sle_version_path = '15-SP4' %}
 {% endif %}
 
-{% if '4.0-nightly' in grains.get('product_version') %}
-python2_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/{{ sle_version_path }}/x86_64/product/
-    - refresh: True
-
-python2_updates_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/{{ sle_version_path }}/x86_64/update/
-    - refresh: True
-{% endif %}
-
 {% endif %}
 
 

--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -1,37 +1,5 @@
 {% if 'proxy' in grains.get('roles') %}
 
-{% if '4.0' in grains['product_version'] and not grains.get('proxy_registration_code') %}
-proxy_product_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Proxy/4.0/x86_64/product/
-    - refresh: True
-
-proxy_product_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Proxy/4.0/x86_64/update/
-    - refresh: True
-
-proxy_module_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Proxy/4.0/x86_64/product/
-    - refresh: True
-
-proxy_module_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Proxy/4.0/x86_64/update/
-    - refresh: True
-
-module_server_applications_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/
-    - refresh: True
-
-module_server_applications_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/
-    - refresh: True
-{% endif %}
-
 {% if '4.1' in grains['product_version'] and not grains.get('proxy_registration_code')%}
 proxy_product_pool_repo:
   pkgrepo.managed:
@@ -215,20 +183,6 @@ module_server_applications_update_repo:
     - refresh: True
 
 {% endif %}
-{% endif %}
-
-{% if '4.0-nightly' in grains['product_version'] %}
-server_devel_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0/images/repo/SLE-Module-SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1/
-    - refresh: True
-    - priority: 96
-
-server_devel_releasenotes_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/ToSLE/SLE_15_SP1/
-    - refresh: True
-    - priority: 96
 {% endif %}
 
 {% if '4.1-nightly' in grains['product_version'] %}

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -1,57 +1,5 @@
 {% if 'server' in grains.get('roles') %}
 
-{% if '4.0' in grains['product_version'] and not grains.get('server_registration_code') %}
-server_product_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.0/x86_64/product/
-    - refresh: True
-
-server_product_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Server/4.0/x86_64/update/
-    - refresh: True
-
-server_module_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Server/4.0/x86_64/product/
-    - refresh: True
-
-server_module_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Server/4.0/x86_64/update/
-    - refresh: True
-
-module_server_applications_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/
-    - refresh: True
-
-module_server_applications_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP1/x86_64/update/
-    - refresh: True
-
-module_web_scripting_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product/
-    - refresh: True
-
-module_web_scripting_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Web-Scripting/15-SP1/x86_64/update/
-    - refresh: True
-
-module_python2_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/
-    - refresh: True
-
-module_python2_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP1/x86_64/update/
-    - refresh: True
-{% endif %}
-
 {% if '4.1' in grains['product_version'] and not grains.get('server_registration_code') %}
 server_product_pool_repo:
   pkgrepo.managed:
@@ -308,20 +256,6 @@ module_web_scripting_update_repo:
     - refresh: True
 
 {% endif %}
-{% endif %}
-
-{% if '4.0-nightly' in grains['product_version'] %}
-server_devel_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0/SLE_15_SP1/
-    - refresh: True
-    - priority: 96
-
-server_devel_releasenotes_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.0:/ToSLE/SLE_15_SP1/
-    - refresh: True
-    - priority: 96
 {% endif %}
 
 {% if '4.1-nightly' in grains['product_version'] %}


### PR DESCRIPTION
## What does this PR change?

Adds link for SLE Micro 5.1 build at [sumaform:images:microos project](https://build.opensuse.org/project/show/systemsmanagement:sumaform:images:microos)

MicroOS, being a transactional system, requires salt to skip creating new snapshots. Added `direct_call` module executor ensures that.
