### PR TITLE
fix: Switch SLE15SP4 image from JeOS to Minimal

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -18,7 +18,7 @@ locals {
     sles15sp2       = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp2.x86_64.qcow2"
     sles15sp2o      = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/install/SLE-15-SP2-JeOS-GM/SLES15-SP2-JeOS.x86_64-15.2-OpenStack-Cloud-GM.qcow2"
     sles15sp3o      = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/install/SLE-15-SP3-JeOS-GM/SLES15-SP3-JeOS.x86_64-15.3-OpenStack-Cloud-GM.qcow2"
-    sles15sp4o      = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/install/SLE-15-SP4-JeOS-Beta3-202201/SLES15-SP4-JeOS.x86_64-15.4-OpenStack-Cloud-Beta3-202201.qcow2"
+    sles15sp4o      = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/install/SLE-15-SP4-Minimal-Snapshot-202204-2/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-Snapshot-202204-2.qcow2"
     sles11sp4       = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles11sp4.x86_64.qcow2"
     sles12sp3       = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp3.x86_64.qcow2"
     sles12sp4       = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp4.x86_64.qcow2"

--- a/salt/mirror/etc/mirror-images.conf
+++ b/salt/mirror/etc/mirror-images.conf
@@ -14,7 +14,7 @@ http://download.suse.de/install/SLE-15-SP2-JeOS-GM/SLES15-SP2-JeOS.x86_64-15.2-O
 http://download.suse.de/install/SLE-12-SP4-JeOS-GM/SLES12-SP4-JeOS.x86_64-12.4-OpenStack-Cloud-GM.qcow2
 http://download.suse.de/install/SLE-12-SP5-JeOS-GM/SLES12-SP5-JeOS.x86_64-12.5-OpenStack-Cloud-GM.qcow2
 http://download.suse.de/install/SLE-15-SP3-JeOS-GM/SLES15-SP3-JeOS.x86_64-15.3-OpenStack-Cloud-GM.qcow2
-http://download.suse.de/install/SLE-15-SP4-JeOS-Beta3-202201/SLES15-SP4-JeOS.x86_64-15.4-OpenStack-Cloud-Beta3-202201.qcow2
+http://download.suse.de/install/SLE-15-SP4-Minimal-Snapshot-202204-2/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-Snapshot-202204-2.qcow2
 http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
 http://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
 http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img


### PR DESCRIPTION
## What does this PR change?

JeOS does not exist anylonger and is now called "Minimal". This adjusts
the URLs for SLE15SP4 and fixes #1083.
