### PR TITLE
Add `login_timeout` variable to `cucumber_testsuite`

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -69,6 +69,7 @@ module "server" {
   additional_repos               = lookup(local.additional_repos, "server", {})
   additional_repos_only          = lookup(local.additional_repos_only, "server", {})
   additional_packages            = lookup(local.additional_packages, "server", [])
+  login_timeout                  = var.login_timeout
 
   saltapi_tcpdump   = var.saltapi_tcpdump
   provider_settings = lookup(local.provider_settings_by_host, "server", {})

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -137,3 +137,8 @@ variable "provider_settings" {
   description = "Settings specific to the provider, see README_TESTING.md"
   default     = {}
 }
+
+variable "login_timeout" {
+  description = "How long the webUI login session cookie is valid"
+  default     = null
+}


### PR DESCRIPTION
## What does this PR change?

This will add the `login_timeout` variable that @ncounter indroduced to the `cucumber_testsuite` module.

Links:

* https://github.com/uyuni-project/sumaform/pull/1074
* https://github.com/uyuni-project/sumaform/pull/1079

