### PR TITLE
RHEL9 and derivatives support in sumaform

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -358,6 +358,27 @@ data "aws_ami" "ubuntu1604" {
   }
 }
 
+data "aws_ami" "rhel9" {
+  most_recent = true
+  name_regex  = "^RHEL-9.0.0_HVM-"
+  owners      = ["309956199498"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
 data "aws_ami" "rhel8" {
   most_recent = true
   name_regex  = "^RHEL-8.2.0_HVM-"

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -73,6 +73,7 @@ locals {
       ubuntu1804  = { ami = data.aws_ami.ubuntu1804.image_id, ssh_user = "ubuntu" },
       ubuntu1604  = { ami = data.aws_ami.ubuntu1604.image_id, ssh_user = "ubuntu" },
       rhel8       = { ami = data.aws_ami.rhel8.image_id},
+      rhel9       = { ami = data.aws_ami.rhel9.image_id},
       //rhel7       = { ami = data.aws_ami.rhel7.image_id},
     }
     },

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -108,6 +108,19 @@ runcmd:
   - zypper removerepo --all
   - rm /etc/modprobe.d/50-ipv6.conf
 %{ endif }
+%{ if image == "rhel9"}
+yum_repos:
+  # repo for salt
+  temp_tools_pool_repo:
+    baseurl: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    name: temp_tools_pool_repo
+    priority: 98
+
+packages: ["salt-minion"]
+%{ endif }
 %{ if image == "rhel8"}
 yum_repos:
   # repo for salt

--- a/backend_modules/azure/base/main.tf
+++ b/backend_modules/azure/base/main.tf
@@ -108,6 +108,13 @@ data "azurerm_platform_image" "rhel8" {
   sku       = "8-LVM"
 }
 
+data "azurerm_platform_image" "rhel9" {
+  location  = local.location
+  publisher = "RedHat"
+  offer     = "RHEL"
+  sku       = "9-LVM"
+}
+
 data "azurerm_platform_image" "ubuntu1604" {
   location  = local.location
   publisher = "cognosys"
@@ -190,6 +197,7 @@ locals {
       ubuntu2004   = { platform_image = data.azurerm_platform_image.ubuntu2004 },
       ubuntu1804   = { platform_image = data.azurerm_platform_image.ubuntu1804 },
       ubuntu1604   = { platform_image = data.azurerm_platform_image.ubuntu1604 },
+      rhel9        = { platform_image = data.azurerm_platform_image.rhel9 },
       rhel8        = { platform_image = data.azurerm_platform_image.rhel8 },
       rhel7        = { platform_image = data.azurerm_platform_image.rhel7 },
       suma41       = { platform_image = data.azurerm_platform_image.suma41 },

--- a/backend_modules/azure/host/user_data.yaml
+++ b/backend_modules/azure/host/user_data.yaml
@@ -124,6 +124,19 @@ runcmd:
   - zypper removerepo --all
   - rm /etc/modprobe.d/50-ipv6.conf
 %{ endif }
+%{ if image == "rhel9"}
+yum_repos:
+  # repo for salt
+  temp_tools_pool_repo:
+    baseurl: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    name: temp_tools_pool_repo
+    priority: 98
+
+packages: ["salt-minion"]
+%{ endif }
 %{ if image == "rhel8"}
 yum_repos:
   # repo for salt

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -3,12 +3,16 @@ locals {
   images_used = var.use_shared_resources ? [] : var.images
   image_urls = {
     almalinux8o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://repo.almalinux.org"}/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-latest.x86_64.qcow2"
+    almalinux9o     = "${var.use_mirror_images ? "http://${var.mirror}" : "https://repo.almalinux.org"}/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2"
     rocky8o         = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.rockylinux.org"}/pub/rocky/8.6/images/Rocky-8-GenericCloud.latest.x86_64.qcow2"
+    rocky9o         = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.rockylinux.org"}/pub/rocky/9.0/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2"
     oraclelinux8o   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://yum.oracle.com"}/templates/OracleLinux/OL8/u6/x86_64/OL8U6_x86_64-kvm-b126.qcow"
+    oraclelinux9o   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://yum.oracle.com"}/templates/OracleLinux/OL9/u0/x86_64/OL9U0_x86_64-kvm-b142.qcow"
     centos6o        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/6/images/CentOS-6-x86_64-GenericCloud.qcow2"
     centos7         = "${var.use_mirror_images ? "http://${var.mirror}" : "https://github.com"}/uyuni-project/sumaform-images/releases/download/4.3.0/centos7.qcow2"
     centos7o        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2"
     centos8o        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/8/x86_64/images/CentOS-8-GenericCloud-8.2.2004-20200611.2.x86_64.qcow2"
+    centos9o        = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cloud.centos.org"}/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20220829.0.x86_64.qcow2"
     amazonlinux2o   = "${var.use_mirror_images ? "http://${var.mirror}" : "https://cdn.amazonlinux.com"}/os-images/2.0.20210721.2/kvm/amzn2-kvm-2.0.20210721.2-x86_64.xfs.gpt.qcow2"
     opensuse152o    = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2"
     opensuse153o    = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"

--- a/backend_modules/libvirt/host/cpu_features.xsl
+++ b/backend_modules/libvirt/host/cpu_features.xsl
@@ -1,0 +1,33 @@
+<?xml version="1.0" ?>
+<!-- Transformation of libvirt definition for RHEL9 and derivatives -->
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+
+  <!-- Features for x86-64 v2 -->
+  <xsl:template match="/domain/cpu[@mode = 'host-model']">
+    <xsl:element name="cpu">
+      <xsl:apply-templates select="node()|@*"/>
+      <xsl:text>  </xsl:text>
+      <feature policy='require' name='lahf_lm'/>
+      <xsl:text>&#x0A;    </xsl:text>
+      <feature policy='require' name='popcnt'/>
+      <xsl:text>&#x0A;    </xsl:text>
+      <feature policy='require' name='sse4.1'/>
+      <xsl:text>&#x0A;    </xsl:text>
+      <feature policy='require' name='sse4.2'/>
+      <xsl:text>&#x0A;    </xsl:text>
+      <feature policy='require' name='ssse3'/>
+      <xsl:text>&#x0A;    </xsl:text>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- Copy the rest -->
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -2,6 +2,7 @@ locals {
   resource_name_prefix = "${var.base_configuration["name_prefix"]}${var.name}"
   manufacturer = lookup(var.provider_settings, "manufacturer", "Intel")
   product      = lookup(var.provider_settings, "product", "Genuine")
+  x86_64_v2_images = ["almalinux9o", "rocky9o", "oraclelinux9o", "centos9o"]
   provider_settings = merge({
     memory          = 1024
     vcpu            = 1
@@ -10,6 +11,7 @@ locals {
     cpu_model       = "custom"
     xslt            = null
     },
+    contains(local.x86_64_v2_images, var.image) ? { cpu_model = "host-model", xslt = file("${path.module}/cpu_features.xsl") } : {},
     contains(var.roles, "server") ? { memory = 4096, vcpu = 2 } : {},
     contains(var.roles, "server") && lookup(var.base_configuration, "testsuite", false) ? { memory = 8192, vcpu = 4 } : {},
     contains(var.roles, "proxy") && lookup(var.base_configuration, "testsuite", false) ? { memory = 2048, vcpu = 2 } : {},

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -133,6 +133,50 @@ packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 %{ endif }
 
+%{ if image == "centos9o" }
+bootcmd:
+  # WORKAROUND: yum_repos state cant replace a repo, so we need to delete it,
+  # otherwise the workaround for archived repo doesn't work
+  - [rm, -f, /etc/yum.repos.d/CentOS-Base.repo, /etc/yum.repos.d/CentOS-AppStream.repo]
+
+yum_repos:
+  # repo for salt
+  tools_pool_repo:
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/
+    enabled: true
+    gpgcheck: false
+    name: tools_pool_repo
+    priority: 98
+  # repo for nss-mdns
+  epel:
+    baseurl: http://download.fedoraproject.org/pub/epel/9/$basearch
+    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-9&arch=$basearch
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: epel
+  # repo for Centos-Base backup
+  CentOS-Base_backup:
+    baseurl: http://vault.centos.org/$contentdir/$releasever/BaseOS/$basearch/os/
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: CentOS-Base_backup
+  # repo for Centos-Appstream backup
+  CentOS-Appstream_backup:
+    baseurl: http://vault.centos.org/$contentdir/$releasever/AppStream/$basearch/os/
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: CentOS-AppStream_backup
+
+%{ if install_salt_bundle }
+packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+%{ else }
+packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+%{ endif }
+%{ endif }
+
 %{ if image == "opensuse152o" }
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "qemu-guest-agent"]
@@ -540,6 +584,35 @@ packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
 %{ endif }
 
 %{ endif }
+
+%{ if image == "almalinux9o" }
+yum_repos:
+  # repo for salt
+  tools_pool_repo:
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    name: tools_pool_repo
+    priority: 98
+  # repo for nss-mdns
+  epel:
+    baseurl: http://download.fedoraproject.org/pub/epel/9/$basearch
+    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-9&arch=$basearch
+    failovermethod: priority
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: epel
+
+%{ if install_salt_bundle }
+packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+%{ else }
+packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
+%{ endif }
+
+%{ endif }
+
 %{ if image == "rocky8o" }
 yum_repos:
   # repo for salt
@@ -565,6 +638,32 @@ packages: ["avahi", "nss-mdns", "salt-minion"]
 %{ endif }
 
 %{ endif }
+
+%{ if image == "rocky9o" }
+yum_repos:
+  # repo for salt
+  tools_pool_repo:
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9
+    enabled: true
+    gpgcheck: false
+    name: tools_pool_repo
+    priority: 98
+  # repo for nss-mdns
+  epel:
+    baseurl: http://download.fedoraproject.org/pub/epel/9/$basearch
+    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-9&arch=$basearch
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: epel
+
+%{ if install_salt_bundle }
+packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns"]
+%{ else }
+packages: ["avahi", "nss-mdns", "salt-minion"]
+%{ endif }
+%{ endif }
+
 %{ if image == "oraclelinux8o" }
 yum_repos:
   # repo for salt
@@ -590,6 +689,33 @@ packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
   %{ endif }
   
   %{ endif }
+
+%{ if image == "oraclelinux9o" }
+yum_repos:
+  # repo for salt
+  tools_pool_repo:
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9
+    enabled: true
+    gpgcheck: false
+    name: tools_pool_repo
+    priority: 98
+  # repo for nss-mdns
+  epel:
+    baseurl: http://download.fedoraproject.org/pub/epel/9/$basearch
+    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-9&arch=$basearch
+    enabled: true
+    gpgcheck: false
+    priority: 99
+    name: epel
+
+  %{ if install_salt_bundle }
+packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+  %{ else }
+packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
+  %{ endif }
+  
+%{ endif }
+
 %{ if image == "opensuse153armo" }
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "salt-minion"]


### PR DESCRIPTION
## What does this PR change?

Added support for the following OSs:

**libvirt backend** [Commit](https://github.com/uyuni-project/sumaform/pull/1166/commits/dcf8a6e598ea8e6354f95cfd3528e17928896e93)

- Rocky 9
- CentOS 9
- AlmaLinux 9
- Oracle Linux 9

Also addressed the issue with the x86-64-v2 architecture. 
See [the bugzilla thread](https://bugzilla.redhat.com/show_bug.cgi?id=2060839) and [the article from RedHat](https://developers.redhat.com/blog/2021/01/05/building-red-hat-enterprise-linux-9-for-the-x86-64-v2-microarchitecture-level#) for more details. 

**aws and azure backend** [Commit](https://github.com/uyuni-project/sumaform/pull/1166/commits/195a2bf1fce18b0ba558576eb3bef843d7ae7d39)

- RHEL9