### PR TITLE
Enable LTSS repos for SLE15SP2 instances

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -394,10 +394,9 @@ os_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/
     - refresh: True
 
-# uncomment when it goes LTSS
-# os_ltss_repo:
-#   pkgrepo.managed:
-#     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
 
 {% endif %} {# '15.2' == grains['osrelease'] #}
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue we are getting in our SUMA 4.1 and 4.2 deployments because an issue when installing Salt 3004 in the SLE15SP2 instances.

The problem is that Salt 3004 requires two new dependencies `python3-contextvars` and `python3-immutables`. These packages are released for SLE15SP2 in the LTSS repos, which is not yet enabled in sumaform for those instances.

This PR simply enabled the LTSS repos for SLE15SP2.