### PR TITLE
Fix issue with renamed "prometheus-postgres_exporter" package

### DIFF
--- a/salt/server/prometheus.sls
+++ b/salt/server/prometheus.sls
@@ -19,6 +19,7 @@ node_exporter_service:
 postgres_exporter:
   pkg.installed:
     - name: golang-github-wrouesnel-postgres_exporter
+    - resolve_capabilities: True
     - require:
       - sls: repos
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue caused by the rename of `golang-github-wrouesnel-postgres_exporter` package to the new name `prometheus-postgres_exporter`:

```
 ----------
           ID: postgres_exporter
     Function: pkg.installed
         Name: golang-github-wrouesnel-postgres_exporter
       Result: False
      Comment: An error was encountered while installing package(s): Zypper command failure: Running scope as unit: run-r26d6462004e94715bc8379823f80b52e.scope
               Package 'golang-github-wrouesnel-postgres_exporter' not found.
      Started: 10:56:02.685046
     Duration: 775.988 ms
      Changes:
```

The new `prometheus-postgres_exporter` package does provides `golang-github-wrouesnel-postgres_exporter`.

This PR changes the state to resolve the "provides" when looking the package to install.