### PR TITLE
use tool updates also on tests on PRs

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -578,7 +578,7 @@ tools_update_repo:
     - priority: 98
     - require:
       - cmd: galaxy_key
-{% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
+{% elif 'uyuni-master' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') %}
 
 {% set centos_client_tool_prefix = 'EL' %}
 {% if release < 8 %}


### PR DESCRIPTION
## What does this PR change?

Before this PR:

* on a tests on PRs deployment:
```
[root@suma-pr2-min-centos7 yum.repos.d]# ls *_repo.repo 
tools_pool_repo.repo
```
* on Uyuni master deployment:
```
[root@uyuni-master-min-centos7 yum.repos.d]# ls *_repo.repo 
tools_pool_repo.repo tools_update_repo.repo
```

This PR enables `tools_update_repo.repo` also for tests on PRs on CentOS.
