### PR TITLE
add minion role to build host machine

### DIFF
--- a/modules/build_host/main.tf
+++ b/modules/build_host/main.tf
@@ -16,7 +16,7 @@ module "build_host" {
   ipv6                          = var.ipv6
   connect_to_base_network       = true
   connect_to_additional_network = true
-  roles                         = ["build_host"]
+  roles                         = ["build_host", "minion"]
   disable_firewall              = var.disable_firewall
   grains = {
     product_version = var.product_version


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

The new module build host module was a spin-off from the minion module. 
I think we should also add the minion role to allow, for example, auto-register the machine to the suse manager server.
Cucumber testsuite module disable the auto registration, so I'm expecting the same behaviour we already have on the CI.
