### PR TITLE
Fix: rename duplicate salt state id

### DIFF
--- a/salt/server/tomcat.sls
+++ b/salt/server/tomcat.sls
@@ -18,7 +18,7 @@ tomcat_config:
 {% endif %}
 
 {% if grains.get('login_timeout') %}
-extend_login_timeout:
+extend_tomcat_login_timeout:
   file.replace:
     - name: /srv/tomcat/webapps/rhn/WEB-INF/web.xml
     - pattern: <session-timeout>*


### PR DESCRIPTION
## What does this PR change?

$subject

Duplicate ID: see [`salt/server/init.sls`](https://github.com/uyuni-project/sumaform/blob/master/salt/server/init.sls#L131)