### PR TITLE
New parameter to allow not installing any kind of salt package

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -31,6 +31,7 @@ data "template_file" "user_data" {
     use_mirror_images   = var.base_configuration["use_mirror_images"]
     mirror              = var.base_configuration["mirror"]
     install_salt_bundle = var.install_salt_bundle
+    install_salt_minion = var.install_salt_minion
   }
 }
 
@@ -166,6 +167,7 @@ resource "null_resource" "provisioning" {
         use_os_released_updates   = var.use_os_released_updates
         use_os_unreleased_updates = var.use_os_unreleased_updates
         install_salt_bundle       = var.install_salt_bundle
+        install_salt_minion       = var.install_salt_minion
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
         additional_certs          = var.additional_certs
@@ -210,6 +212,7 @@ resource "null_resource" "provisioning" {
         use_os_released_updates   = var.use_os_released_updates
         use_os_unreleased_updates = var.use_os_unreleased_updates
         install_salt_bundle       = var.install_salt_bundle
+        install_salt_minion       = var.install_salt_minion
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
         additional_certs          = var.additional_certs

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -49,8 +49,10 @@ yum_repos:
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+%{ else }
+packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 
 runcmd:
@@ -84,8 +86,10 @@ yum_repos:
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+%{ else }
+packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 %{ endif }
 
@@ -132,8 +136,10 @@ yum_repos:
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+%{ else }
+packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 %{ endif }
 
@@ -348,8 +354,10 @@ runcmd:
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
+%{ else }
+packages: ["avahi-daemon", "qemu-guest-agent"]
 %{ endif }
 %{ endif }
 
@@ -362,8 +370,10 @@ runcmd:
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
+%{ else }
+packages: ["avahi-daemon", "qemu-guest-agent"]
 %{ endif }
 %{ endif }
 
@@ -404,8 +414,10 @@ runcmd:
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
+%{ else }
+packages: ["avahi-daemon", "qemu-guest-agent"]
 %{ endif }
 %{ endif }
 %{ if image == "debian11o" }
@@ -417,8 +429,10 @@ runcmd:
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent", "gnupg", "python3-apt"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "gnupg", "python3-apt"]
+%{ else }
+packages: ["avahi-daemon", "qemu-guest-agent", "gnupg", "python3-apt"]
 %{ endif }
 %{ endif }
 %{ if image == "debian10o" }
@@ -430,8 +444,10 @@ runcmd:
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
+%{ else }
+packages: ["avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
 %{ endif }
 %{ endif }
 %{ if image == "debian9o" }
@@ -442,8 +458,10 @@ runcmd:
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
+%{ else }
+packages: ["avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]
 %{ endif }
 %{ endif }
 
@@ -470,8 +488,10 @@ yum_repos:
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+%{ else }
+packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 
 %{ endif }
@@ -507,7 +527,7 @@ packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
 %{ if image == "opensuse153armo" }
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion"]
-%{ else }
+%{ elif install_salt_minion }
 packages: ["salt-minion"]
 %{ endif }
 

--- a/backend_modules/null/host/main.tf
+++ b/backend_modules/null/host/main.tf
@@ -6,6 +6,7 @@ resource "null_resource" "domain" {
     use_os_released_updates       = var.use_os_released_updates
     use_os_unreleased_updates     = var.use_os_unreleased_updates
     install_salt_bundle           = var.install_salt_bundle
+    install_salt_minion           = var.install_salt_minion
     additional_repos              = yamlencode(var.additional_repos)
     additional_repos_only         = var.additional_repos_only
     additional_certs              = yamlencode(var.additional_certs)

--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -52,6 +52,11 @@ variable "install_salt_bundle" {
   default     = false
 }
 
+variable "install_salt_minion" {
+  description = "use true to install the salt-minion package in the hosts"
+  default     = false
+}
+
 variable "quantity" {
   description = "number of hosts like this one"
   default     = 1

--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -7,6 +7,7 @@ module "client" {
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
+  install_salt_minion           = var.install_salt_minion
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only
   additional_packages           = var.additional_packages

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -56,6 +56,11 @@ variable "install_salt_bundle" {
   default     = false
 }
 
+variable "install_salt_minion" {
+  description = "use true to install the salt-minion package in the hosts"
+  default     = false
+}
+
 variable "quantity" {
   description = "number of hosts like this one"
   default     = 1

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -36,6 +36,8 @@ locals {
     host_key => lookup(var.host_settings[host_key], "name", null) if var.host_settings[host_key] != null ? contains(keys(var.host_settings[host_key]), "name") : false }
   install_salt_bundle       = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "install_salt_bundle", false) if var.host_settings[host_key] != null }
+  install_salt_minion       = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "install_salt_minion", true) if var.host_settings[host_key] != null }
 }
 
 module "server" {
@@ -90,6 +92,7 @@ module "proxy" {
   use_os_released_updates   = true
   ssh_key_path              = "./salt/controller/id_rsa.pub"
   install_salt_bundle = lookup(local.install_salt_bundle, "proxy", false)
+  install_salt_minion = lookup(local.install_salt_minion, "proxy", true)
 
   additional_repos  = lookup(local.additional_repos, "proxy", {})
   additional_repos_only  = lookup(local.additional_repos_only, "proxy", {})
@@ -117,6 +120,7 @@ module "suse-client" {
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "suse-client", false)
+  install_salt_minion     = lookup(local.install_salt_minion, "suse-client", false)
 
   additional_repos  = lookup(local.additional_repos, "suse-client", {})
   additional_repos_only  = lookup(local.additional_repos_only, "suse-client", {})
@@ -139,6 +143,7 @@ module "suse-minion" {
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "suse-minion", false)
+  install_salt_minion     = lookup(local.install_salt_minion, "suse-minion", true)
 
   additional_repos  = lookup(local.additional_repos, "suse-minion", {})
   additional_repos_only  = lookup(local.additional_repos_only, "suse-minion", {})
@@ -161,6 +166,7 @@ module "suse-sshminion" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
   install_salt_bundle     = lookup(local.install_salt_bundle, "suse-sshminion", false)
+  install_salt_minion     = lookup(local.install_salt_minion, "suse-sshminion", false)
 
   additional_repos  = lookup(local.additional_repos, "suse-sshminion", {})
   additional_repos_only  = lookup(local.additional_repos_only, "suse-sshminion", {})
@@ -183,6 +189,7 @@ module "redhat-minion" {
   auto_connect_to_master = false
   ssh_key_path           = "./salt/controller/id_rsa.pub"
   install_salt_bundle    = lookup(local.install_salt_bundle, "redhat-minion", false)
+  install_salt_minion    = lookup(local.install_salt_minion, "redhat-minion", true)
 
   additional_repos  = lookup(local.additional_repos, "redhat-minion", {})
   additional_repos_only  = lookup(local.additional_repos_only, "redhat-minion", {})
@@ -206,6 +213,7 @@ module "debian-minion" {
   auto_connect_to_master = false
   ssh_key_path           = "./salt/controller/id_rsa.pub"
   install_salt_bundle    = lookup(local.install_salt_bundle, "debian-minion", false)
+  install_salt_minion    = lookup(local.install_salt_minion, "debian-minion", true)
 
   additional_repos  = lookup(local.additional_repos, "debian-minion", {})
   additional_repos_only  = lookup(local.additional_repos_only, "debian-minion", {})
@@ -230,6 +238,7 @@ module "build-host" {
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   avahi_reflector         = var.avahi_reflector
   install_salt_bundle     = lookup(local.install_salt_bundle, "build-host", false)
+  install_salt_minion     = lookup(local.install_salt_minion, "build-host", true)
 
   additional_repos  = lookup(local.additional_repos, "build-host", {})
   additional_repos_only  = lookup(local.additional_repos_only, "build-host", {})
@@ -264,6 +273,7 @@ module "kvm-host" {
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "kvm-host", false)
+  install_salt_minion     = lookup(local.install_salt_minion, "kvm-host", true)
 
   additional_repos  = lookup(local.additional_repos, "kvm-host", {})
   additional_repos_only  = lookup(local.additional_repos_only, "kvm-host", {})
@@ -289,6 +299,7 @@ module "xen-host" {
   use_os_released_updates = true
   ssh_key_path            = "./salt/controller/id_rsa.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "xen-host", false)
+  install_salt_minion     = lookup(local.install_salt_minion, "xen-host", true)
 
   additional_repos  = lookup(local.additional_repos, "xen-host", {})
   additional_repos_only  = lookup(local.additional_repos_only, "xen-host", {})

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -8,6 +8,7 @@ module "host" {
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
+  install_salt_minion           = var.install_salt_minion
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only
   additional_certs              = var.additional_certs

--- a/modules/minion/main.tf
+++ b/modules/minion/main.tf
@@ -7,6 +7,7 @@ module "minion" {
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
+  install_salt_minion           = var.install_salt_minion
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only
   additional_packages           = var.additional_packages

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -81,6 +81,11 @@ variable "install_salt_bundle" {
   default     = false
 }
 
+variable "install_salt_minion" {
+  description = "use true to install the salt-minion package in the hosts"
+  default     = true
+}
+
 variable "quantity" {
   description = "number of hosts like this one"
   default     = 1

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -25,6 +25,7 @@ module "proxy" {
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
+  install_salt_minion           = var.install_salt_minion
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only
   additional_packages           = var.additional_packages

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -91,6 +91,11 @@ variable "install_salt_bundle" {
   default     = false
 }
 
+variable "install_salt_minion" {
+  description = "use true to install the salt-minion package in the hosts"
+  default     = false
+}
+
 variable "quantity" {
   description = "number of hosts like this one"
   default     = 1

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -24,6 +24,7 @@ module "server" {
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
+  install_salt_minion           = var.install_salt_minion
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only
   additional_certs              = var.additional_certs

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -187,6 +187,11 @@ variable "install_salt_bundle" {
   default     = false
 }
 
+variable "install_salt_minion" {
+  description = "use true to install the salt-minion package in the hosts"
+  default     = false
+}
+
 variable "traceback_email" {
   description = "recipient email address that will receive errors during usage"
   default     = null

--- a/modules/sshminion/main.tf
+++ b/modules/sshminion/main.tf
@@ -7,6 +7,7 @@ module "sshminion" {
   use_os_released_updates       = var.use_os_released_updates
   use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
+  install_salt_minion           = var.install_salt_minion
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only
   additional_packages           = var.additional_packages

--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -52,6 +52,11 @@ variable "install_salt_bundle" {
   default     = false
 }
 
+variable "install_salt_minion" {
+  description = "use true to install the salt-minion package in the hosts"
+  default     = false
+}
+
 variable "quantity" {
   description = "number of hosts like this one"
   default     = 1

--- a/modules/virthost/main.tf
+++ b/modules/virthost/main.tf
@@ -10,6 +10,7 @@ module "virthost" {
   use_os_released_updates   = var.use_os_released_updates
   use_os_unreleased_updates = var.use_os_unreleased_updates
   install_salt_bundle       = var.install_salt_bundle
+  install_salt_minion       = var.install_salt_minion
   additional_repos          = var.additional_repos
   additional_repos_only         = var.additional_repos_only
   additional_packages       = var.additional_packages

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -56,6 +56,11 @@ variable "install_salt_bundle" {
   default     = false
 }
 
+variable "install_salt_minion" {
+  description = "use true to install the salt-minion package in the hosts"
+  default     = true
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default     = null


### PR DESCRIPTION
## What does this PR change?

In order to test regular salt minion, we expect no salt package installed in the host where we will bootstrap the salt minion.


Related to card: https://github.com/SUSE/spacewalk/issues/16687
