### PR TITLE
Instance type changes

### DIFF
--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -95,7 +95,7 @@ module "bastion" {
   name                          = "bastion"
   connect_to_additional_network = true
   provider_settings = {
-    instance_type   = "t2.micro"
+    instance_type   = "t3a.micro"
     public_instance = true
     instance_with_eip = true
   }

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -30,6 +30,8 @@ locals {
 
   resource_name_prefix = "${var.base_configuration["name_prefix"]}${var.name}"
 
+  additional_device_name = substr(local.provider_settings["instance_type"], 0, 3) == "t2." ? "xvdf" : "nvme1n1"
+
   availability_zone = var.base_configuration["availability_zone"]
   region            = var.base_configuration["region"]
 
@@ -234,7 +236,7 @@ resource "null_resource" "host_salt_configuration" {
         connect_to_additional_network = var.connect_to_additional_network
         reset_ids                     = true
         ipv6                          = var.ipv6
-        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "xvdf" : null
+        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? local.additional_device_name : null
       },
     var.grains))
     destination = "/tmp/grains"


### PR DESCRIPTION
## What does this PR change?

Use t3(a) instance types for bastion host and mirror. They are cheaper an more powerful.
But this has changes to the device names which are important for the mirror.
Try to handle all of this in terraform and salt.
