### PR TITLE
change pg_hba.conf when external connections should not be allowed

### DIFF
--- a/salt/server/postgres.sls
+++ b/salt/server/postgres.sls
@@ -18,20 +18,26 @@ postgresql_main_configuration:
     - require:
       - sls: server
 
+{% if grains.get('allow_postgres_connections') %}
 postgresql_hba_configuration:
   file.append:
     - name: /var/lib/pgsql/data/pg_hba.conf
     - text: |
+{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-released', '4.3-beta'] %}
+        host    all     all       0.0.0.0/0      scram-sha-256
+        host    all     all       ::/0           scram-sha-256
+{%- else %}
         host    all     all       0.0.0.0/0      md5
         host    all     all       ::/0           md5
+{%- endif %}
     - require:
       - sls: server
+{% endif %}
 
 postgresql:
   service.running:
     - watch:
       - file: postgresql_main_configuration
+{% if grains.get('allow_postgres_connections') %}
       - file: postgresql_hba_configuration
-    - require:
-      - file: postgresql_main_configuration
-      - file: postgresql_hba_configuration
+{% endif %}


### PR DESCRIPTION
## What does this PR change?

When external connections to the postgresql DB should no be allowed, do not configure pg_hba.conf to do so.
