### PR TITLE
Containerized proxy services installed in 4.3-nightly and Uyuni PR tests

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -10,7 +10,7 @@ include:
 
 {% set install_proxy_container_packages = false %}
 {% if grains.get('proxy_containerized') | default(false, true) or grains.get('testsuite') | default(false, true)%}
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') %}
+{% if grains.get('product_version') | regex_match('(head|uyuni|4\.3).*') %}
     {% set install_proxy_container_packages = true %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Containerized proxy services installed in 4.3-nightly and Uyuni PR tests

Necessary to develop and run Containerized proxy tests in PR tests and CI tests.