### PR TITLE
Fix products version for Uyuni to force Salt bundle usage

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -77,7 +77,7 @@ testsuite_salt_packages:
     - require:
       - sls: repos
 
-{% set products_to_use_salt_bundle = ["uyuni", "head", "4.3-released", "4.3-nightly"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,


### PR DESCRIPTION
## What does this PR change?

This PR fixes a problem detected on Uyuni Master testsuite caused by a typo on the list of products version where to force the usage of Salt Bundle