### PR TITLE
modify vendor files also when additional_repos_only is set

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -420,23 +420,6 @@ os_ltss_repo:
 
 {% endif %} {# grains['osfullname'] == 'SLES' #}
 
-allow_vendor_changes:
-  {% if grains['osfullname'] == 'Leap' %}
-  file.managed:
-    - name: /etc/zypp/vendors.d/opensuse
-    - makedirs: True
-    - contents: |
-        [main]
-        vendors = openSUSE,openSUSE Build Service,obs://build.suse.de/Devel:Galaxy,obs://build.opensuse.org
-  {% else %}
-  file.managed:
-    - name: /etc/zypp/vendors.d/suse
-    - makedirs: True
-    - contents: |
-        [main]
-        vendors = SUSE,openSUSE Build Service,obs://build.suse.de/Devel:Galaxy,obs://build.opensuse.org
-  {% endif %}
-
 install_recommends:
   file.comment:
     - name: /etc/zypp/zypp.conf

--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -1,4 +1,5 @@
 include:
+  - repos.vendor
   {% if not grains.get('additional_repos_only') %}
   - repos.default
   - repos.minion

--- a/salt/repos/vendor.sls
+++ b/salt/repos/vendor.sls
@@ -1,0 +1,17 @@
+allow_vendor_changes:
+  {% if grains['osfullname'] == 'Leap' %}
+  file.managed:
+    - name: /etc/zypp/vendors.d/opensuse
+    - makedirs: True
+    - contents: |
+        [main]
+        vendors = openSUSE,openSUSE Build Service,obs://build.suse.de/Devel:Galaxy,obs://build.opensuse.org
+  {% else %}
+  file.managed:
+    - name: /etc/zypp/vendors.d/suse
+    - makedirs: True
+    - contents: |
+        [main]
+        vendors = SUSE,openSUSE Build Service,obs://build.suse.de/Devel:Galaxy,obs://build.opensuse.org
+  {% endif %}
+


### PR DESCRIPTION
## What does this PR change?

Otherwise, we cannot add additional_repos via terraform to test, for
example, salt packages under development.


