### PR TITLE
force the refresh to really have latest repos

### DIFF
--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -15,7 +15,7 @@ include:
 {% if grains['os'] == 'SUSE' %}
 refresh_repos:
   cmd.run:
-    - name: zypper --non-interactive --gpg-auto-import-keys refresh; exit 0
+    - name: zypper --non-interactive --gpg-auto-import-keys --force refresh; exit 0
 {% endif %}
 
 # WORKAROUND: see github:saltstack/salt#10852


### PR DESCRIPTION
## What does this PR change?

We sometimes have the case, that a normal refresh skip repos as they were just refreshed a minute ago, but the repo changed anyway. Do a force refresh to really get the latest packages.
