### PR TITLE
Use newer image in example libvirt and ssh config

### DIFF
--- a/main.tf.libvirt.example
+++ b/main.tf.libvirt.example
@@ -49,7 +49,7 @@ module "client" {
   base_configuration = module.base.configuration
 
   name = "client"
-  image = "sles12sp3"
+  image = "sles15sp4o"
   server_configuration = module.server.configuration
   // see modules/client/variables.tf for possible values
 }
@@ -59,7 +59,7 @@ module "minion" {
   base_configuration = module.base.configuration
 
   name = "minion"
-  image = "sles12sp3"
+  image = "sles15sp4o"
   server_configuration = module.server.configuration
   // see modules/minion/variables.tf for possible values
 }

--- a/main.tf.ssh.example
+++ b/main.tf.ssh.example
@@ -36,7 +36,7 @@ module "client" {
   base_configuration = module.base.configuration
 
   name = "client"
-  image = "sles12sp3"
+  image = "sles15sp4o"
   server_configuration = module.server.configuration
   // see modules/client/variables.tf for possible values
 
@@ -50,7 +50,7 @@ module "minion" {
   base_configuration = module.base.configuration
 
   name = "minion"
-  image = "sles12sp3"
+  image = "sles15sp4o"
   server_configuration = module.server.configuration
   // see modules/minion/variables.tf for possible values
 


### PR DESCRIPTION
This commit updates the image name to "sles15sp4o" in the example config for libvirt and ssh. Previously, this was set to "sles12sp3", an image which is no longer available, so `terraform apply` would fail.
