### PR TITLE
Set custom "mgr_force_venv_salt_minion" pillar also for head and 4.3

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -77,13 +77,13 @@ testsuite_salt_packages:
     - require:
       - sls: repos
 
-
-{% if 'uyuni' in grains.get('product_version') | default('', true) %}
+{% set products_to_use_salt_bundle = ["uyuni", "head", "4.3-released", "4.3-nightly"] %}
+{% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,
 # in cases where the "venv-salt-minion" is not available in the bootstrap repository.
 # Once bootstrap repository contains the venv-salt-minion before running bootstrap
-# then these staes can be removed
+# then these states can be removed
 
 create_pillar_top_sls_to_assign_salt_bundle_config:
   file.managed:


### PR DESCRIPTION
## What does this PR change?

This PR prepares testsuite deployments to force the usage of Salt bundle during bootstrapping not only for Uyuni but also for SUSE Manager 4.3 and Head versions.

I'm currently testing this PR together with some other changes in the testsuite in our internal TEST enviroment.

Please, do not merge this PR yet. I'll take care of merging this once it is the time for this.