### PR TITLE
Use proper "cobbler" settings file on newer Cobbler versions

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -42,6 +42,8 @@ test_repo_debian_updates:
       {% endif %}
 
 # modify cobbler to be executed from remote-machines..
+{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly"] %}
+{% set cobbler_use_settings_yaml = grains.get('product_version') | default('', true) in products_using_new_cobbler_version %}
 
 cobbler_configuration:
     service:
@@ -49,13 +51,23 @@ cobbler_configuration:
     - running
     - enable: True
     - watch :
+{% if cobbler_use_settings_yaml %}
+      - file : /etc/cobbler/settings.yaml
+{% else %}
       - file : /etc/cobbler/settings
+{% endif %}
     - require:
       - sls: server
     file.replace:
+{% if cobbler_use_settings_yaml %}
+    - name: /etc/cobbler/settings.yaml
+    - pattern: "redhat_management_permissive: false"
+    - repl: "redhat_management_permissive: true"
+{% else %}
     - name: /etc/cobbler/settings
     - pattern: "redhat_management_permissive: 0"
     - repl: "redhat_management_permissive: 1"
+{% endif %}
     - require:
       - sls: server
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem when deploying the "server" node on Cobbler versions higher than 3.3.0, where the settings file is now named `settings.yaml`.

Tracks: https://github.com/SUSE/spacewalk/issues/16538

**IMPORTANT NOTE: DO NOT MERGE THIS PR UNTIL WE HAVE COBBLER 3.3.2 AT HEAD AND UYUNI**