### PR TITLE
Revert "New variable to set up custom download endpoint"

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -271,19 +271,6 @@ module "cucumber_testsuite" {
 }
 ```
 
-## Custom download endpoint
-
-By default, packages are downloaded from the SUSE Manager server via HTTP. However, we also test that they can be downloaded from a custom endpoint. You may set this up by using `custom_download_endpoint` variable.
-
-For example:
-```hcl
-module "cucumber_testsuite" {
-   ...
-   custom_download_endpoint = "ftp://name.of.endpoint:445"
-   ...
-}
-```
-
 ## Virtual host
 
 User may need to change the KVM/Xen image download. To do it, one can use the `additional_grains` property:

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -326,18 +326,17 @@ module "controller" {
   kvmhost_configuration   = contains(local.hosts, "kvm-host") ? module.kvm-host.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
   xenhost_configuration   = contains(local.hosts, "xen-host") ? module.xen-host.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [] }
 
-  branch                   = var.branch
-  git_username             = var.git_username
-  git_password             = var.git_password
-  git_repo                 = var.git_repo
-  git_profiles_repo        = var.git_profiles_repo
-  no_auth_registry         = var.no_auth_registry
-  auth_registry            = var.auth_registry
-  auth_registry_username   = var.auth_registry_username
-  auth_registry_password   = var.auth_registry_password
-  server_http_proxy        = var.server_http_proxy
-  custom_download_endpoint = var.custom_download_endpoint
-  swap_file_size           = null
+  branch                 = var.branch
+  git_username           = var.git_username
+  git_password           = var.git_password
+  git_repo               = var.git_repo
+  git_profiles_repo      = var.git_profiles_repo
+  no_auth_registry       = var.no_auth_registry
+  auth_registry          = var.auth_registry
+  auth_registry_username = var.auth_registry_username
+  auth_registry_password = var.auth_registry_password
+  server_http_proxy      = var.server_http_proxy
+  swap_file_size         = null
 
   additional_repos  = lookup(local.additional_repos, "controller", {})
   additional_repos_only  = lookup(local.additional_repos_only, "controller", {})

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -127,11 +127,6 @@ variable "server_http_proxy" {
   default     = null
 }
 
-variable "custom_download_endpoint" {
-  description = "URL (protocol, domain name and port) of custom download endpoint for packages"
-  default     = null
-}
-
 variable "saltapi_tcpdump" {
   description = "If set to true, all network operations of salt-api on the Server are logged to /tmp/ with tcpdump."
   default     = false

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -85,7 +85,6 @@ export AUTH_REGISTRY_CREDENTIALS="{{ grains.get('auth_registry_username') }}|{{ 
 {% if grains.get('auth_registry') | default(false, true) %}export AUTH_REGISTRY="{{ grains.get('auth_registry') }}" {% else %}# no authenticated registry defined {% endif %}
 {% if grains.get('no_auth_registry') | default(false, true) %}export NO_AUTH_REGISTRY="{{ grains.get('no_auth_registry') }}" {% else %}# no container registry defined {% endif %}
 {% if grains.get('server_http_proxy') | default(false, true) %}export SERVER_HTTP_PROXY="{{ grains.get('server_http_proxy') }}" {% else %}# no server HTTP proxy defined {% endif %}
-{% if grains.get('custom_download_endpoint') | default(false, true) %}export CUSTOM_DOWNLOAD_ENDPOINT="{{ grains.get('custom_download_endpoint') }}" {% else %}# no custom download endpoint defined {% endif %}
 {% if grains.get('pxeboot_image') | default(false, true) %}export PXEBOOT_IMAGE="{{ grains.get('pxeboot_image') }}" {% else %}# no PXE boot image defined {% endif %}
 export PROVIDER="{{ grains.get('provider') }}"
 {% if 'build_image' not in grains.get('product_version') | default('', true) %}export IS_USING_BUILD_IMAGE="{{ grains.get('is_using_build_image') }}" {% endif %}


### PR DESCRIPTION
Reverts uyuni-project/sumaform#1164


Reverting as this is breaking our deployments.
https://ci.suse.de/view/Manager/view/Manager-4.3/job/manager-4.3-dev-acceptance-tests-PRV/189/console