### PR TITLE
final preparation to support 4.3

### DIFF
--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -150,10 +150,10 @@ scc:
     - SLE-Product-SUSE-Manager-Server-4.2-Updates
     - SLE-Module-SUSE-Manager-Server-4.2-Pool
     - SLE-Module-SUSE-Manager-Server-4.2-Updates
-    #- SLE-Product-SUSE-Manager-Server-4.3-Pool
-    #- SLE-Product-SUSE-Manager-Server-4.3-Updates
-    #- SLE-Module-SUSE-Manager-Server-4.3-Pool
-    #- SLE-Module-SUSE-Manager-Server-4.3-Updates
+    - SLE-Product-SUSE-Manager-Server-4.3-Pool
+    - SLE-Product-SUSE-Manager-Server-4.3-Updates
+    - SLE-Module-SUSE-Manager-Server-4.3-Pool
+    - SLE-Module-SUSE-Manager-Server-4.3-Updates
     # SUSE Manager Proxy
     - SLE-Product-SUSE-Manager-Proxy-4.0-Pool
     - SLE-Product-SUSE-Manager-Proxy-4.0-Updates
@@ -167,10 +167,10 @@ scc:
     - SLE-Product-SUSE-Manager-Proxy-4.2-Updates
     - SLE-Module-SUSE-Manager-Proxy-4.2-Pool
     - SLE-Module-SUSE-Manager-Proxy-4.2-Updates
-    #- SLE-Product-SUSE-Manager-Proxy-4.3-Pool
-    #- SLE-Product-SUSE-Manager-Proxy-4.3-Updates
-    #- SLE-Module-SUSE-Manager-Proxy-4.3-Pool
-    #- SLE-Module-SUSE-Manager-Proxy-4.3-Updates
+    - SLE-Product-SUSE-Manager-Proxy-4.3-Pool
+    - SLE-Product-SUSE-Manager-Proxy-4.3-Updates
+    - SLE-Module-SUSE-Manager-Proxy-4.3-Pool
+    - SLE-Module-SUSE-Manager-Proxy-4.3-Updates
     # Retail Branch Server
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Pool
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Updates
@@ -184,10 +184,10 @@ scc:
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.2-Updates
     - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.2-Pool
     - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.2-Updates
-    #- SLE-Product-SUSE-Manager-Retail-Branch-Server-4.3-Pool
-    #- SLE-Product-SUSE-Manager-Retail-Branch-Server-4.3-Updates
-    #- SLE-Module-SUSE-Manager-Retail-Branch-Server-4.3-Pool
-    #- SLE-Module-SUSE-Manager-Retail-Branch-Server-4.3-Updates
+    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.3-Pool
+    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.3-Updates
+    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.3-Pool
+    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.3-Updates
     # SUSE Manager Tools
     - SLES11-SP4-SUSE-Manager-Tools
     - SLE-Manager-Tools12-Pool
@@ -396,48 +396,48 @@ http:
     archs: [amd64]
 
   # SUSE Manager 4.3 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3/SLE_15_SP4
-  #  archs: [x86_64]
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/ToSLE/SLE_15_SP4/
-  #  archs: [x86_64]
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3/images/repo/SLE-Module-SUSE-Manager-Testing-Overlay-4.3-POOL-x86_64-Media1/
-  #  archs: [x86_64]
-
-  # SLE 11 SP4 Manager Tools 4.3 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3/SLE_15_SP4
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/ToSLE/SLE_15_SP4/
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3/images/repo/SLE-Module-SUSE-Manager-Testing-Overlay-4.3-POOL-x86_64-Media1/
+    archs: [x86_64]
 
   # SLE 12 (GA and all SPs) Manager Tools 4.3 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/SLE12-SUSE-Manager-Tools/SLE_12/
+    archs: [x86_64]
 
   # SLE 15 Manager Tools 4.3 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/SLE15-SUSE-Manager-Tools/SLE_15/
+    archs: [x86_64]
 
   # RES 7 Manager Tools 4.3 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
+    archs: [x86_64]
 
   # RES 8 Manager Tools 4.3 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/RES8-SUSE-Manager-Tools/SUSE_RES-8_Update_standard
-  #  archs: [x86_64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/RES8-SUSE-Manager-Tools/SUSE_RES-8_Update_standard
+    archs: [x86_64]
 
   # Ubuntu 18.04 Manager Tools 4.3 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/Ubuntu18.04-SUSE-Manager-Tools/xUbuntu_18.04
-  #  archs: [amd64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/Ubuntu18.04-SUSE-Manager-Tools/SaltBundle/xUbuntu_18.04
+    archs: [amd64]
 
   # Ubuntu 20.04 Manager Tools 4.3 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/Ubuntu20.04-SUSE-Manager-Tools/xUbuntu_20.04
-  #  archs: [amd64]
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/Ubuntu20.04-SUSE-Manager-Tools/SaltBundle/xUbuntu_20.04/
+    archs: [amd64]
 
   # Debian 9 Manager Tools 4.3 devel
   #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/Debian9-SUSE-Manager-Tools/Debian_9
   #  archs: [amd64]
 
   # Debian 10 Manager Tools 4.3 devel
-  #- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.3:/Debian10-SUSE-Manager-Tools/Debian_10
-  #  archs: [amd64]
+  - url: https://download.suse.de/download/ibs/Devel:/Galaxy:/Manager:/4.3:/Debian10-SUSE-Manager-Tools/SaltBundle/Debian_10/
+    archs: [amd64]
+
+  # Debian 11 Manager Tools 4.3 devel
+  - url: https://download.suse.de/download/ibs/Devel:/Galaxy:/Manager:/4.3:/Debian11-SUSE-Manager-Tools/SaltBundle/Debian_11/
+    archs: [amd64]
 
   # SUSE Manager Head devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/SLE_15_SP3

--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -99,12 +99,6 @@ proxy_module_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Proxy/4.3/x86_64/update/
     - refresh: True
 
-# WORKAROUND: Moving target, only until SLE15SP4 GA is ready. Remove this block when we start using GA.
-proxy_os_movingtarget_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP4:/GA:/TEST/images/repo/SLE-15-SP4-Module-Server-Applications-POOL-x86_64-Media1/
-    - refresh: True
-# WORKAROUND: Moving target, only until SLE15SP4 GA is ready
 {% endif %}
 
 module_server_applications_pool_repo:

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -139,19 +139,6 @@ server_module_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Server/4.3/x86_64/update/
     - refresh: True
 
-# WORKAROUND: Moving target, only until SLE15SP4 GA is ready. Remove this block when we start using GA.
-server_os_movingtarget_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP4:/GA:/TEST/images/repo/SLE-15-SP4-Module-Server-Applications-POOL-x86_64-Media1/
-    - refresh: True
-# WORKAROUND: Moving target, only until SLE15SP4 GA is ready
-
-# WORKAROUND: Moving target, only until SLE15SP4 GA is ready. Remove this block when we start using GA.
-web_scripting_os_movingtarget_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-15-SP4:/GA:/TEST/images/repo/SLE-15-SP4-Module-Web-Scripting-POOL-x86_64-Media1/
-    - refresh: True
-# WORKAROUND: Moving target, only until SLE15SP4 GA is ready
 {% endif %}
 
 module_server_applications_pool_repo:


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Implements: https://github.com/SUSE/spacewalk/issues/17912

Final touches in support of SUSE Manager 4.3 released and nightly versions.
@juliogonzalez has already done most of the work. 
After https://github.com/SUSE/spacewalk/issues/18057 is done, the URL in here need to be verified. 
