### PR TITLE
Devel parameter: extend login timeout

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -288,6 +288,7 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
    * `disable_download_tokens`: disable package token download checks. Set to `false` to enable checking
    * `forward_registration`: enable forwarding of registrations to SCC (default off)
    *  `server_registration_code` : register server with SCC key and enable modules needed for SUMA Server during deployment. Set to `null` by default to use repositories for deployment
+   * `login_timeout`: define how long the webUI login cookie is valid (in seconds). Set to null by default to leave it up to the application default value.
 
 
 ## Adding channels to SUSE Manager Servers

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -76,6 +76,7 @@ module "server" {
     forward_registration           = var.forward_registration
     server_registration_code       = var.server_registration_code
     accept_all_ssl_protocols       = var.accept_all_ssl_protocols
+    login_timeout                  = var.login_timeout
   }
 
 

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -259,3 +259,8 @@ variable "accept_all_ssl_protocols" {
   description = "Turn to true to force Apache to accept a greater range of protocol versions"
   default     = false
 }
+
+variable "login_timeout" {
+  description = "How long the webUI login session cookie is valid"
+  default     = null
+}

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -89,3 +89,14 @@ substitute_email_traceback_address:
     - require:
         - cmd: server_setup
 {% endif %}
+
+{% if grains.get('login_timeout') %}
+extend_login_timeout:
+  file.replace:
+    - name: /etc/rhn/rhn.conf
+    - pattern: web.session_database_lifetime.*
+    - repl: web.session_database_lifetime = {{ grains['login_timeout'] }}
+    - append_if_not_found: True
+    - require:
+        - cmd: server_setup
+{% endif %}


### PR DESCRIPTION
## What does this PR change?

## tl;dr
At _sumaforming time_ set the webUI `login_timeout` as desired.


## Verbose reason

At development time you don't really want to re-login again during the day while you are going back and forth fir a bit more than just 1 hour. This _optional_ parameters overrides the default one by editing the `/etc/rhn/rhn.conf` file in the same way the normal user should in the real life to change that value.


### Review

Note: review asked to some random developer