### PR TITLE
Update default images list

### DIFF
--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -65,6 +65,6 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos7o", "centos8o", "opensuse153o", "opensuse154o", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "ubuntu1804o", "ubuntu2004o", "amazonlinux2o", "almalinux8o", "rocky8o"]
+  default     = ["centos7o", "rocky8o", "opensuse153o", "opensuse154o", "sles12sp4o", "sles12sp5o", "sles15sp3o", "sles15sp4o", "ubuntu1804o", "ubuntu2004o", "amazonlinux2o", "almalinux8o"]
   type        = set(string)
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -36,7 +36,7 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos7o", "centos8o", "opensuse152o", "opensuse153o", "opensuse154o", "sles11sp4", "sles12sp3", "sles12sp4o", "sles12sp5o", "sles15o", "sles15sp1o", "sles15sp2o", "sles15sp3o", "sles15sp4o", "ubuntu1804o", "ubuntu2004o", "rocky8o"]
+  default     = ["centos7o", "rocky8o", "opensuse153o", "opensuse154o", "sles12sp4o", "sles12sp5o", "sles15sp3o", "sles15sp4o", "ubuntu1804o", "ubuntu2004o"]
 }
 
 variable "mirror" {


### PR DESCRIPTION
## What does this PR change?

Follow-up of #1147

In the default images list:
 - remove centos8o
 - remove opensuse152o
 - remove sles11sp4
 - remove sles12sp3
 - remove sles15o, sles15sp1o, and sles15sp2o
 - add sles15sp4o
