### PR TITLE
docs: Several (Markdown) fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ SUSE Linux Enterprise images are built and tracked in [SUSE's internal OBS insta
 
 Access is limited to SUSE employees at this time.
 
-Please note that all of the above projects have the build flag disabled unless some change is ongoing to prevent spontaneous rebuilds. Please click on *Repositories*-> *Build Flag*-> hover the gear icon in the top-left corner of the table (*All*, *All*)-> *Enable* until all images are rebuilt.
+Please note that all of the above projects have the build flag disabled unless some change is ongoing to prevent spontaneous rebuilds. Please click on *Repositories* -> *Build Flag* -> hover the gear icon in the top-left corner of the table (*All*, *All*) -> *Enable* until all images are rebuilt.
 
 Non-SUSE images are built and tracked in the [sumaform-images](https://github.com/moio/sumaform-images) GitHub project. [Pull Requests](https://help.github.com/articles/about-pull-requests/) can be created with a free account, write access is given to meritable community members.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ sumaform requires a specific Terraform version and provides several special-purp
 #### Terraform and terraform-provider libvirt upgrade instructions
 
 Terraform:
+
 ```bash
 osc checkout systemsmanagement:sumaform
 osc up systemsmanagement:sumaform
@@ -45,6 +46,7 @@ osc commit
 ```
 
 terraform-provider-libvirt:
+
 ```bash
 osc checkout systemsmanagement:sumaform
 osc up systemsmanagement:sumaform

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,25 +3,28 @@
 ### Base OS images
 
 openSUSE images are built and tracked in the [Open Build Service](https://build.opensuse.org/):
- - [libvirt project](https://build.opensuse.org/project/show/systemsmanagement:sumaform:images:libvirt)
+
+- [libvirt project](https://build.opensuse.org/project/show/systemsmanagement:sumaform:images:libvirt)
 
 [Submit Requests](https://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.request_and_review_ystem.html) can be created with a free account, project maintainership is given to meritable community members.
 
 SUSE Linux Enterprise images are built and tracked in [SUSE's internal OBS instance](https://build.suse.de/project/show/Devel:Galaxy:Terraform:Images):
- - [libvirt project](https://build.suse.de/project/show/Devel:Galaxy:Terraform:Images)
- - [AWS project](https://build.suse.de/project/show/Devel:Galaxy:Terraform:Images:AmazonEC2)
+
+- [libvirt project](https://build.suse.de/project/show/Devel:Galaxy:Terraform:Images)
+- [AWS project](https://build.suse.de/project/show/Devel:Galaxy:Terraform:Images:AmazonEC2)
 
 Access is limited to SUSE employees at this time.
 
-Please note that all of the above projects have the build flag disabled unless some change is ongoing to prevent spontaneous rebuilds. Please click on *Repositories* -> *Build Flag* -> hover the gear icon in the top-left corner of the table (*All*, *All*) -> *Enable* until all images are rebuilt.
+Please note that all of the above projects have the build flag disabled unless some change is ongoing to prevent spontaneous rebuilds. Please click on *Repositories*-> *Build Flag*-> hover the gear icon in the top-left corner of the table (*All*, *All*)-> *Enable* until all images are rebuilt.
 
 Non-SUSE images are built and tracked in the [sumaform-images](https://github.com/moio/sumaform-images) GitHub project. [Pull Requests](https://help.github.com/articles/about-pull-requests/) can be created with a free account, write access is given to meritable community members.
 
 ### Software Packages
 
 sumaform requires a specific Terraform version and provides several special-purpose RPM packages as well. Those are built and tracked inthe [Open Build Service](https://build.opensuse.org/):
- - the [systemsmanagement:sumaform](https://build.opensuse.org/project/show/systemsmanagement:sumaform) project builds `terraform` and `terraform-provider-libvirt` with some dependencies
- - the [systemsmanagement:sumaform:tools](https://build.opensuse.org/project/show/systemsmanagement:sumaform:tools) project builds other software meant to be installed in sumaformed machines
+
+- the [systemsmanagement:sumaform](https://build.opensuse.org/project/show/systemsmanagement:sumaform) project builds `terraform` and `terraform-provider-libvirt` with some dependencies
+- the [systemsmanagement:sumaform:tools](https://build.opensuse.org/project/show/systemsmanagement:sumaform:tools) project builds other software meant to be installed in sumaformed machines
 
 [Submit Requests](https://openbuildservice.org/help/manuals/obs-reference-guide/cha.obs.request_and_review_ystem.html) can be created with a free account, project maintainership is given to meritable community members.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,11 +1,13 @@
 # Design of sumaform
 
 ## Goal
+
 Automating deployment and configuration of virtualized SUSE Manager installations for testing, debugging and development.
 
 Security is explicitly not a goal, convenience is.
 
 ## Idea
+
 sumaform is:
 
 - [Terraform](https://www.terraform.io/) modules of two types:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,12 +7,13 @@ Security is explicitly not a goal, convenience is.
 
 ## Idea
 sumaform is:
- * [Terraform](https://www.terraform.io/) modules of two types:
-   * "backend" modules, provider-specific. Those define basic infrastructure components such as hosts and disks
-   * "backend-independent" modules (logical components like `suse_manager` or `minion`), that do not vary depending on the chosen backend
- * `cloud-init` configuration files (for OSs which have an official disk image on supported providers)
- * base disk images: bare-bones OSs to bootstrap VMs (for OSs which do not have an official disk image, or for historical reasons)
- * [Salt](https://saltstack.com/) states: they define all software configuration on top of bare-bones OSs: SUSE Manager servers, clients, proxies, etc.
+
+- [Terraform](https://www.terraform.io/) modules of two types:
+  - "backend" modules, provider-specific. Those define basic infrastructure components such as hosts and disks
+  - "backend-independent" modules (logical components like `suse_manager` or `minion`), that do not vary depending on the chosen backend
+- `cloud-init` configuration files (for OSs which have an official disk image on supported providers)
+- base disk images: bare-bones OSs to bootstrap VMs (for OSs which do not have an official disk image, or for historical reasons)
+- [Salt](https://saltstack.com/) states: they define all software configuration on top of bare-bones OSs: SUSE Manager servers, clients, proxies, etc.
 
 Intent is to keep those three components well separated in their purpose.
 
@@ -27,10 +28,11 @@ It is expected all newly supported OSs to make use of "official" images, thus ba
 ## Requirements for base disk images
 
 Basic Virtual Machine images must:
- - have a `root` user in `root` group and password `linux`
- - expect a network interface and assume its addreess is provided via DHCP
- - contain an SSH server listening on port 22, allow plain password authentication
- - contain `salt-minion` or an equivalent package
- - contain any other package needed for the target virtualization infrastructure (eg. `qemu-ga` or equivalent package for libvirt)
- - be immutable (not need to be upgraded). Ideally, they should be based on the initial release repo of the target OS (ie. without any updates). Upgrades will be taken care of by Salt states when needed, at the needed version
- - be as minimal as possible, ideally [JeOS](https://www.suse.com/products/server/jeos)
+
+- have a `root` user in `root` group and password `linux`
+- expect a network interface and assume its address is provided via DHCP
+- contain an SSH server listening on port 22, allow plain password authentication
+- contain `salt-minion` or an equivalent package
+- contain any other package needed for the target virtualization infrastructure (eg. `qemu-ga` or equivalent package for libvirt)
+- be immutable (not need to be upgraded). Ideally, they should be based on the initial release repo of the target OS (ie. without any updates). Upgrades will be taken care of by Salt states when needed, at the needed version
+- be as minimal as possible, ideally [JeOS](https://www.suse.com/products/server/jeos)

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ You will need to edit HCL ([HashiCorp Configuration Language](https://github.com
 - null backend
 
 The simplest, recommended setup is to use libvirt on your local host. That needs at least 8 GB of RAM in your machine.
-If you need a lot of VMs or lack hardware you probably want using an external libvirt host with bridged networking is also possible.
+If you need a lot of VMs or lack hardware you probably want to use an external libvirt host with bridged networking.
 
-The Amazon Web Services backend is currently under maintainance and is not immediately usable as-is. We plan to restore it soon.
+The Amazon Web Services backend is currently under maintenance and is not immediately usable as-is. We plan to restore it soon.
 
 The null backend can be useful in a wide variety of scenarios, for example:
 
@@ -65,6 +65,7 @@ The null backend can be useful in a wide variety of scenarios, for example:
 
 In `sumaform` you define a set of virtual machines in a `main.tf` configuration file, then run Terraform to have them deployed. Contents of the file vary slightly depending on the backend you choose.
 
+To choose the backend in use one should create a symbolic link to a `backend_module` module. Refer to the specific READMEs to get started:
 
 - [libvirt README](backend_modules/libvirt/README.md)
 - [AWS README](backend_modules/aws/README.md)

--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ You will need to edit HCL ([HashiCorp Configuration Language](https://github.com
 ## Backend choice
 
 `sumaform` can deploy virtual machines to:
- - single libvirt hosts
- - Amazon Web Services
- - null backend
+
+- single libvirt hosts
+- Amazon Web Services
+- null backend
 
 The simplest, recommended setup is to use libvirt on your local host. That needs at least 8 GB of RAM in your machine.
 If you need a lot of VMs or lack hardware you probably want using an external libvirt host with bridged networking is also possible.
@@ -54,20 +55,21 @@ If you need a lot of VMs or lack hardware you probably want using an external li
 The Amazon Web Services backend is currently under maintainance and is not immediately usable as-is. We plan to restore it soon.
 
 The null backend can be useful in a wide variety of scenarios, for example:
- - Test configurations before going live in another supported backend
- - Cases in which the virtual infrastructure is outside of the Terraform user's control
- - Cover architectures that will maybe never be covered by any other Terraform plugin
+
+- Test configurations before going live in another supported backend
+- Cases in which the virtual infrastructure is outside of the Terraform user's control
+- Cover architectures that will maybe never be covered by any other Terraform plugin
 
 ## Basic `main.tf` configuration
 
 In `sumaform` you define a set of virtual machines in a `main.tf` configuration file, then run Terraform to have them deployed. Contents of the file vary slightly depending on the backend you choose.
 
-To choose the backend in use one should create a symbolic link to a `backend_module` module. Refer to specific READMEs to get started:
- * [libvirt README](backend_modules/libvirt/README.md)
- * [AWS README](backend_modules/aws/README.md)
- * [AZURE README](backend_modules/azure/README.md)
- * [SSH README](backend_modules/ssh/README.md)
- * [NULL README](backend_modules/null/README.md)
+
+- [libvirt README](backend_modules/libvirt/README.md)
+- [AWS README](backend_modules/aws/README.md)
+- [AZURE README](backend_modules/azure/README.md)
+- [SSH README](backend_modules/ssh/README.md)
+- [NULL README](backend_modules/null/README.md)
 
 ## Typical use
 
@@ -82,8 +84,8 @@ terraform apply # prepare and apply a plan to create your systems (after manual 
 
 ## Advanced use
 
- - To run the Cucumber testsuite for Uyuni or SUSE Manager, see [README_TESTING.md](README_TESTING.md)
- - For any other use, please see [README_ADVANCED.md](README_ADVANCED.md)
+- To run the Cucumber testsuite for Uyuni or SUSE Manager, see [README_TESTING.md](README_TESTING.md)
+- For any other use, please see [README_ADVANCED.md](README_ADVANCED.md)
 
 ### I have a problem!
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Travis CI build status](https://travis-ci.org/uyuni-project/sumaform.svg?branch=master)](https://travis-ci.org/uyuni-project/sumaform)
 [![Join the chat at https://gitter.im/sumaform/Lobby](https://badges.gitter.im/sumaform/Lobby.svg)](https://gitter.im/sumaform/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-
 ## Installation
 
 **Terraform version**: 1.0.10

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ For a very quick start:
 ```bash
 vim main.tf     # change your VM setup
 terraform init  # populate modules
+terraform validate # check if the configuration is valid
 terraform apply # prepare and apply a plan to create your systems (after manual confirmation)
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,6 @@ terraform apply # prepare and apply a plan to create your systems (after manual 
 - To run the Cucumber testsuite for Uyuni or SUSE Manager, see [README_TESTING.md](README_TESTING.md)
 - For any other use, please see [README_ADVANCED.md](README_ADVANCED.md)
 
-### I have a problem!
+## I have a problem!
 
 Check [TROUBLESHOOTING.md](TROUBLESHOOTING.md) first, if that does not help feel free to [join the Gitter chat](https://gitter.im/sumaform/Lobby) or directly drop a line to moio at suse dot de!

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 **Libvirt provider version**: 0.6.3
 
 openSUSE and SUSE Linux Enterprise Server:
-```
+
+```bash
 # Uncomment one of the following lines depending on your distro
 
 #sudo zypper addrepo http://download.opensuse.org/repositories/systemsmanagement:/sumaform/openSUSE_Tumbleweed/systemsmanagement:sumaform.repo
@@ -27,7 +28,8 @@ git clone https://github.com/uyuni-project/sumaform.git
 ```
 
 Ubuntu and Debian:
-```
+
+```bash
 sudo apt install alien
 wget http://download.opensuse.org/repositories/systemsmanagement:/sumaform/SLE_15_SP1/x86_64/terraform.rpm
 sudo alien -i terraform.rpm
@@ -75,7 +77,8 @@ In `sumaform` you define a set of virtual machines in a `main.tf` configuration 
 Refer to the [official guides](https://www.terraform.io/docs/index.html) for a general understanding of Terraform and full commands.
 
 For a very quick start:
-```
+
+```bash
 vim main.tf     # change your VM setup
 terraform init  # populate modules
 terraform apply # prepare and apply a plan to create your systems (after manual confirmation)

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -879,7 +879,7 @@ module "server" {
 }
 ```
 
-# Debugging facilities
+## Debugging facilities
 
 The `server` module has options to automatically capture more diagnostic information, off by default:
 

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -705,7 +705,7 @@ module "grafana" {
 }
 ```
 
-Grafana is accessible at http://grafana.tf.local with username and password `admin`.
+Grafana is accessible at [http://grafana.tf.local](http://grafana.tf.local) with username and password `admin`.
 
 Please note for the Java probes to work the `java_debugging` setting has to be enabled in the `server` module (it is by default).
 
@@ -737,7 +737,7 @@ It is also possible to set up a delay on the response time of the replicas. By d
 - `2.0` makes `evil-minion` react twice as slow as the original minion
 - `0.5` makes `evil-minion` react twice as fast as the original minion
 
-For more information, visit the `evil-minions` project page at https://github.com/moio/evil-minions/ .
+For more information, visit the `evil-minions` project page at [here](https://github.com/moio/evil-minions).
 
 A libvirt example follows:
 

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -95,6 +95,7 @@ The following steps need to be performed:
 - Adapt the `main.tf` file to the new provider specific properties
 - remove folder `.terraform`
 - Create a new backend symbolic link to point to the new backend. From the `modules` folder run:
+
 ln -sfn ../backend_modules/<BACKEND> modules/backend
 ```
 
@@ -147,7 +148,6 @@ module "jenkins" {
 
 Usually you will want to use this on public clouds, but if you want to use this in libvirt, you are encouraged to use a separate pool, as explained for the mirror below.
 
-
 ## Mirror
 
 If you are using `sumaform` outside of the SUSE Nuremberg network you should use a special extra virtual machine named `mirror` that will cache packages downloaded from the SUSE engineering network for faster access and lower bandwidth consumption.
@@ -155,6 +155,7 @@ If you are using `sumaform` outside of the SUSE Nuremberg network you should use
 It will be be used exclusively by other VMs to download SUSE content - that means your SUSE Manager servers, clients, minions and proxies will be "fully disconnected", not requiring Internet access to operate.
 
 To enable `mirror`, add `mirror = "mirror.tf.local"` to the `base` section in `main.tf` and add the following module definition:
+
 ```hcl
 module "mirror" {
   source = "./modules/mirror"
@@ -186,12 +187,10 @@ module "mirror" {
 
 Note that `mirror` must be populated before any host can be deployed. By default, its cache is refreshed nightly via `cron`, as configured in `/etc/cron.daily`. You can also schedule a one-time refresh by running manually some of the scripts that reside in `/usr/local/bin` directory.
 
-
 ## Mirror only for Server (products synchronization)
 
 In addition to the parameter `mirror`, which will wrap this case, you might only want to setup a mirror for server products syncronization, but not for the repositories used by sumaform during the deployment of your environment.
 For that use case, instead of `mirror` use `server_mounted_mirror` parameter inside the server module definition.
-
 
 ## Virtual hosts
 
@@ -346,7 +345,6 @@ At deploy time the `spacewalk-clone-by-date` will be used for each channel set. 
 
 Activation keys are also automatically created for each clone with the name `1-<CLONE_PREFIX>`.
 
-
 ## Shared resources, prefixing, sharing virtual hardware
 
 Whenever multiple sumaform users deploy to the same virtualization hardware (eg. libvirt host) it is recommended to set the `name_prefix` variable in the `base` module in order to have a unique per-user prefix for all resource names. This will prevent conflicting names.
@@ -424,7 +422,6 @@ When there is only one connection, the card is always `eth0`, no matter to which
 
 Some modules have preset defaults: SUSE Manager/Uyuni Servers and the testsuite controller connect only to the base network, while SUSE Manager/Uyuni Proxies and clients or minions connect to both networks.
 
-
 ## Custom SSH keys
 
 If you want to use another key for all VMs, specify the path of the public key with `ssh_key_path` into the `base` config. Example:
@@ -441,7 +438,6 @@ The `ssh_key_path` option can also be specified on a per-host basis. In this cas
 
 If you don't want to copy any ssh key at all (and use passwords instead), just supply an empty file (eg. `ssh_key_path = "/dev/null"`).
 
-
 ## SSH access without specifying a username
 
 You can add the following lines to `~/.ssh/config` to avoid checking hosts and specifying a username:
@@ -452,7 +448,6 @@ StrictHostKeyChecking no
 UserKnownHostsFile=/dev/null
 User root
 ```
-
 
 ## Activation Keys for minions
 
@@ -469,7 +464,6 @@ module "suse-minion" {
   activation_key = "1-DEFAULT"
 }
 ```
-
 
 ## Proxies
 
@@ -521,7 +515,6 @@ module "proxy" {
 }
 ```
 
-
 ## Inter-Server Sync (ISS)
 
 Create two SUSE Manager server modules and add `iss_master` and `iss_slave` variable definitions to them, as in the example below:
@@ -550,7 +543,6 @@ Please note that `iss_master` is set from `master`'s module output variable `hos
 
 Also note that this requires `create_first_user` and `publish_private_ssl_key` settings to be true (they are by default).
 
-
 ## Working on multiple configuration sets (workspaces) locally
 
 Terraform supports working on multiple infrastructure resource groups with the same set of files through the concept of [workspaces](https://www.terraform.io/docs/state/workspaces.html). Unfortunately those are not supported for the default filesystem backend and do not really work well with different `main.tf` files, which is often needed in sumaform.
@@ -572,7 +564,6 @@ local_workspaces/libvirt-testsuite/terraform.tfstate
 ... -> local_workspaces/libvirt-testsuite/terraform.tfstate
 ```
 
-
 ## Plain hosts
 
 You can have totally unconfigured hosts in your configuration by using the `host` module, for example if you need to test bootstrapping.
@@ -588,7 +579,6 @@ module "vanilla" {
   image = "sles12sp5o"
 }
 ```
-
 
 ## Build hosts
 
@@ -608,7 +598,6 @@ module "build-host"
   image = "sles15sp3o"
 }
 ```
-
 
 ## PXE boot hosts
 
@@ -631,7 +620,6 @@ module "pxeboot-minion"
 }
 ```
 
-
 ## SMT
 
 You can configure SUSE Manager instances to download packages from an SMT server instead of SCC, in case a `mirror` is not used:
@@ -646,7 +634,6 @@ module "server" {
   smt = "http://smt.suse.de"
 }
 ```
-
 
 ## Custom repos and packages
 
@@ -696,11 +683,9 @@ module "suse-sshminion" {
 }
 ```
 
-
 ## Prometheus/Grafana monitoring
 
 It is possible to install Prometheus exporters on a SUSE Manager Server instance via the `monitored` flag. Those can be consumed by Prometheus and Grafana server to analyze visually. A libvirt example follows:
-
 
 ```hcl
 module "server" {
@@ -738,7 +723,6 @@ module "registry" {
 
 The registry will be available on port 80 (unencrypted http) and without authentication.
 
-
 ## [evil-minions](https://github.com/moio/evil-minions) load generator
 
 `evil-minions` is a Salt load generator useful for performance tests and demoing. It contains tools to "record" behavior of a Salt minion and to "play it back" multiple times in parallel in order to test the Salt Master or SUSE Manager Server.
@@ -768,7 +752,6 @@ module "minion" {
   evil_minion_slowdown_factor = 1
 }
 ```
-
 
 ## Use Locust for http load testing
 
@@ -808,7 +791,6 @@ module "locust" {
   slave_quantity = 5
 }
 ```
-
 
 ## Use Operating System updates (released and unreleased)
 
@@ -858,7 +840,6 @@ module "sumamail3" {
   traceback_email = "michele.bologna@chameleon-mail.com"
 }
 ```
-
 
 ## Swap file configuration
 

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -96,6 +96,7 @@ The following steps need to be performed:
 - remove folder `.terraform`
 - Create a new backend symbolic link to point to the new backend. From the `modules` folder run:
 
+```bash
 ln -sfn ../backend_modules/<BACKEND> modules/backend
 ```
 
@@ -220,7 +221,7 @@ This means that in order for virtual hosts to host virtual machines, nested virt
 For this, the `kvm_intel` or `kvm_amd` kernel modules need to have `nested` parameter set to `1`.
 To check if nested virtualization is enabled on the physical machine, the following command needs to return either `1` or `Y`:
 
-```
+```bash
 # For intel CPU:
 cat /sys/module/kvm_intel/parameters/nested
 
@@ -288,7 +289,7 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
 
 You can specifiy a set of SUSE official channels to be added at deploy time of a SUSE Manager Server. This operation is typically time-intensive, thus it is disabled by default. In order to add a channel, first get the label name from an existing SUSE Manager Server:
 
-```
+```bash
 # mgr-sync list channels --compact
 Available Channels:
 ...
@@ -442,7 +443,7 @@ If you don't want to copy any ssh key at all (and use passwords instead), just s
 
 You can add the following lines to `~/.ssh/config` to avoid checking hosts and specifying a username:
 
-```
+```config
 Host *.tf.local
 StrictHostKeyChecking no
 UserKnownHostsFile=/dev/null
@@ -549,7 +550,7 @@ Terraform supports working on multiple infrastructure resource groups with the s
 
 As a workaround, you can create a `local_workspaces` directory with a subdirectory per workspace, each containing main.tf and terraform.tfstate files, then use symlinks to the sumaform root:
 
-```
+```bash
 ~/sumaform$ find local_workspaces/
 local_workspaces/
 local_workspaces/aws-demo

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -3,24 +3,27 @@
 ## Changing product versions
 
 Some modules have a `product_version` variable that determines the software product version. Specifically:
- * in `server`, `proxy` etc. `product_version` determines the SUSE Manager/Uyuni product version,
- * in `minion`, `client`, etc. `product_version` determines the SUSE Manager/Uyuni Tools version.
+
+- in `server`, `proxy` etc. `product_version` determines the SUSE Manager/Uyuni product version,
+- in `minion`, `client`, etc. `product_version` determines the SUSE Manager/Uyuni Tools version.
 
 Legal values for released software are:
- * `4.0-released`   (latest released Maintenance Update for SUSE Manager 4.0 and Tools)
- * `4.1-released`   (latest released Maintenance Update for SUSE Manager 4.1 and Tools)
- * `4.2-released`   (latest released Maintenance Update for SUSE Manager 4.2 and Tools)
- * `4.3-released`   (latest released Maintenance Update for SUSE Manager 4.3 and Tools)
- * `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
+
+- `4.0-released`   (latest released Maintenance Update for SUSE Manager 4.0 and Tools)
+- `4.1-released`   (latest released Maintenance Update for SUSE Manager 4.1 and Tools)
+- `4.2-released`   (latest released Maintenance Update for SUSE Manager 4.2 and Tools)
+- `4.3-released`   (latest released Maintenance Update for SUSE Manager 4.3 and Tools)
+- `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
 
 Legal values for work-in-progress software are:
- * `4.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.0)
- * `4.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.1)
- * `4.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.2)
- * `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
- * `4.3-beta`    (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
- * `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, for `server` and `proxy`only works with SLE15SP4 image)
- * `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap image)
+
+- `4.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.0)
+- `4.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.1)
+- `4.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.2)
+- `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
+- `4.3-beta`    (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
+- `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, for `server` and `proxy`only works with SLE15SP4 image)
+- `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap image)
 
 Legal values for CI:
 
@@ -85,14 +88,13 @@ Many projects/vendors provide official OS images for the various backends, and s
 Changing the backend normally means destroying the current one (see "Working on multiple configuration sets" to maintain multiple).
 
 The following steps need to be performed:
- * Clean the current Terraform state
-   * Consider run `terraform destroy`
-   * Remove the `terraform.tfstate` file
- * Adapt the `main.tf` file to the new provider specific properties
- * remove folder `.terraform`
- * Create a new backend symbolic link to point to the new backend. From the `modules` folder run:
 
-```
+- Clean the current Terraform state
+  - Consider run `terraform destroy`
+  - Remove the `terraform.tfstate` file
+- Adapt the `main.tf` file to the new provider specific properties
+- remove folder `.terraform`
+- Create a new backend symbolic link to point to the new backend. From the `modules` folder run:
 ln -sfn ../backend_modules/<BACKEND> modules/backend
 ```
 
@@ -229,9 +231,9 @@ cat /sys/module/kvm_amd/parameters/nested
 
 The generated virtual host will be setup with:
 
-* a `default` virtual network or `nat` type with `192.168.42.1/24` IP addresses,
-* a `default` virtual storage pool of `dir` type targeting `/var/lib/libvirt/images`
-* and a VM template disk image located in `/var/testsuite-data/disk-image-template.qcow2`.
+- a `default` virtual network or `nat` type with `192.168.42.1/24` IP addresses,
+- a `default` virtual storage pool of `dir` type targeting `/var/lib/libvirt/images`
+- and a VM template disk image located in `/var/testsuite-data/disk-image-template.qcow2`.
 
 The template disk image is the `opensuse153` image used by sumaform and is downloaded when applying the highstate on the virtual host.
 In order to use another or a cached image, use the `hvm_disk_image` variable.
@@ -247,42 +249,41 @@ Note that the Xen virtualization host will be rebooted when applying the highsta
 
 By default, sumaform deploys hosts with a range of tweaked settings for convenience reasons. If in your use case this is not wanted, you can turn those off via the following variables.
 
- * `client` module:
-   * `auto_register`: automatically registers clients to the SUSE Manager Server. Set to `false` for manual registration
-   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
- * `minion` module:
-   * `auto_connect_to_master`: automatically connects to the Salt Master. Set to `false` to manually configure
-   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
- * `sshminion` module:
-   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
- * `host` module:
-   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
- * `proxy` module:
-   * `minion`: whether to configure this Proxy as a Salt minion. Set to `false` to have the Proxy set up as a traditional client
-   * `auto_connect_to_master`: automatically connects to the Salt Master. Set to `false` to manually configure. Requires `minion` to be `true`
-   * `auto_register`: automatically registers the proxy to its upstream Server or Proxy. Defaults to `false`, requires `minion` to be `false`
-   * `download_private_ssl_key`: automatically copies SSL certificates from the upstream SUSE Manager Server or SUSE Manager Proxy. Requires `publish_private_ssl_key` on the upstream server or proxy. Set to `false` for manual distribution
-   * `install_proxy_pattern`: install proxy pattern with all proxy-related software. Set to `false` to install manually
-   * `auto_configure`: automatically runs the `confure-proxy.sh` script which enables Proxy functionality. Set to `false` to run manually. Requires `auto_register`, `download_private_ssl_key`, and `install_proxy_pattern`
-   * `generate_bootstrap_script`: generates a bootstrap script for traditional clients and copies it in /pub. Set to `false` to generate manually. Requires `auto_configure`
-   * `publish_private_ssl_key`: copies the private SSL key in /pub for cascaded Proxies to copy automatically. Set to `false` for manual distribution. Requires `download_private_ssl_key`
-   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
- * `server` module:
-   * `auto_accept`: whether to automatically accept minion keys. Set to `false` to manually accept
-   * `create_first_user`: whether to automatically create the first user (the SUSE Manager Admin)
-     * `server_username` and `server_password`: define credentials for the first user, admin/admin by default
-   * `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
-   * `allow_postgres_connections`: configure Postgres to accept connections from external hosts. Set to `false` to only allow localhost connections
-   * `unsafe_postgres`: use PostgreSQL settings that improve performance by worsening durability. Set to `false` to ensure durability
-   * `skip_changelog_import`: import RPMs without changelog data, this speeds up spacewalk-repo-sync. Set to `false` to import changelogs
-   * `mgr_sync_autologin`: whether to set mgr-sync credentials in the .mgr-sync file. Requires `create_first_user`
-   * `create_sample_channel`: whether to create an empty test channel. Requires `create_first_user`
-   * `create_sample_activation_key`: whether to create a sample activation key. Requires `create_first_user`
-   * `create_sample_bootstrap_script`: whether to create a sample bootstrap script for traditional clients. Requires `create_sample_activation_key`
-   * `publish_private_ssl_key`: copies the private SSL key in /pub for Proxies to copy automatically. Set to `false` for manual distribution
-   * `disable_download_tokens`: disable package token download checks. Set to `false` to enable checking
-   * `forward_registration`: enable forwarding of registrations to SCC (default off)
-
+- `client` module:
+  - `auto_register`: automatically registers clients to the SUSE Manager Server. Set to `false` for manual registration
+  - `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
+- `minion` module:
+  - `auto_connect_to_master`: automatically connects to the Salt Master. Set to `false` to manually configure
+  - `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
+- `sshminion` module:
+  - `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
+- `host` module:
+  - `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
+- `proxy` module:
+  - `minion`: whether to configure this Proxy as a Salt minion. Set to `false` to have the Proxy set up as a traditional client
+  - `auto_connect_to_master`: automatically connects to the Salt Master. Set to `false` to manually configure. Requires `minion` to be `true`
+  - `auto_register`: automatically registers the proxy to its upstream Server or Proxy. Defaults to `false`, requires `minion` to be `false`
+  - `download_private_ssl_key`: automatically copies SSL certificates from the upstream SUSE Manager Server or SUSE Manager Proxy. Requires `publish_private_ssl_key` on the upstream server or proxy. Set to `false` for manual distribution
+  - `install_proxy_pattern`: install proxy pattern with all proxy-related software. Set to `false` to install manually
+  - `auto_configure`: automatically runs the `confure-proxy.sh` script which enables Proxy functionality. Set to `false` to run manually. Requires `auto_register`, `download_private_ssl_key`, and `install_proxy_pattern`
+  - `generate_bootstrap_script`: generates a bootstrap script for traditional clients and copies it in /pub. Set to `false` to generate manually. Requires `auto_configure`
+  - `publish_private_ssl_key`: copies the private SSL key in /pub for cascaded Proxies to copy automatically. Set to `false` for manual distribution. Requires `download_private_ssl_key`
+  - `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
+- `server` module:
+  - `auto_accept`: whether to automatically accept minion keys. Set to `false` to manually accept
+  - `create_first_user`: whether to automatically create the first user (the SUSE Manager Admin)
+    - `server_username` and `server_password`: define credentials for the first user, admin/admin by default
+  - `disable_firewall`: disables the firewall making all ports available to any host. Set to `false` to only have typical SUSE Manager ports open
+  - `allow_postgres_connections`: configure Postgres to accept connections from external hosts. Set to `false` to only allow localhost connections
+  - `unsafe_postgres`: use PostgreSQL settings that improve performance by worsening durability. Set to `false` to ensure durability
+  - `skip_changelog_import`: import RPMs without changelog data, this speeds up spacewalk-repo-sync. Set to `false` to import changelogs
+  - `mgr_sync_autologin`: whether to set mgr-sync credentials in the .mgr-sync file. Requires `create_first_user`
+  - `create_sample_channel`: whether to create an empty test channel. Requires `create_first_user`
+  - `create_sample_activation_key`: whether to create a sample activation key. Requires `create_first_user`
+  - `create_sample_bootstrap_script`: whether to create a sample bootstrap script for traditional clients. Requires `create_sample_activation_key`
+  - `publish_private_ssl_key`: copies the private SSL key in /pub for Proxies to copy automatically. Set to `false` for manual distribution
+  - `disable_download_tokens`: disable package token download checks. Set to `false` to enable checking
+  - `forward_registration`: enable forwarding of registrations to SCC (default off)
 
 ## Adding channels to SUSE Manager Servers
 
@@ -351,9 +352,9 @@ Activation keys are also automatically created for each clone with the name `1-<
 Whenever multiple sumaform users deploy to the same virtualization hardware (eg. libvirt host) it is recommended to set the `name_prefix` variable in the `base` module in order to have a unique per-user prefix for all resource names. This will prevent conflicting names.
 
 Additionally, it is possible to have only one user to upload images and other shared infrastructure such as mirrors, having all other users re-use them. In order to accomplish this:
- * add a `use_shared_resources = true` variable to the `base` module of all users but one
- * make sure there is exactly one user that does not have the variable set, make sure this user has no `name_prefix` set. This user will deploy shared infrastructure for all users
 
+- add a `use_shared_resources = true` variable to the `base` module of all users but one
+- make sure there is exactly one user that does not have the variable set, make sure this user has no `name_prefix` set. This user will deploy shared infrastructure for all users
 
 ## Disabling Avahi and Avahi reflectors
 
@@ -746,10 +747,10 @@ In order to create an `evil-minions` load generator, you have to define a regula
 
 It is also possible to set up a delay on the response time of the replicas. By default, the replicas will respond as fast as possible, which might not be appropriate depending on the objectives of your simulation. To reproduce delays observed by the original minion, use the `evil_minion_slowdown_factor` variable, as follows:
 
- - `0.0`, the default value, makes evil minions respond as fast as possible
- - `1.0` makes `evil-minion` introduce delays to match the response times of the original minion
- - `2.0` makes `evil-minion` react twice as slow as the original minion
- - `0.5` makes `evil-minion` react twice as fast as the original minion
+- `0.0`, the default value, makes evil minions respond as fast as possible
+- `1.0` makes `evil-minion` introduce delays to match the response times of the original minion
+- `2.0` makes `evil-minion` react twice as slow as the original minion
+- `0.5` makes `evil-minion` react twice as fast as the original minion
 
 For more information, visit the `evil-minions` project page at https://github.com/moio/evil-minions/ .
 
@@ -901,5 +902,5 @@ module "server" {
 
 The `server` module has options to automatically capture more diagnostic information, off by default:
 
-* `java_debugging`: enable Java debugging and profiling support in Tomcat and Taskomatic
-* `postgres_log_min_duration`: log PostgreSQL statements taking longer than the duration (expressed as a string, eg. `250ms` or `3s`), or log all statements by specifying `0`
+- `java_debugging`: enable Java debugging and profiling support in Tomcat and Taskomatic
+- `postgres_log_min_duration`: log PostgreSQL statements taking longer than the duration (expressed as a string, eg. `250ms` or `3s`), or log all statements by specifying `0`

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -60,7 +60,7 @@ module "server" {
 
 ## Changing Operating Systems
 
-You can specifiy a base OS in most modules specifying an `image` variable.
+You can specify a base OS in most modules specifying an `image` variable.
 
 For some modules like `minion`, `image` is mandatory and Terraform will refuse to apply plans if it is missing. Please refer to `modules/<backend>/base/main.tf` for the exact list of supported OSs.
 
@@ -138,7 +138,7 @@ For now, the module provides Jenkins with the following plugins enabled:
 
 Authentication is enabled, and a user `admin` is created. The password can be found at `/var/lib/jenkins/secrets/initialAdminPassword` at the Jenkins instance.
 
-To enable Jenkins, use the following definition.
+To enable Jenkins, use the following definition:
 
 ```hcl
 module "jenkins" {
@@ -190,7 +190,7 @@ Note that `mirror` must be populated before any host can be deployed. By default
 
 ## Mirror only for Server (products synchronization)
 
-In addition to the parameter `mirror`, which will wrap this case, you might only want to setup a mirror for server products syncronization, but not for the repositories used by sumaform during the deployment of your environment.
+In addition to the parameter `mirror`, which will wrap this case, you might only want to setup a mirror for server products synchronization, but not for the repositories used by sumaform during the deployment of your environment.
 For that use case, instead of `mirror` use `server_mounted_mirror` parameter inside the server module definition.
 
 ## Virtual hosts
@@ -287,7 +287,7 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
 
 ## Adding channels to SUSE Manager Servers
 
-You can specifiy a set of SUSE official channels to be added at deploy time of a SUSE Manager Server. This operation is typically time-intensive, thus it is disabled by default. In order to add a channel, first get the label name from an existing SUSE Manager Server:
+You can specify a set of SUSE official channels to be added at deploy time of a SUSE Manager Server. This operation is typically time-intensive, thus it is disabled by default. In order to add a channel, first get the label name from an existing SUSE Manager Server:
 
 ```bash
 # mgr-sync list channels --compact
@@ -604,7 +604,7 @@ module "build-host"
 
 PXE boot hosts are unprovisioned hosts that are capable of booting from their networking card. Additionally, they have a hardware type of "Genuine Intel" to make provisioning via SUSE Manager for Retail easier.
 
-"unprovisioned" means that they are completly unprepared: no SSH keys, no initialization at all.
+"unprovisioned" means that they are completely unprepared: no SSH keys, no initialization at all.
 
 SUSE Manager makes use of PXE booting in two use cases: cobbler, and Retail.
 
@@ -808,8 +808,7 @@ module "server" {
 }
 ```
 
-
-## E-mail configuration
+## Email configuration
 
 With the default configuration, whenever SUSE Manager server hosts are configured to use root@`hostname -d` as the email sender. The recipient's SMTP server may discard those emails since they come from a non-existent domain name.
 

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -246,6 +246,7 @@ module "cucumber_testsuite" {
    ...
 }
 ```
+
 ## Virtual host
 
 User may need to change the kvm/xem image download. To do it, one can use the `additional_grains` property:

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -2,7 +2,7 @@
 
 ## Basic deployment
 
-It is possible to run [the Cucumber testsuite for SUSE Manager and Uyuni](https://github.com/uyuni-project/uyuni/tree/master/testsuite) by using the `cucumber_testsuite` module. A libvirt example follows:
+It is possible to run [the Cucumber testsuite](https://github.com/uyuni-project/uyuni/tree/master/testsuite)  for SUSE Manager and Uyuni by using the `cucumber_testsuite` module. A libvirt example follows:
 
 ```hcl
 provider "libvirt" {

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -65,17 +65,19 @@ To enable/disable features, edit these YAML files. Keep in mind that:
 - features not prefixed with `core_` are idempotent, so they can be run multiple times without changing test results.
 
 Once all `core_` features have been executed you can run a non-core Cucumber feature as follows:
-```
-$ ssh root@head-ctl.tf.local
-# cd spacewalk/testsuite
-# cucumber -r features features/secondary/my_feature.feature
+
+```bash
+ssh root@head-ctl.tf.local
+cd spacewalk/testsuite
+cucumber -r features features/secondary/my_feature.feature
 ```
 
 or an individual scenario with:
-```
-$ ssh root@head-ctl.tf.local
-# cd spacewalk/testsuite
-# cucumber -r features "My nice scenario title"
+
+```bash
+ssh root@head-ctl.tf.local
+cd spacewalk/testsuite
+cucumber -n "My nice scenario title"
 ```
 
 Read HTML results at:

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -53,7 +53,7 @@ That will generate the outputs on-screen and will store them at the `terraform.t
 
 To start the testsuite, use:
 
-```
+```bash
 ssh -t head-ctl.tf.local run-testsuite
 ```
 
@@ -84,17 +84,20 @@ Read HTML results at:
  `head-ctl.tf.local/output.html`. There is an additional running service, enabled during the `highstate`, on the `controller` which is exposing the entire `/root/spacewalk/testsuite` folder: all testsuite files, including results saved under this folder, are readable through the `http` protocol at the port `80`.
 
 Get HTML results with:
-```
+
+```bash
 scp head-ctl.tf.local://root/spacewalk-testsuite-base/output.html .
 ```
 
 To keep the testsuite running after ending the ssh session using `screen` tool:
-```
+
+```bash
 ssh -t head-ctl.tf.local screen run-testsuite
 ```
 
 You can detach from the session at anytime using the key sequence `^A d`. To re-attach to the existing session:
-```
+
+```bash
 ssh -t head-ctl.tf.local screen -r
 ```
 
@@ -160,7 +163,7 @@ server = {
   }
   additional_packages = [ "vim" ]
 }
-````
+```
 
 The `cucumber_testsuite` module also offers the `use_avahi` and `avahi_reflector` variables, see [README_ADVANCED.md](README_ADVANCED.md) for their meaning.
 
@@ -251,6 +254,7 @@ module "cucumber_testsuite" {
 
 User may need to change the kvm/xem image download. To do it, one can use the `additional_grains` property:
 
+```hcl
 host_settings = {
     kvm-host = {
         additional_grains = {
@@ -269,4 +273,4 @@ host_settings = {
         }
     }
 }
-    ```
+```

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -61,8 +61,9 @@ By default, `run-testsuite` runs over a selection of the YAML files at `run_sets
 `sanity_check.yml`, `core.yml`, `reposync.yml`, `init_clients.yml`, `secondary.yml`, `secondary_parallelizable.yml`, `finishing.yml`.
 
 To enable/disable features, edit these YAML files. Keep in mind that:
- - features prefixed with `core_` are essential for others to work, cannot be repeated and must be executed in the order given by `testsuite.yml`
- - features not prefixed with `core_` are idempotent, so they can be run multiple times without changing test results.
+
+- features prefixed with `core_` are essential for others to work, cannot be repeated and must be executed in the order given by `testsuite.yml`
+- features not prefixed with `core_` are idempotent, so they can be run multiple times without changing test results.
 
 Once all `core_` features have been executed you can run a non-core Cucumber feature as follows:
 ```
@@ -140,11 +141,12 @@ host_settings = {
 ```
 
 Each of the hosts (including `server` and `controller` which are always present) accepts the following parameters:
- - `provider_settings`: Map of provider-specific settings for the host, see the backend-specific README file
- - `additional_repos` to add software repositories (see [README_ADVANCED.md](README_ADVANCED.md))
- - `additional_packages` to add software packages (see [README_ADVANCED.md](README_ADVANCED.md))
- - `additional_grains` to add or overwrite salt grains on salt minions. Map of key value
- - `image` to use a different base image
+
+- `provider_settings`: Map of provider-specific settings for the host, see the backend-specific README file
+- `additional_repos` to add software repositories (see [README_ADVANCED.md](README_ADVANCED.md))
+- `additional_packages` to add software packages (see [README_ADVANCED.md](README_ADVANCED.md))
+- `additional_grains` to add or overwrite salt grains on salt minions. Map of key value
+- `image` to use a different base image
 
 A libvirt example follows:
 
@@ -169,8 +171,9 @@ You can configure a `mirror` host for the testsuite and that will be beneficial 
 ## Alternative testsuite version
 
 You can also select an alternative fork or branch for the Cucumber testsuite code:
- - the `git_repo` variable in the `cucumber_testsuite` module overrides the fork URL (by default either the Uyuni or the SUSE Manager repository is used)
- - the `branch` variable in the `cucumber_testsuite` module overrides the branch (by default an automatic selection is made).
+
+- the `git_repo` variable in the `cucumber_testsuite` module overrides the fork URL (by default either the Uyuni or the SUSE Manager repository is used)
+- the `branch` variable in the `cucumber_testsuite` module overrides the branch (by default an automatic selection is made).
 
 As an example:
 

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -38,16 +38,15 @@ The example will have to be completed with SCC credentials and GitHub credential
 
 By default, the `cucumber_testsuite` module will not produce any outputs for the resources (for example the hostname for the instances).
 
-If you want them, add:
+If you want them, add the following to the end of your `main.tf` file:
 
 ```hcl
 output "configuration" {
   value = module.cucumber_testsuite.configuration
 }
 ```
-At the end of your `main.tf` file.
 
-That will generate the outputs on-screen and will store them at the `terraform.tfstate`.
+That will generate the outputs on-screen and will store them in the `terraform.tfstate` file.
 
 ## Running the testsuite
 
@@ -57,7 +56,7 @@ To start the testsuite, use:
 ssh -t head-ctl.tf.local run-testsuite
 ```
 
-By default, `run-testsuite` runs over a selection of the YAML files at `run_sets`, i.e.:
+By default, `run-testsuite` runs over a selection of the YAML files in `run_sets`, i.e.:
 `sanity_check.yml`, `core.yml`, `reposync.yml`, `init_clients.yml`, `secondary.yml`, `secondary_parallelizable.yml`, `finishing.yml`.
 
 To enable/disable features, edit these YAML files. Keep in mind that:
@@ -194,7 +193,7 @@ module "cucumber_testsuite" {
 
 ## Alternative Docker and Kiwi profiles
 
-By default, the Docker and Kiwi profiles used by the testsuite (all branches) are picked up from [the public uyuni branch](https://github.com/uyuni-project/uyuni/tree/master/testsuite/features/profiles). If you want to experiment with alternative Docker or Kiwi profiles, you can do that with the `git_profiles_repo` variable.
+By default, the Docker and Kiwi profiles used by the testsuite (all branches) are picked up from [the public Uyuni branch](https://github.com/uyuni-project/uyuni/tree/master/testsuite/features/profiles). If you want to experiment with alternative Docker or Kiwi profiles, you can do that with the `git_profiles_repo` variable.
 
 Example:
 
@@ -252,7 +251,7 @@ module "cucumber_testsuite" {
 
 ## Virtual host
 
-User may need to change the kvm/xem image download. To do it, one can use the `additional_grains` property:
+User may need to change the KVM/Xen image download. To do it, one can use the `additional_grains` property:
 
 ```hcl
 host_settings = {

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -104,7 +104,7 @@ ssh -t head-ctl.tf.local screen -r
 
 ### Adding hosts to the testsuite
 
-Several test hosts are optional and can be activated via a host_settings block like the following:
+Several test hosts are optional and can be activated via a `host_settings` block like the following:
 
 ```hcl
 host_settings = {
@@ -131,7 +131,7 @@ host_settings = {
 }
 ```
 
-The default value for host_settings block has a SUSE family traditional client and SUSE family minion present:
+The default value for `host_settings` block has a SUSE family traditional client and SUSE family minion present:
 
 ```hcl
 host_settings = {

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -213,6 +213,6 @@ rm -r .terraform/
 
 ## Q: Why are documentation files not installed after package installation?
 
-Sumaform uses JeOS and, by default, `zypper` is configures to not install docs.
-To change that behavior edit `/etc/zypp/zypp.conf` and change the property `rpm.install.excludedocs = no`
+Sumaform uses JeOS and, by default, `zypper` is configured to not install docs.
+To change that behavior, edit `/etc/zypp/zypp.conf` and change the property `rpm.install.excludedocs = no`
 and re-install the package.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -3,7 +3,8 @@
 ## Q: how can I work around backend not defined error?
 
 Typical error message follows:
-```
+
+```bash
 Error: Unreadable module directory
 
 Unable to evaluate directory symlink: lstat modules/backend: no such file or directory
@@ -12,7 +13,7 @@ Unable to evaluate directory symlink: lstat modules/backend: no such file or dir
 Terraform cannot find the path for the backend in use.
 Create a symbolic link to the backend module directory inside the `modules` directory:
 
-```
+```bash
 cd modules
 ln -sfn ../backend_modules/<BACKEND> backend
 ```
@@ -21,12 +22,11 @@ ln -sfn ../backend_modules/<BACKEND> backend
 
 Typical error message follows:
 
-```
+```bash
 Could not resolve hostname server.tf.local: Name or service not known
-```
 
-or:
-```
+# or
+
 connect: Invalid argument
 ```
 
@@ -42,16 +42,18 @@ Check that:
 - mdns is configured in glibc's Name Server Switch configuration file
 
 In `/etc/nsswitch.conf` you should see a `hosts:` line that looks like the following:
-```
+
+```config
 hosts:          files mdns4 [NOTFOUND=return] dns
 ```
+
 `mdns4` should be present in this line. If it is not, add it.
 
 Note: `mdns6` also exists to resolve to IPv6 addresses, but currently [one known issue exists](https://github.com/lathiat/avahi/issues/110) where it may return incorrect addresses (specifically: link local addresses starting with `fe80:` but without a zone identifier trailer such as `%eth0`). We recommend IPv4 for the time being.
 
 Starting with `nss-mdns` version 0.14.1, you also need to populate `/etc/mdns.allow` with:
 
-```
+```bash
 .local
 .tf.local
 ```
@@ -67,26 +69,24 @@ This can happen, for example, in libvirt if the NAT network being used does not 
 ## Q: how can I work around a libvirt permission denied error?
 
 Typical error message follows:
-```
-* libvirt_domain.domain: Error creating libvirt domain: [Code-1] [Domain-10]
+
+```bash
+libvirt_domain.domain: Error creating libvirt domain: [Code-1] [Domain-10]
 internal error: process exited while connecting to monitor:
 2016-10-14T06:49:07.518689Z qemu-system-x86_64: -drive file=/var/lib/libvirt/images/mirror-main-disk,format=qcow2,if=none,id=drive-virtio-disk0:
 Could not open '/var/lib/libvirt/images/mirror-main-disk':
 Permission denied
-```
 
-Another possible one is:
-```
-* libvirt_domain.domain: Error creating libvirt domain: virError(Code=1, Domain=0, Message='internal error: child reported: Kernel does not provide mount namespace: Permission denied')
-```
+# Another possible one is:
+libvirt_domain.domain: Error creating libvirt domain: virError(Code=1, Domain=0, Message='internal error: child reported: Kernel does not provide mount namespace: Permission denied')
 
-Yet another one is:
-```
+# Yet another one is:
 Failed to connect socket to '/var/run/libvirt/libvirt-sock': No such file or directory'
 ```
 
 Some variants of this issue will also be logged in `/var/log/syslog` like:
-```
+
+```bash
 Oct 14 08:10:03 dell kernel: [52456.461754] audit: type=1400 audit(1476425403.666:27):
 apparmor="DENIED" operation="open" profile="libvirt-4d4f9b58-f50d-4f60-a8a1-315c9a2d02c1"
 name="/var/lib/libvirt/images/terraform_mirror_main_disk"
@@ -116,6 +116,8 @@ AppArmor can be used both to isolate the host from its guests, and guests from o
 
 - host-guest protection: add `security_driver = "none"` to `/etc/libvirt/qemu.conf
 - guest-guest protection:
+
+```bash
 sudo ln -s /etc/apparmor.d/usr.sbin.libvirtd /etc/apparmor.d/disable/
 sudo /etc/init.d/apparmor restart
 sudo aa-status | grep libvirt # output should be empty
@@ -125,7 +127,7 @@ sudo aa-status | grep libvirt # output should be empty
 
 If you run into this error:
 
-`* dial tcp 192.168.122.193:22: getsockopt: network is unreachable`
+`dial tcp 192.168.122.193:22: getsockopt: network is unreachable`
 
 during the `terraform apply`, it means Terraform was able to create a VM, but then is unable to log in via SSH do configure it. This is typically caused by network misconfiguration - `ping 192.168.122.193` should work but it does not. Please double check your networking configuration. If you are using AWS, make sure your current IP is listed in the `ssh_allowed_ips` variable (or check it is whitelisted in AWS Console -> VPC -> Security Groups).
 
@@ -137,7 +139,7 @@ Run `sh /root/salt/highstate.sh`.
 
 A: you can use [Terraform's taint command](https://www.terraform.io/docs/commands/taint.html) to mark a resource to be re-created during the next `terraform apply`. To get the correct name of the module and resource use `terraform state list`:
 
-```
+```bash
 $ terraform state list
 ...
 module.server.module.server.libvirt_volume.main_disk[0]
@@ -145,11 +147,12 @@ module.server.module.server.libvirt_volume.main_disk[0]
 $ terraform taint module.server.module.server.libvirt_volume.main_disk[0]
 Resource instance module.server.module.server.libvirt_volume.main_disk[0] has been marked as tainted.
 ```
+
 ## Q: how to force the re-download of an image?
 
 A: see above, use the taint command as per the following example:
 
-```
+```bash
 $ terraform state list
 ...
 module.base.libvirt_volume.volumes[2]
@@ -168,7 +171,7 @@ Terraform cannot find your SSH key in the default path `~/.ssh/id_rsa.pub`. See 
 
 If you have just switched from non-bridged to bridged networking or vice versa you might get the following error:
 
-```
+```bash
 Error applying plan:
 
 1 error(s) occurred:
@@ -184,12 +187,12 @@ This is a known issue, simply repeat the `terraform apply` command and it will g
 
 If you run `terraform apply` from outside of the sumaform tree, you will get the error message:
 
-```
+```bash
 Error applying plan:
 
 1 error(s) occurred:
 
-* stat salt: no such file or directory
+stat salt: no such file or directory
 ```
 
 A simple solution is to create a symbolic link pointing to the `salt` directory on top level of the sumaform files tree. Create this symlink in your current directory.
@@ -204,7 +207,7 @@ To change to another workspace just remove and create the corresponding links ag
 
 When we change between workspaces,it may happen that `terraform init` throws "is not a valid parameter" errors, as if we actually didn't change to another workspace. To resolve this just remove the terraform cache:
 
-```
+```bash
 rm -r .terraform/
 ```
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -31,14 +31,15 @@ connect: Invalid argument
 ```
 
 Check that:
- - your firewall is not blocking UDP port 5353
+
+- your firewall is not blocking UDP port 5353
   - on SUSE systems check YaST -> Security and Users -> Firewall -> Zones -> "public" and "libvirt"
-   - "mdns" should appear on the list on the right (allowed)
- - Avahi is installed and running
-   - typically you can check this via systemd: `systemctl status avahi-daemon`
-   - be sure you don't have mixed versions: `rpm -qa | grep avahi`
- - Avahi is capable of resolving the host you are trying to reach: `avahi-resolve -n <host>.tf.local`
- - mdns is configured in glibc's Name Server Switch configuration file
+  - "mdns" should appear on the list on the right (allowed)
+- Avahi is installed and running
+  - typically you can check this via systemd: `systemctl status avahi-daemon`
+  - be sure you don't have mixed versions: `rpm -qa | grep avahi`
+- Avahi is capable of resolving the host you are trying to reach: `avahi-resolve -n <host>.tf.local`
+- mdns is configured in glibc's Name Server Switch configuration file
 
 In `/etc/nsswitch.conf` you should see a `hosts:` line that looks like the following:
 ```
@@ -100,20 +101,21 @@ There are two possible causes: plain Unix permissions or AppArmor.
 Check that the interested directory (in the case above `/var/lib/libvirt/images`) is writable by the user running `qemu` (you can check it via `ps -eo uname:20,comm | grep qemu-system-x86` when you have at least one virtual machine running).
 
 If the directory has wrong permissions:
- - fix their them manually via `chmod`/`chown`;
- - check that the pool definition has right user and permissions via `virsh pool-edit <POOL_NAME>` (note that mode is specified in octal and user/group as IDs, see `id -u <USERNAME>` and `cat /etc/groups`).
+
+- fix their them manually via `chmod`/`chown`;
+- check that the pool definition has right user and permissions via `virsh pool-edit <POOL_NAME>` (note that mode is specified in octal and user/group as IDs, see `id -u <USERNAME>` and `cat /etc/groups`).
 
 If the user running `qemu` is not the one you expected:
- - change the `user` and `group` variables in `/etc/libvirt/qemu.conf`, typically `root`/`root` will solve any problem
- - restart the libvirt daemon
+
+- change the `user` and `group` variables in `/etc/libvirt/qemu.conf`, typically `root`/`root` will solve any problem
+- restart the libvirt daemon
 
 ### AppArmor
 
 AppArmor can be used both to isolate the host from its guests, and guests from one another. Both of those protections must be properly configured in order for sumaform to operate correctly. Unfortunately, this configuration can be difficult and is well beyond the scope of this guide. Following are instructions to disable AppArmor completely in non-security-sensitive environments.
 
- * host-guest protection: add `security_driver = "none"` to `/etc/libvirt/qemu.conf
- * guest-guest protection:
-```sh
+- host-guest protection: add `security_driver = "none"` to `/etc/libvirt/qemu.conf
+- guest-guest protection:
 sudo ln -s /etc/apparmor.d/usr.sbin.libvirtd /etc/apparmor.d/disable/
 sudo /etc/init.d/apparmor restart
 sudo aa-status | grep libvirt # output should be empty
@@ -171,7 +173,7 @@ Error applying plan:
 
 1 error(s) occurred:
 
-* libvirt_domain.domain: diffs didn't match during apply. This is a bug with Terraform and should be reported as a GitHub Issue.
+libvirt_domain.domain: diffs didn't match during apply. This is a bug with Terraform and should be reported as a GitHub Issue.
 ...
 Mismatch reason: attribute mismatch: network_interface.0.bridge
 ```

--- a/backend_modules/aws/README.md
+++ b/backend_modules/aws/README.md
@@ -3,13 +3,14 @@
 ## Overview
 
 Base Module will create:
- - a VPC
- - three subnets
-   - one private, that can only access other hosts in the VPC and outbound connection to internet
-   - one additional network, private too, that only allows communications between hosts inside the subnet and no outbound connections allowed
-   - one public, that can also access the Internet and accepts connections from an IP whitelist
- - security groups, routing tables, Internet gateways, NAT gateway as appropriate
- - one `bastion` host is also created in the public network
+
+- a VPC
+- three subnets
+  - one private, that can only access other hosts in the VPC and outbound connection to internet
+  - one additional network, private too, that only allows communications between hosts inside the subnet and no outbound connections allowed
+  - one public, that can also access the Internet and accepts connections from an IP whitelist
+- security groups, routing tables, Internet gateways, NAT gateway as appropriate
+- one `bastion` host is also created in the public network
 
 This architecture is based on [AWS VPC with Public and Private Subnets](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Scenario2.html).
 
@@ -21,9 +22,10 @@ AWS backend don't have support for pxe_boot hosts. It's implementation will be c
 ## Prerequisites
 
 You will need:
- - an AWS account, specifically an Access Key ID and a Secret Access Key
- - [an SSH key pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#having-ec2-create-your-key-pair) valid for that account
- - the name of the region and availability zone you want to use.
+
+- an AWS account, specifically an Access Key ID and a Secret Access Key
+- [an SSH key pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#having-ec2-create-your-key-pair) valid for that account
+- the name of the region and availability zone you want to use.
 
 ## Select AWS backend to be used
 
@@ -88,8 +90,8 @@ An example follows:
 
 `server`, `proxy` and `mirror` modules have configuration settings specific for extra data volumes, those are set via the `volume_provider_settings` map variable. They are described below.
 
- * `volume_snapshot_id`: data volume snapshot id to be used as base for the new disk (default value: `null`)
- * `type`: volume type that should be used (default value `sc1`). See the list at the [AWS EBS Volume Type documentation page](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html).
+- `volume_snapshot_id`: data volume snapshot id to be used as base for the new disk (default value: `null`)
+- `type`: volume type that should be used (default value `sc1`). See the list at the [AWS EBS Volume Type documentation page](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html).
 
  An example follows:
  ``` hcl

--- a/backend_modules/aws/README.md
+++ b/backend_modules/aws/README.md
@@ -1,4 +1,4 @@
- # AWS-specific configuration
+# AWS-specific configuration
 
 ## Overview
 
@@ -36,6 +36,7 @@ Create a symbolic link to the `aws` backend module directory inside the `modules
 Most modules have configuration settings specific to the AWS backend, those are set via the `provider_settings` map variable. They are all described below.
 
 ### Base Module
+
 Available provider settings for the base module:
 
 | Variable name            | Type   | Default value   | Description                                                                                                    |

--- a/backend_modules/aws/README.md
+++ b/backend_modules/aws/README.md
@@ -50,8 +50,8 @@ Available provider settings for the base module:
 | server_registration_code | string | `null`          | SUMA SCC server registration code to use SCC repositories and disable internal repositories                    |
 | proxy_registration_code  | string | `null`          | SUMA SCC proxy registration code to use SCC repositories and disable internal repositories                     |
 
-
 An example follows:
+
 ```hcl-terraform
 ...
 provider_settings = {
@@ -79,6 +79,7 @@ Following settings apply to all modules that create one or more hosts of the sam
 | instance_type   | string   | `t2.micro`([apart from specific roles](Default-values-by-role))  | [AWS instance type](https://aws.amazon.com/pt/ec2/instance-types/)  |
 
 An example follows:
+
 ```hcl
 ...
   provider_settings = {
@@ -94,6 +95,7 @@ An example follows:
 - `type`: volume type that should be used (default value `sc1`). See the list at the [AWS EBS Volume Type documentation page](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html).
 
  An example follows:
+
  ``` hcl
 volume_provider_settings = {
   volume_snapshot_id = "snap-0123abcd"
@@ -116,7 +118,7 @@ Some roles such as `server` or `mirror` have specific defaults that override tho
 
 `bastion` is accessible through SSH at the public name noted in outputs.
 
-```
+```bash
 $ terraform apply
 ...
 Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
@@ -133,7 +135,7 @@ Other hosts are accessible via SSH from the `bastion` itself.
 
 This project provides a utility script, `configure_aws_tunnels.rb`, which will add `Host` definitions in your SSH config file so that you don't have to input tunneling flags manually.
 
-```
+```bash
 $ terraform apply
 ...
 $ ./configure_aws_tunnels.rb

--- a/backend_modules/aws/README_ADVANCED.md
+++ b/backend_modules/aws/README_ADVANCED.md
@@ -53,11 +53,13 @@ module "mirror" {
 **Sync mirror data (this will take some time):**
 
    If you are using released versions only or creating a mirror disk from scratch:
+
    1. `ssh root@<MIRROR_HOST>`
    1. `sudo minima.sh` (or any other mirroring script in `/usr/local/bin`)
 
 If you need access to SUSE internal nightly builds or `Devel:` packages, you will first of all need a fully set up and synced libvirt based mirror on a machine in the engineering network.
 Once you have it you can transfer development packages to your AWS mirror via rsync, for example via the commands below:
+
    1. `scp <YOUR_AWS_KEY> root@<LOCAL_MIRROR_HOST>://root/key.pem`
    2. `ssh root@<MIRROR_HOST>`
    3. `zypper in rsync`
@@ -75,6 +77,7 @@ We have two options to perform this task: using AWS console or with terraform re
 
 ##### Terraform resource
 1. Create a disk snapshot (this will take some time)
+
     ```hcl
     data "aws_ebs_volume" "data_disk_id" {
       most_recent = true

--- a/backend_modules/aws/README_ADVANCED.md
+++ b/backend_modules/aws/README_ADVANCED.md
@@ -27,6 +27,7 @@ module "mirror" {
 ```
 
 * Creating using a data disk snapshot:
+
 ```hcl
 data "aws_ebs_snapshot" "data_disk_snapshot" {
   most_recent = true
@@ -70,12 +71,14 @@ Once you have it you can transfer development packages to your AWS mirror via rs
 We have two options to perform this task: using AWS console or with terraform resource.
 
 ##### AWS console
+
 1. Login to the AWS console
 2. Select `EC2` on Services list
 3. On left-side menu select `Volumes` under `Elastic Block Store` menu option
 4. Right click on the data volume and select `Create Snapshot`
 
 ##### Terraform resource
+
 1. Create a disk snapshot (this will take some time)
 
     ```hcl
@@ -99,6 +102,7 @@ We have two options to perform this task: using AWS console or with terraform re
       }
     }
     ```
+
 2. In case you want to destroy/delete the mirror instance but keep the snapshot
     1. remove snapshot resource from terraform state: `terraform state rm aws_ebs_snapshot.mirror_data_snapshot`
     2. If you now run `terraform destroy` the snapshot will be preserved.
@@ -125,6 +129,7 @@ To use it, a set of properties should be set on sumaform base module.
 | bastion_host                         | string  | `null`        | bastion machine hostname (to access machines in private network) |
 
 Example:
+
 ```hcl
 module "base" {
   source = "./modules/base"
@@ -147,6 +152,7 @@ module "base" {
 It is possible to use a custom image instead of letting sumaform lookup the most appropriate image.
 
 Example:
+
 ```hcl
 module "server" {
   source = "./modules/server"

--- a/backend_modules/azure/README.md
+++ b/backend_modules/azure/README.md
@@ -3,14 +3,15 @@
 ## Overview
 
 Base Module will create:
- - A Resource Group
- - A Virtual Network
- - three subnets
-   - one private, that can only access other hosts in the VPC and outbound connection to internet
-   - one additional network, private too, that only allows communications between hosts inside the subnet and no outbound connections allowed
-   - one public, that can also access the Internet and accepts connections from an IP whitelist
- - security groups, routing tables, Internet gateways, NAT gateway as appropriate
- - one `bastion` host is also created in the public network
+
+- A Resource Group
+- A Virtual Network
+- three subnets
+  - one private, that can only access other hosts in the VPC and outbound connection to internet
+  - one additional network, private too, that only allows communications between hosts inside the subnet and no outbound connections allowed
+  - one public, that can also access the Internet and accepts connections from an IP whitelist
+- security groups, routing tables, Internet gateways, NAT gateway as appropriate
+- one `bastion` host is also created in the public network
 
 This architecture is based on [Azure Virtual Network concepts and best practices](https://docs.microsoft.com/en-us/azure/virtual-network/concepts-and-best-practices).
 
@@ -22,10 +23,11 @@ Azure backend don't have support for pxe_boot hosts. It's implementation will be
 ## Prerequisites
 
 You will need:
- - an azure account. You have 2 options here:
-    - [Sign in via the CLI](https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli)
-    - [Use an azure service principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal): In this case you will need to include the service principal in the provider configuration. More information on alternative connection methods to azure can be found here:
-       - [Azure Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs)
+
+- an azure account. You have 2 options here:
+  - [Sign in via the CLI](https://docs.microsoft.com/en-us/cli/azure/authenticate-azure-cli)
+  - [Use an azure service principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal): In this case you will need to include the service principal in the provider configuration. More information on alternative connection methods to azure can be found here:
+    - [Azure Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs)
 - [an SSH key pair](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys) valid for that account
 - the name of the region and availability zone you want to use.
 
@@ -89,7 +91,7 @@ An example follows:
 
 `server`, `proxy` and `mirror` modules have configuration settings specific for extra data volumes, those are set via the `volume_provider_settings` map variable. They are described below.
 
- * `volume_snapshot`: name of the volume snapshot to be used as a base for the new disk (default value: `null`)
+- `volume_snapshot`: name of the volume snapshot to be used as a base for the new disk (default value: `null`)
 
  An example follows:
  ``` hcl

--- a/backend_modules/azure/README.md
+++ b/backend_modules/azure/README.md
@@ -120,7 +120,7 @@ Some roles such as `server` or `mirror` have specific defaults that override tho
 
 `bastion` is accessible through SSH at the public name noted in outputs.
 
-```
+```bash
 $ terraform apply
 ...
 Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

--- a/backend_modules/azure/README.md
+++ b/backend_modules/azure/README.md
@@ -40,6 +40,7 @@ Create a symbolic link to the `azure` backend module directory inside the `modul
 Most modules have configuration settings specific to the Azure backend, those are set via the `provider_settings` map variable. They are all described below.
 
 ### Base Module
+
 Available provider settings for the base module:
 
 | Variable name       | Type   | Default value   | Description                                                                                                     |
@@ -53,6 +54,7 @@ Available provider settings for the base module:
 | public_key_location | string | `null`          | Location for access public key                                                                                  |
 
 An example follows:
+
 ```hcl-terraform
 ...
 provider_settings = {
@@ -80,6 +82,7 @@ Following settings apply to all modules that create one or more hosts of the sam
 | vm_size             | string   | `Standard_B4ms`([apart from specific roles](Default-values-by-role))  | [Virtual Machine series](https://azure.microsoft.com/en-us/pricing/details/virtual-machines/series/)  |
 
 An example follows:
+
 ```hcl
 ...
   provider_settings = {
@@ -94,6 +97,7 @@ An example follows:
 - `volume_snapshot`: name of the volume snapshot to be used as a base for the new disk (default value: `null`)
 
  An example follows:
+
  ``` hcl
  data "azurerm_snapshot" "repodisk-snapshot" {
      volume_snapshot                = "snapshot disk name"

--- a/backend_modules/azure/README.md
+++ b/backend_modules/azure/README.md
@@ -1,4 +1,4 @@
- # Azure-specific configuration
+# Azure-specific configuration
 
 ## Overview
 

--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -43,6 +43,7 @@ Available provider settings for the base module:
 | additional_network | string | `null`        | A network mask for PXE tests                                             |
 
 An example follows:
+
 ```hcl-terraform
 ...
 provider_settings = {
@@ -68,6 +69,7 @@ Following settings apply to all modules that create one or more hosts of the sam
 | xslt            | string         | `null` ([apart from specific roles](Default-values-by-role)) | XSLT contents to apply on the libvirt domain                                               |
 
 An example follows:
+
 ```hcl-terraform
 ...
 provider_settings = {
@@ -86,6 +88,7 @@ provider_settings = {
  * `pool = <String>` storage were the volume should be created (default value `default`)
 
  An example follows:
+
  ``` hcl-terraform
 volume_provider_settings = {
   pool = "ssd"
@@ -139,6 +142,7 @@ Finally, the images come with serial console support, so you can use
 ```
 virsh console suma32pg
 ```
+
 especially in the case the network is not working and you need to debug it, or if the images have difficulties booting.
 
 ## Only upload a subset of available images

--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -2,30 +2,30 @@
 
 ## First-time configuration
 
- - copy `main.tf.libvirt.example` to `main.tf`
- - if your VMs are to be deployed on an external libvirt host:
-   - change the libvirt connection URI in the `provider` section. Typically it has the form `qemu+ssh://<USER>@<HOST>/system` assuming that `<USER>` has passwordless SSH access to `<HOST>`
-   - set up bridged networking:
-     - ensure your target libvirt host has a bridge device on the network you want to expose your machines on ([NetworkManager instructions](https://www.xmodulo.com/configure-linux-bridge-network-manager-ubuntu.html), refer to distro-specific instructions if you are not using NetworkManager)
-     - uncomment the `bridge` variable declaration in the `base` module and add proper device name (eg. `br1`)
-     - set the `network_name` variable declaration to `null` or remove it
-     - optionally specify fixed MAC addresses by adding `mac = "CA:FE:BA:BE:00:01"` lines to VM modules
-     - if configuration does not work, double check your firewall rules
-   - if other sumaform users deploy to the same host, or different bridged hosts in the same network, uncomment the `name_prefix` variable declaration in the `base` module to specify a unique prefix for your VMs
- - complete the `cc_password` variable in the `base` module
- - make sure that:
-   - either your target libvirt host has a storage pool named `default`
-   - or you [create one](https://documentation.suse.com/sles/12-SP4/html/SLES-all/cha-libvirt-storage.html#sec-libvirt-storage-vmm-addpool)
-   - or you specify a different name by uncommenting the `pool` variable declaration in the `base` module
- - if you are not using bridged networking, make sure that:
-   - either your target libvirt host has a NAT network which is named `default`
-   - or you [create one](https://documentation.suse.com/sles/12-SP4/html/SLES-all/cha-libvirt-networks.html#libvirt-networks-virtual-vmm-define)
-     - Note: ipv6 is configured by default on all VMs created by sumaform, so make sure to enable ipv6 too (DHCPv6 is not necessary)
-   - or you specify a different name by uncommenting the `network_name` variable declaration in the `base` module
- - decide the set of virtual machines you want to run. Delete any `module` section relative to VMs you don't want to use and feel free to copy and paste to add more
- - Create a symbolic link to the `libvirt` backend module directory inside the `modules` directory: `cd modules && ln -sfn ../backend_modules/libvirt backend`
- - run `terraform init` to make sure Terraform has detected all modules
- - run `terraform apply` to actually have the VMs set up!
+- copy `main.tf.libvirt.example` to `main.tf`
+- if your VMs are to be deployed on an external libvirt host:
+  - change the libvirt connection URI in the `provider` section. Typically it has the form `qemu+ssh://<USER>@<HOST>/system` assuming that `<USER>` has passwordless SSH access to `<HOST>`
+  - set up bridged networking:
+    - ensure your target libvirt host has a bridge device on the network you want to expose your machines on ([NetworkManager instructions](https://www.xmodulo.com/configure-linux-bridge-network-manager-ubuntu.html), refer to distro-specific instructions if you are not using NetworkManager)
+    - uncomment the `bridge` variable declaration in the `base` module and add proper device name (eg. `br1`)
+    - set the `network_name` variable declaration to `null` or remove it
+    - optionally specify fixed MAC addresses by adding `mac = "CA:FE:BA:BE:00:01"` lines to VM modules
+    - if configuration does not work, double check your firewall rules
+  - if other sumaform users deploy to the same host, or different bridged hosts in the same network, uncomment the `name_prefix` variable declaration in the `base` module to specify a unique prefix for your VMs
+- complete the `cc_password` variable in the `base` module
+- make sure that:
+  - either your target libvirt host has a storage pool named `default`
+  - or you [create one](https://documentation.suse.com/sles/12-SP4/html/SLES-all/cha-libvirt-storage.html#sec-libvirt-storage-vmm-addpool)
+  - or you specify a different name by uncommenting the `pool` variable declaration in the `base` module
+- if you are not using bridged networking, make sure that:
+  - either your target libvirt host has a NAT network which is named `default`
+  - or you [create one](https://documentation.suse.com/sles/12-SP4/html/SLES-all/cha-libvirt-networks.html#libvirt-networks-virtual-vmm-define)
+    - Note: ipv6 is configured by default on all VMs created by sumaform, so make sure to enable ipv6 too (DHCPv6 is not necessary)
+  - or you specify a different name by uncommenting the `network_name` variable declaration in the `base` module
+- decide the set of virtual machines you want to run. Delete any `module` section relative to VMs you don't want to use and feel free to copy and paste to add more
+- Create a symbolic link to the `libvirt` backend module directory inside the `modules` directory: `cd modules && ln-sfn ../backend_modules/libvirt backend`
+- run `terraform init` to make sure Terraform has detected all modules
+- run `terraform apply` to actually have the VMs set up!
 
 ## libvirt backend specific variables
 

--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -125,7 +125,7 @@ module "base" {
 
 By default, the machines use Avahi (mDNS), and are configured on the `.tf.local` domain. Thus if your host is on the same network segment of the virtual machines you can simply use:
 
-```
+```bash
 ssh root@suma32pg.tf.local
 ```
 
@@ -139,7 +139,7 @@ Web access is on standard ports, so `firefox server.tf.local` will work as expec
 
 Finally, the images come with serial console support, so you can use
 
-```
+```bash
 virsh console suma32pg
 ```
 
@@ -182,8 +182,8 @@ module "base" {
 
 If you are using the `default`virtual network in the 192.168.122.1 network, you will have this interface:
 
-```
-$ sudo virsh net-list --all
+```bash
+$ sudo virsh net-list--all
  Name                 State      Autostart     Persistent
 ----------------------------------------------------------
  default              active     yes           yes
@@ -191,7 +191,7 @@ $ sudo virsh net-list --all
 
 You can edit the XML with virt-manager (do not forget to stop the interface before making changes, or they will be lost!) or with virsh:
 
-```
+```bash
 $ sudo virsh net-edit default
 ```
 
@@ -273,7 +273,7 @@ module "base" {
 
 Now edit `/etc/hosts` on the host machine and add your guests:
 
-```
+```config
 192.168.122.2 uyuniserver.suse.lab
 192.168.122.3 leap151.suse.lab
 192.168.122.4 win10.suse.lab
@@ -281,7 +281,7 @@ Now edit `/etc/hosts` on the host machine and add your guests:
 
 Finally, destroy and start again your libvirt network:
 
-```
+```bash
 $ sudo virsh net-destroy default && sudo virsh net-start default
 ```
 
@@ -293,7 +293,7 @@ These days most Linux distributions are using Network Manager for configuration 
 
 In case you want to double check whether you are using Network Manager or something else (e. g. wicked, networkd, etc), check for the service status:
 
-```
+```bash
 $ sudo systemctl status NetworkManager
 ● NetworkManager.service - Network Manager
 Loaded: loaded (/usr/lib/systemd/system/NetworkManager.service; enabled; vendor preset: disabled)
@@ -304,7 +304,7 @@ Active: active (running)
 
 or in case you are not running systemd:
 
-```
+```bash
 $ sudo service NetworkManager status
 * NetworkManager.service - Network Manager
 Loaded: loaded (/usr/lib/systemd/system/NetworkManager.service; enabled; vendor preset: disabled)
@@ -319,7 +319,7 @@ Some other query command may be required if you are running another operating sy
 
 If you are using NetworkManager on the host machine, tell it to control dnsmasq:
 
-```
+```bash
 $ sudo vi /etc/NetworkManager/conf.d/localdns.conf
 [main]
 plugins=keyfile
@@ -328,7 +328,7 @@ dns=dnsmasq
 
 But only for the `suse.lab` domain:
 
-```
+```bash
 $ sudo vi /etc/NetworkManager/dnsmasq.d/libvirt_dnsmasq.conf
 server=/suse.lab/192.168.122.1
 ```
@@ -337,7 +337,7 @@ server=/suse.lab/192.168.122.1
 
 If you are not using NetworkManager or do not want dnsmasq to be controlled by NetworkManager, use this configuration:
 
-```
+```bash
 $ sudo vi /etc/NetworkManager/NetworkManager.conf
 [main]
 plugins=keyfile
@@ -346,7 +346,7 @@ dns=none
 
 Tell your local dnsmasq to manage only `suse.lab`:
 
-```
+```bash
 $ sudo vi /etc/dnsmasq.conf
 listen-address=127.0.0.1
 interface=lo
@@ -360,7 +360,7 @@ local=/suse.lab/
 
 And add localhost to your /etc/resolv.conf:
 
-```
+```bash
 $ sudo vi /etc/resolv.conf
 # This should be the first nameserver entry in resolv.conf!
 nameserver 127.0.0.1
@@ -371,13 +371,13 @@ nameserver 127.0.0.1
 
 Finally, restart all services: libvirtd, dnsmasq and NetworkManager:
 
-```
+```bash
 $ sudo systemctl restart NetworkManager.service NetworkManager-dispatcher.service dnsmasq.service libvirtd.service libvirt-guests.service
 ```
 
 And test name resolution from the host:
 
-```
+```bash
 $ nslookup uyuniserver.suse.lab 127.0.0.1
 Server:         127.0.0.1
 Address:        127.0.0.1#53
@@ -398,7 +398,7 @@ $ nslookup 192.168.122.2 192.168.122.1
 
 and from the guests:
 
-```
+```bash
 $ nslookup uyuniserver.suse.lab 192.168.122.1
 Server:         192.168.122.1
 Address:        192.168.122.1#53

--- a/backend_modules/null/README.md
+++ b/backend_modules/null/README.md
@@ -9,7 +9,7 @@ Existing modules:
 - `base`
 - `bost`
 
-# Interface for other backend's
+## Interface for other backend's
 
 All `variable.tf` and `version.tf` present in these backend modules are shared with all other backend modules.
 The goal is to have a kind of interface that can be used but modules in `modules` directory and ensure compatibility between all backends.

--- a/backend_modules/ssh/README.md
+++ b/backend_modules/ssh/README.md
@@ -4,16 +4,16 @@ This backend, differently from others, assumes hosts already exist and can be ac
 
 ## First-time configuration
 
- - Copy `main.tf.ssh.example` to `main.tf`
- - Complete the missing information
- - Create a symbolic link to the `ssh` backend module directory inside the `modules` directory: `ln -sfn ../backend_modules/ssh modules/backend`
+- Copy `main.tf.ssh.example` to `main.tf`
+- Complete the missing information
+- Create a symbolic link to the `ssh` backend module directory inside the `modules` directory: `ln-sfn ../backend_modules/ssh modules/backend`
 
 ## Requirements
 
- - SSH access via password or private key to a user with root privileges
-    - Access through a [bastion host](https://en.wikipedia.org/wiki/Bastion_host) is also possible using password or private key
- - Machine must come with `salt` pre-installed
- - If additional_network is needed one should make sure it is set up correctly and have the IP mask for it (this backend will not create it)
+- SSH access via password or private key to a user with root privileges
+  - Access through a [bastion host](https://en.wikipedia.org/wiki/Bastion_host) is also possible using password or private key
+- Machine must come with `salt` pre-installed
+- If additional_network is needed one should make sure it is set up correctly and have the IP mask for it (this backend will not create it)
 
 ### Base module
 

--- a/backend_modules/ssh/README.md
+++ b/backend_modules/ssh/README.md
@@ -60,6 +60,7 @@ Following settings apply to all modules, such as `server`, `proxy`, `client`, `g
 | timeout             | string  | base module value | The timeout to wait for the connection to become available. Should be a value like 30s or 5m                                                                                                  |
 
 An example follows:
+
 ```hcl-terraform
  ...
  provider_settings = {


### PR DESCRIPTION
## What does this PR change?

Fixes
- outdated cucumber command in the testsuite README
- grammar/spelling
- code snippet syntax
- headings
- missing/empty lines
- listings
- bare URLs
All in all this will align the documents more with the Markdown language standard.

Adds
- `terraform validate` command in the base README to verify ones configuration