### PR TITLE
Change inheritance of pool when no variable is set

### DIFF
--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -87,7 +87,7 @@ provider_settings = {
 
 `suse_manager`, `proxy` and `mirror` modules have configuration settings specific for extra data volumes, those are set via the `volume_provider_settings` map variable. They are described below.
 
- * `pool = <String>` storage were the volume should be created (default value `default`)
+ * `pool = <String>` storage were the volume should be created (default value inherits from base module provider settings pool)
 
  An example follows:
 

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -60,7 +60,7 @@ resource "libvirt_volume" "data_disk" {
   name  = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}-data-disk"
   // needs to be converted to bytes
   size  = (var.additional_disk_size == null? 0: var.additional_disk_size) * 1024 * 1024 * 1024
-  pool  = lookup(var.volume_provider_settings, "pool", "default")
+  pool  = lookup(var.volume_provider_settings, "pool", var.base_configuration["pool"])
   count = var.additional_disk_size == null? 0 : var.additional_disk_size > 0 ? var.quantity : 0
 }
 


### PR DESCRIPTION
## What does this PR change?

Change inheritance of pool when no variable is set. From using the default pool to using the pool that is defined in the base module. 
