### PR TITLE
Fix prometheus-postgres_exporter name

### DIFF
--- a/salt/server/prometheus.sls
+++ b/salt/server/prometheus.sls
@@ -18,7 +18,7 @@ node_exporter_service:
 
 postgres_exporter:
   pkg.installed:
-    - name: golang-github-wrouesnel-postgres_exporter
+    - name: prometheus-postgres_exporter
     - require:
       - sls: repos
 


### PR DESCRIPTION

## What does this PR change?
golang-github-wrouesnel-postgres_exporter was renamed to
prometheus-postgres_exporter