### PR TITLE
Why would we install the bundle on a trad client?

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -112,10 +112,6 @@ host_settings = {
     additional_packages = [ "venv-salt-minion" ]
     install_salt_bundle = true
   }
-  suse-client = {
-    additional_packages = [ "venv-salt-minion" ]
-    install_salt_bundle = true
-  }
   suse-minion = {
     additional_packages = [ "venv-salt-minion" ]
     install_salt_bundle = true


### PR DESCRIPTION
## What does this PR change?

Small doc fix: I don't think it makes sense to install the bundle on a traditional client.
