### PR TITLE
add support for rocky linux 8 on libvirt backend

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -3,6 +3,7 @@ locals {
   images_used = var.use_shared_resources ? [] : var.images
   image_urls = {
     almalinux8o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://repo.almalinux.org"}/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-latest.x86_64.qcow2"
+    rocky8o         = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.rockylinux.org"}/pub/rocky/8.6/images/Rocky-8-GenericCloud.latest.x86_64.qcow2"
     oraclelinux8o   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://yum.oracle.com"}/templates/OracleLinux/OL8/u6/x86_64/OL8U6_x86_64-kvm-b126.qcow"
     centos6o        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2"
     centos7         = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/uyuni-project/sumaform-images/releases/download/4.3.0/centos7.qcow2"

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -499,7 +499,7 @@ packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
 %{ endif }
 
 %{ endif }
-%{ if image == "oraclelinux8o" }
+%{ if image == "rocky8o" }
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -518,13 +518,37 @@ yum_repos:
     name: epel
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns"]
 %{ else }
+packages: ["avahi", "nss-mdns", "salt-minion"]
+%{ endif }
+
+%{ endif }
+%{ if image == "oraclelinux8o" }
+yum_repos:
+  # repo for salt
+  tools_pool_repo:
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8
+    enabled: true
+    gpgcheck: false
+    name: tools_pool_repo
+    priority: 98
+  # repo for nss-mdns
+  epel:
+    baseurl: http://download.fedoraproject.org/pub/epel/8/$basearch
+    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: epel
+
+  %{ if install_salt_bundle }
+packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+  %{ else }
 packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
-%{ endif }
-
-%{ endif }
-
+  %{ endif }
+  
+  %{ endif }
 %{ if image == "opensuse153armo" }
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion"]


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Add support to deploy rocky linux 8 on libvirt backend.
Implements: https://github.com/SUSE/spacewalk/issues/16319

Looks like some of the mirrors have problems with the http response status which leads to inconsistent errors when downloading the image file.
I will try to find which one is, and try to contact someone from rocky linux.