### PR TITLE
Reboot always after setting virthost to enable br0

### DIFF
--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -132,9 +132,4 @@ reboot:
   module.run:
     - name: system.reboot
     - at_time: +2
-    - onchanges:
-        - pkg: no_kernel_default_base
-        {% if grains['hypervisor']|lower() == 'xen' %}
-        - cmd: rebuild_grub_cfg
-        {% endif %}
     - order: last


### PR DESCRIPTION
## What does this PR change?

We are setting br0 but we are not activating this.
We need to restart the network, but I don't want to do this and loose
the connectivity when salt is setting up configurations.
I think the safest thing is just to force the reboot always, to activate
this network configuration.

