### PR TITLE
change tools repo for RHEL based os to use EL8

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -98,7 +98,7 @@ bootcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
-    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -476,7 +476,7 @@ packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 yum_repos:
   # repo for salt
   tools_pool_repo:
-    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
     failovermethod: priority
     enabled: true
     gpgcheck: false

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -544,10 +544,16 @@ suse_res6_key:
     - watch:
       - file: suse_res6_key
 {% else %}
+
+{% set centos_client_tool_prefix = 'EL' %}
+{% if release < 8 %}
+{% set centos_client_tool_prefix = 'CentOS' %}
+{% endif %}
+
 tools_pool_repo:
   pkgrepo.managed:
     - humanname: tools_pool_repo
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS{{ release }}-Uyuni-Client-Tools/CentOS_{{ release }}/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/{{centos_client_tool_prefix}}{{ release }}-Uyuni-Client-Tools/{{centos_client_tool_prefix}}_{{ release }}/
     - refresh: True
     - priority: 98
     - require:
@@ -573,13 +579,19 @@ tools_update_repo:
     - require:
       - cmd: galaxy_key
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
+
+{% set centos_client_tool_prefix = 'EL' %}
+{% if release < 8 %}
+{% set centos_client_tool_prefix = 'CentOS' %}
+{% endif %}
+
 tools_update_repo:
   pkgrepo.managed:
     - humanname: tools_update_repo
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/CentOS{{ release }}-Uyuni-Client-Tools/CentOS_{{ release }}/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/{{centos_client_tool_prefix}}{{ release }}-Uyuni-Client-Tools/{{centos_client_tool_prefix}}_{{ release }}/
     - refresh: True
     - gpgcheck: 1
-    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/CentOS{{ release }}-Uyuni-Client-Tools/CentOS_{{ release }}/repodata/repomd.xml.key
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/{{centos_client_tool_prefix}}{{ release }}-Uyuni-Client-Tools/{{centos_client_tool_prefix}}_{{ release }}/repodata/repomd.xml.key
     - priority: 98
     - require:
       - cmd: uyuni_key


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Centos tools repository are out of support and we should use EL8 tool for all rhel based systems from now on.