### PR TITLE
Cucumber test suite module: Update used SUSE images

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -138,7 +138,7 @@ module "suse-minion" {
   quantity = contains(local.hosts, "suse-minion") ? 1 : 0
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "suse-minion", "sles15sp3o")
+  image              = lookup(local.images, "suse-minion", "sles15sp4o")
   name               = lookup(local.names, "suse-minion", "min-sles15")
 
   server_configuration = local.minimal_configuration
@@ -163,7 +163,7 @@ module "suse-sshminion" {
 
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "suse-sshminion", "sles15sp3o")
+  image              = lookup(local.images, "suse-sshminion", "sles15sp4o")
   name               = lookup(local.names, "suse-sshminion", "minssh-sles15")
  sles_registration_code = lookup(local.sles_registration_code, "suse-sshminion", null)
 


### PR DESCRIPTION
## What does this PR change?

This will update the SUSE minion and SSH minion from SLES15 SP3 to SP4 since we use SP4 in the test suite for them. The migration from SP3 to SP4 was moved to build validation so they do not need to be SP3 any longer.


