### PR TITLE
Use beta tools on 4.4 instead of 4.3

### DIFF
--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -148,9 +148,8 @@ extend_login_timeout:
         - cmd: server_setup
 {% endif %}
 
-# WORKAROUND: 4.3 is needed only until the branching of Manager-4.3 is completed and
-# the testsuite can be addapted
-{% if 'head' in grains.get('product_version') or '4.3' in grains.get('product_version') %}
+# WORKAROUND: 4.4 is needed only until the branching of SUSE Manager 4.4 is completed
+{% if 'head' in grains.get('product_version') or '4.4' in grains.get('product_version') %}
 change_product_tree_to_beta:
   file.replace:
     - name: /etc/rhn/rhn.conf


### PR DESCRIPTION
## What does this PR change?

We now need the beta tools only for version 4.4

** Merge all 4 PRs at once **

## Links

* 4.2: https://github.com/SUSE/spacewalk/pull/18866
* 4.3: https://github.com/SUSE/spacewalk/pull/18866
* Uyuni: https://github.com/uyuni-project/uyuni/pull/5887
