### PR TITLE
Add support for AWS partition name

### DIFF
--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -95,7 +95,7 @@ module "bastion" {
   name                          = "bastion"
   connect_to_additional_network = true
   provider_settings = {
-    instance_type   = "t2.micro"
+    instance_type   = "t3a.micro"
     public_instance = true
     instance_with_eip = true
   }

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -32,6 +32,7 @@ locals {
 
   availability_zone = var.base_configuration["availability_zone"]
   region            = var.base_configuration["region"]
+  data_disk_device = split(".", local.provider_settings["instance_type"])[0] == "t2" ? "xvdf" : "nvme1n1"
 
   host_eip = local.provider_settings["public_instance"] && local.provider_settings["instance_with_eip"]? true: false
 }
@@ -234,7 +235,7 @@ resource "null_resource" "host_salt_configuration" {
         connect_to_additional_network = var.connect_to_additional_network
         reset_ids                     = true
         ipv6                          = var.ipv6
-        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "xvdf" : null
+        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? local.data_disk_device : null
       },
     var.grains))
     destination = "/tmp/grains"

--- a/salt/server/additional_disk.sls
+++ b/salt/server/additional_disk.sls
@@ -6,9 +6,16 @@ include:
 parted:
   pkg.installed
 
+{% set fstype = grains.get('data_disk_fstype') | default('ext4', true) %}
+{% if grains['data_disk_device'] == "nvme1n1" %}
+{% set partition_name = '/dev/' + grains['data_disk_device'] + 'p1' %}
+{% else %}
+{% set partition_name = '/dev/' + grains['data_disk_device'] + '1' %}
+{% endif %}
+
 spacewalk_partition:
   cmd.run:
-    - name: /usr/sbin/parted -s /dev/{{grains['data_disk_device']}} mklabel gpt && /usr/sbin/parted -s /dev/{{grains['data_disk_device']}} mkpart primary 0% 100% && sleep 1 && /sbin/mkfs.ext4 /dev/{{grains['data_disk_device']}}1
+    - name: /usr/sbin/parted -s /dev/{{grains['data_disk_device']}} mklabel gpt && /usr/sbin/parted -s /dev/{{grains['data_disk_device']}} mkpart primary 0% 100% && sleep 1 && /sbin/mkfs.{{fstype}} {{partition_name}}
     - unless: ls /dev/{{grains['data_disk_device']}}1
     - require:
       - pkg: parted
@@ -19,7 +26,7 @@ spacewalk_directory:
     - makedirs: True
   mount.mounted:
     - name: /var/spacewalk
-    - device: /dev/{{grains['data_disk_device']}}1
+    - device: {{partition_name}}
     - fstype: ext4
     - mkmnt: True
     - persist: True


### PR DESCRIPTION
## What does this PR change?

When deploying on AWS, if we use an instance type > t2.XXX, the partition name will be nvme1nX . Sumaform doesn't support this naming for mirror and server with additional disk.

This PR adds nvme1nX naming support

traditionaly partitions are just numbered after the device name:

sda1, sda2, xvdf1, xvdf2, etc.

On NVMe drives this seems to have changed as the device name ends with a number. So they use p1, p2, etc. for partition 1, partition 2, etc.

nvme0n1p1,
nvme0n1p2,
nvme1n1p1

