### PR TITLE
set product tree to Beta on HEAD

### DIFF
--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -137,3 +137,14 @@ extend_login_timeout:
     - require:
         - cmd: server_setup
 {% endif %}
+
+{% if 'head' in grains.get('product_version') %}
+change_product_tree_to_beta:
+  file.replace:
+    - name: /etc/rhn/rhn.conf
+    - pattern: java.product_tree_tag = .*\n
+    - repl: java.product_tree_tag = Beta
+    - append_if_not_found: True
+    - require:
+      - cmd: server_setup
+{% endif %}


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

If the product being deployed is HEAD, then we should change the flag "java.product_tree_tag = Beta"

Implementation of https://github.com/SUSE/spacewalk/issues/17928
