### PR TITLE
Revert "Containerized proxy services installed in 4.3-nightly and Uyuni PR tests"

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -10,7 +10,7 @@ include:
 
 {% set install_proxy_container_packages = false %}
 {% if grains.get('proxy_containerized') | default(false, true) or grains.get('testsuite') | default(false, true)%}
-{% if grains.get('product_version') | regex_match('(head|uyuni|4\.3).*') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') %}
     {% set install_proxy_container_packages = true %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
Reverts uyuni-project/sumaform#1181


We need to revert this, because sumaform is not prepared to support the installation of podman in SUMA Proxy, and we will need some changes first.