### PR TITLE
aws: bastion host with static IP

### DIFF
--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -97,6 +97,7 @@ module "bastion" {
   provider_settings = {
     instance_type   = "t2.micro"
     public_instance = true
+    instance_with_eip = true
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

On AWS bastion host now have a public static  IP (eip) assigned to it.
Before this, the bastion had a public IP but it was not static. This is a better approach to deploying the test infrastructure needed for testsuite.
