### PR TITLE
fix: Enable login timeout

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -78,7 +78,6 @@ module "server" {
     server_registration_code       = var.server_registration_code
     accept_all_ssl_protocols       = var.accept_all_ssl_protocols
     login_timeout                  = var.login_timeout
-    login_timeout_minutes          = var.login_timeout / 60
   }
 
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -78,6 +78,7 @@ module "server" {
     server_registration_code       = var.server_registration_code
     accept_all_ssl_protocols       = var.accept_all_ssl_protocols
     login_timeout                  = var.login_timeout
+    login_timeout_minutes          = var.login_timeout / 60
   }
 
 

--- a/salt/server/tomcat.sls
+++ b/salt/server/tomcat.sls
@@ -17,6 +17,17 @@ tomcat_config:
 
 {% endif %}
 
+{% if grains.get('login_timeout') %}
+extend_login_timeout:
+  file.replace:
+    - name: /srv/tomcat/webapps/rhn/WEB-INF/web.xml
+    - pattern: <session-timeout>*
+    - repl: <session-timeout>{{ grains['login_timeout_minutes'] }}</session-timeout>
+    - append_if_not_found: True
+    - require:
+        - cmd: server_setup
+{% endif %}
+
 tomcat_service:
   service.running:
     - name: tomcat

--- a/salt/server/tomcat.sls
+++ b/salt/server/tomcat.sls
@@ -22,7 +22,7 @@ extend_login_timeout:
   file.replace:
     - name: /srv/tomcat/webapps/rhn/WEB-INF/web.xml
     - pattern: <session-timeout>*
-    - repl: <session-timeout>{{ grains['login_timeout_minutes'] }}</session-timeout>
+    - repl: <session-timeout>{{ grains['login_timeout'] / 60 }}</session-timeout>
     - append_if_not_found: True
     - require:
         - cmd: server_setup

--- a/salt/server/tomcat.sls
+++ b/salt/server/tomcat.sls
@@ -22,7 +22,7 @@ extend_login_timeout:
   file.replace:
     - name: /srv/tomcat/webapps/rhn/WEB-INF/web.xml
     - pattern: <session-timeout>*
-    - repl: <session-timeout>{{ grains['login_timeout'] / 60 }}</session-timeout>
+    - repl: <session-timeout>{{ grains['login_timeout'] // 60 }}</session-timeout>
     - append_if_not_found: True
     - require:
         - cmd: server_setup


### PR DESCRIPTION
## What does this PR change?

This will also adjust the timeout in web.xml in Tomcat according to [rhn_web.conf](https://github.com/uyuni-project/uyuni/blob/d59de49972ee98d8542c852e4e9d24f4d8f5bd42/web/conf/rhn_web.conf#L29-L31).

According to the [Jinja docs](https://jinja.palletsprojects.com/en/3.0.x/templates/#math) we can use `//` to return a truncated integer result of the division that is made.
> //
Divide two numbers and return the truncated integer result. {{ 20 // 7 }} is 2.
