### PR TITLE
Disable JMX ports per default

### DIFF
--- a/salt/server/taskomatic.sls
+++ b/salt/server/taskomatic.sls
@@ -7,7 +7,28 @@ taskomatic_config:
   file.replace:
     - name: /etc/rhn/taskomatic.conf
     - pattern: JAVA_OPTS=""
-    - repl: JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['fqdn'] }}:8001,server=y,suspend=n -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['fqdn'] }}"
+    {% if grains['hostname'] and grains['domain'] %}
+    - repl: JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['hostname'] }}.{{ grains['domain'] }}:8001,server=y,suspend=n"
+    {% else %}
+    - repl: JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['fqdn'] }}:8001,server=y,suspend=n"
+    {% endif %}
+    - require:
+      - sls: server.rhn
+
+taskomatic_config_jmx:
+  file.append:
+    - name: /etc/rhn/taskomatic.conf
+    {% if grains['hostname'] and grains['domain'] %}
+    - text: |
+
+        # Add these options and restart taskomatic for remote monitoring via Java Managent Extensions (JMX)
+        # -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['hostname'] }}.{{ grains['domain'] }}
+    {% else %}
+    - text: |
+
+        # Add these options and restart taskomatic for remote monitoring via Java Managent Extensions (JMX)
+        # -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['fqdn'] }}
+    {% endif %}
     - require:
       - sls: server.rhn
 

--- a/salt/server/tomcat.sls
+++ b/salt/server/tomcat.sls
@@ -8,9 +8,26 @@ tomcat_config:
     - name: /etc/sysconfig/tomcat
     - pattern: 'JAVA_OPTS="(?!-Xdebug)(.*)"'
     {% if grains['hostname'] and grains['domain'] %}
-    - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['hostname'] }}.{{ grains['domain'] }}:8000,server=y,suspend=n -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['hostname'] }}.{{ grains['domain'] }} \1"'
+    - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['hostname'] }}.{{ grains['domain'] }}:8000,server=y,suspend=n \1"'
     {% else %}
-    - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['fqdn'] }}:8000,server=y,suspend=n -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['fqdn'] }} \1"'
+    - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['fqdn'] }}:8000,server=y,suspend=n \1"'
+    {% endif %}
+    - require:
+      - sls: server.rhn
+
+tomcat_config_jmx:
+  file.append:
+    - name: /etc/sysconfig/tomcat
+    {% if grains['hostname'] and grains['domain'] %}
+    - text: |
+
+        # Add these options and restart tomcat for remote monitoring via Java Managent Extensions (JMX)
+        # -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['hostname'] }}.{{ grains['domain'] }}
+    {% else %}
+    - text: |
+
+        # Add these options and restart tomcat for remote monitoring via Java Managent Extensions (JMX)
+        # -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['fqdn'] }}
     {% endif %}
     - require:
       - sls: server.rhn


### PR DESCRIPTION
## What does this PR change?

This patch would disable remote monitoring via Java Management Extensions (JMX) per default for development servers, while allowing to easily enable it from the config file.
