### PR TITLE
download CA cert and key from a hub when setting up a peripheral server

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -49,6 +49,7 @@ module "server" {
   image                          = lookup(local.images, "server", "default")
   name                           = lookup(local.names, "server", "srv")
   auto_accept                    = false
+  download_private_ssl_key       = false
   disable_firewall               = false
   allow_postgres_connections     = false
   skip_changelog_import          = false

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -52,6 +52,7 @@ module "server" {
     susemanager = {
       activation_key = var.activation_key
     }
+    download_private_ssl_key       = var.download_private_ssl_key
     smt                            = var.smt
     server_username                = var.server_username
     server_password                = var.server_password

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -53,7 +53,7 @@ variable "auto_register" {
 }
 
 variable "download_private_ssl_key" {
-  description = "copy SSL certificates from the server upon deployment"
+  description = "copy SSL certificates from the hub server upon deployment"
   default     = true
 }
 

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -52,6 +52,11 @@ variable "auto_register" {
   default     = true
 }
 
+variable "download_private_ssl_key" {
+  description = "copy SSL certificates from the server upon deployment"
+  default     = true
+}
+
 variable "activation_key" {
   description = "an Activation Key to be used when registering to another Server"
   default     = null

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -27,7 +27,7 @@ server_packages:
       - sls: repos
       - sls: server.firewall
 
-{% if grains.get('download_private_ssl_key') and grains.get('server') %}
+{% if 'minion' in grains.get('roles') and grains.get('server') and grains.get('download_private_ssl_key') %}
 
 ssl-build-directory:
   file.directory:

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -27,6 +27,39 @@ server_packages:
       - sls: repos
       - sls: server.firewall
 
+{% if grains.get('download_private_ssl_key') and grains.get('server') %}
+
+ssl-build-directory:
+  file.directory:
+    - name: /root/ssl-build
+
+ssl-building-trusted-cert:
+  file.managed:
+    - name: /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT
+    - source: http://{{grains['server']}}/pub/RHN-ORG-TRUSTED-SSL-CERT
+    - source_hash: http://{{grains['server']}}/pub/RHN-ORG-TRUSTED-SSL-CERT.sha512
+    - requires:
+      - file: ssl-build-directory
+
+ssl-building-private-ssl-key:
+  file.managed:
+    - name: /root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY
+    - source: http://{{grains['server']}}/pub/RHN-ORG-PRIVATE-SSL-KEY
+    - source_hash: http://{{grains['server']}}/pub/RHN-ORG-PRIVATE-SSL-KEY.sha512
+    - requires:
+      - file: ssl-build-directory
+
+ssl-building-ca-configuration:
+  file.managed:
+    - name: /root/ssl-build/rhn-ca-openssl.cnf
+    - source: http://{{grains['server']}}/pub/rhn-ca-openssl.cnf
+    - source_hash: http://{{grains['server']}}/pub/rhn-ca-openssl.cnf.sha512
+    - requires:
+      - file: ssl-build-directory
+
+{% endif %}
+
+
 {% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' and not grains.get('server_registration_code') %}
 product_package_installed:
    cmd.run:


### PR DESCRIPTION
## What does this PR change?

A Hub environment require 1 Root CA for the hub and all peripheral servers to make the reporting feature work.
Download CA cert and key from "server" and re-use it when generating the SSL server certificates
