### PR TITLE
Fix ordering: install Prometheus components before starting Tomcat

### DIFF
--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -8,11 +8,11 @@ include:
   {% if grains.get('db_configuration')['local'] %}
   - server.postgres
   {% endif %}
+  - server.prometheus
   - server.tomcat
   - server.taskomatic
   - server.spacewalk-search
   - server.rhn
-  - server.prometheus
   - server.initial_content
   - server.iss
   - server.testsuite


### PR DESCRIPTION
## What does this PR change?

When setting up a monitored server, Tomcat will not start, Apache sending a 503 error, and several states will fail. The reason is Tomcat needs `/etc/prometheus-jmx_exporter/tomcat/java_agent.yml` to start, but that file has not yet been created as the corresponding states run later.

`journalctl -u tomcat` indeed shows:
```
Aug 22 03:58:04 suma-ref41-srv server[5940]: Caused by: java.io.FileNotFoundException: /etc/prometheus-jmx_exporter/tomcat/java_agent.yml (No such file or directory)
```

This patch fixes ordering, thereby allowing Tomcat to start correctly.

Noticed in the internal reference host: https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-infra-reference-PRV/788/console
Tested: https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-infra-reference-PRV/789/console