### PR TITLE
fix: Ubuntu 22.04 URL in mirror config

### DIFF
--- a/salt/mirror/etc/mirror-images.conf
+++ b/salt/mirror/etc/mirror-images.conf
@@ -18,4 +18,4 @@ http://download.suse.de/install/SLE-15-SP4-Minimal-Snapshot-202205-1/SLES15-SP4-
 http://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
 http://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
 http://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
-http://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
+http://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img


### PR DESCRIPTION
## What does this PR change?

Fixes the URL for Ubuntu 22.04 introduced in https://github.com/uyuni-project/sumaform/pull/1153. The URL for Ubuntu Bionic is already there.