### PR TITLE
Update image value, opensuse153 doesn't match the ami collection

### DIFF
--- a/main.tf.aws.example
+++ b/main.tf.aws.example
@@ -66,7 +66,7 @@ module "server" {
   base_configuration = local.base_configuration
 
   name            = "server"
-  image           = "opensuse153"
+  image           = "opensuse153o"
   product_version = "uyuni-release"
 
   provider_settings = {  }
@@ -77,7 +77,7 @@ module "minion" {
   base_configuration = local.base_configuration
 
   name                 = "minion"
-  image                = "opensuse153"
+  image                = "opensuse153o"
   server_configuration = module.server.configuration
   product_version      = "uyuni-release"
 }


### PR DESCRIPTION
## What does this PR change?

Update image value in main.tf.aws.example to match ami collection
