### PR TITLE
Fix installation of containerized proxy systemd services

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -43,15 +43,30 @@ proxy-packages:
 {% if install_proxy_container_packages %}
 
 {% if 'head' in grains.get('product_version') %}
-    {% set proxy_rpm_download = 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/noarch/' %}
+    {% set client_tools_repo = grains.get("mirror") | default("download.suse.de/ibs", true) ~ '/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/' %}
 {% else %}
-    {% set proxy_rpm_download = 'http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/noarch/' %}
+    {% set client_tools_repo = grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/' %}
 {% endif %}
+
+proxy_client_tools_repo:
+  pkgrepo.managed:
+    - baseurl: {{ client_tools_repo }}
+    - refresh: True
 
 proxy-container-packages:
   pkg.installed:
-    - sources:
-      - uyuni-proxy-systemd-services: {{proxy_rpm_download}}/uyuni-proxy-systemd-services.rpm
+    - pkgs:
+      - uyuni-proxy-systemd-services
+    - require:
+      - pkgrepo: proxy_client_tools_repo
+      - sls: repos
+
+# Remove the client tools repo as it would lead to conflicts on a proxy
+proxy_client_tools_repo_removed:
+  pkgrepo.absent:
+    - name: proxy_client_tools_repo
+    - require:
+      - pkg: proxy-container-packages
 {% endif %}
 
 {% if '4' in grains['product_version'] and grains['osfullname'] != 'Leap' and 'build_image' not in grains.get('product_version') %}


### PR DESCRIPTION
## What does this PR change?

This package lives in the client tools repo, but to reduce the impact on
the testsuite we decided to reuse the proxy machine for containerized
proxy tests.

To avoid manual download and install of the RPM as this leads to issues,
temporarily add the client tools repo to the proxy.