### PR TITLE
use opensuse leap 15.4 for uyuni master

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -10,6 +10,7 @@ locals {
     amazonlinux2o   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cdn.amazonlinux.com"}/os-images/2.0.20210721.2/kvm/amzn2-kvm-2.0.20210721.2-x86_64.xfs.gpt.qcow2"
     opensuse152o    = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2"
     opensuse153o    = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+    opensuse154o    = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
     opensuse153armo = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-ARM-JeOS-efi.aarch64.qcow2"
     sles15          = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15.x86_64.qcow2"
     sles15o         = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/install/SLE-15-JeOS-GM/SLES15-JeOS.x86_64-15.0-OpenStack-Cloud-GM.qcow2"

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -13,7 +13,7 @@ variable "images" {
     "4.3-beta"       = "sles15sp4o"
     "4.3-build_image"= "sles15sp4o"
     "head"           = "sles15sp4o"
-    "uyuni-master"   = "opensuse153o"
+    "uyuni-master"   = "opensuse154o"
     "uyuni-released" = "opensuse153o"
     "uyuni-pr"       = "opensuse153o"
   }

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -13,7 +13,7 @@ variable "images" {
     "4.3-beta"       = "sles15sp4o"
     "4.3-build_image"= "sles15sp4o"
     "head"           = "sles15sp4o"
-    "uyuni-master"   = "opensuse153o"
+    "uyuni-master"   = "opensuse154o"
     "uyuni-released" = "opensuse153o"
     "uyuni-pr"       = "opensuse153o"
   }

--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -490,6 +490,8 @@ http:
     archs: [x86_64]
   - url: http://download.opensuse.org/update/leap/15.3/sle
     archs: [x86_64]
+  - url: http://download.opensuse.org/update/leap/15.4/sle
+    archs: [x86_64]
 
   # Testsuite dummy packages for testing repo
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm
@@ -520,19 +522,20 @@ http:
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3
     archs: [x86_64]
-
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.4
+    archs: [x86_64]
   # Jenkins
   - url: http://download.opensuse.org/repositories/devel:/tools:/building/SLE_15_SP1
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/devel:/tools:/building/SLE_15_SP2
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/devel:/tools:/building/openSUSE_Leap_15.2
+  - url: http://download.opensuse.org/repositories/devel:/tools:/building/15.3
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/devel:/tools:/building/openSUSE_Leap_15.3
+  - url: http://download.opensuse.org/repositories/devel:/tools:/building/15.4
     archs: [x86_64]
 
   # Uyuni Master
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.3/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.4/
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/
     archs: [x86_64]


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Change base OS image for uyuni master to opensuse leap 15.4
