### PR TITLE
Revert "Containerized proxy services installed in 4.3-nightly and Uyuni PR tests"

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -10,7 +10,7 @@ include:
 
 {% set install_proxy_container_packages = false %}
 {% if grains.get('proxy_containerized') | default(false, true) or grains.get('testsuite') | default(false, true)%}
-{% if grains.get('product_version') | regex_match('(head|uyuni|4\.3).*') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') %}
     {% set install_proxy_container_packages = true %}
 {% endif %}
 {% endif %}
@@ -40,10 +40,10 @@ proxy-packages:
 
 {% if install_proxy_container_packages %}
 
-{% if 'uyuni' in grains.get('product_version') %}
-    {% set client_tools_repo =  grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/' %}
-{% else %}
+{% if 'head' in grains.get('product_version') %}
     {% set client_tools_repo =  grains.get("mirror") | default("download.suse.de/ibs", true) ~ '/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/' %}
+{% else %}
+    {% set client_tools_repo =  grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/' %}
 {% endif %}
 
 proxy_client_tools_repo:

--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -122,7 +122,7 @@ proxy_pool_repo:
     - priority: 97
 {% endif %}
 
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') %}
 {% if grains['osfullname'] == 'Leap' %}
 proxy_pool_repo:
   pkgrepo.managed:
@@ -235,7 +235,9 @@ testing_overlay_devel_repo:
 
 # repositories needed for containerized proxy
 {% if grains.get('proxy_containerized') | default(false, true) or grains.get('testsuite') | default(false, true)%}
-{% if grains.get('product_version') | regex_match('(head|uyuni|4\.3).*') %}
+
+# temporary hack since for now we only want to add this on head and uyuni
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') %}
 
 {% if grains['osfullname'] == 'Leap' %}
 {% set ca_path = 'openSUSE_Leap_' + grains['osrelease'] %}
@@ -258,7 +260,7 @@ ca_certificates_suse_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/CA/{{ca_path}}/
     - refresh: True
 
-{% if grains.get('product_version') | regex_match('(head|4\.3).*') %}
+{% if 'head' in grains.get('product_version') %}
 containers_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15-SP4/x86_64/product/

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -172,7 +172,7 @@ server_pool_repo:
     - priority: 97
 {% endif %}
 
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') %}
 {% if grains['osfullname'] == 'Leap' %}
 server_pool_repo:
   pkgrepo.managed:

--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -88,7 +88,7 @@ testsuite_salt_packages:
   pkg.installed:
     - pkgs:
       - salt-ssh
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'nightly' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'nightly' in grains.get('product_version') %}
     - fromrepo: testing_overlay_devel_repo
 {% endif %}
     - require:


### PR DESCRIPTION
Reverts uyuni-project/sumaform#1186

It still some case not working properly... I prefer to revert it now, than generate a snowball trying to fix it on production :)

It looks just a mirror issue, but let's have all good, then merge it again.

```
proxy_client_tools_repo|http://minima-mirror.mgr.prv.suse.net/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/] Valid metadata not found at specified URL
```