### PR TITLE
add iptables package to sshminion to test jumphost functionality

### DIFF
--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -16,6 +16,9 @@ suse_minion_cucumber_requisites:
     - pkgs:
       - aaa_base-extras
       - ca-certificates
+{%- if 'sshminion' in grains.get('roles') %}
+      - iptables
+{%- endif %}
     {% if 'build_image' not in grains.get('product_version') | default('', true) %}
     - require:
       - sls: repos


### PR DESCRIPTION
## What does this PR change?

The testsuite got a feature to test Proxy as jumphost. This try to forbid direct access from server to sshminion using iptables
firewall rule. For this we need to have iptables installed.
