### PR TITLE
traditional was dropped from uyuni, create a standard bootstrap script

### DIFF
--- a/salt/server/initial_content.sls
+++ b/salt/server/initial_content.sls
@@ -124,7 +124,7 @@ create_empty_activation_key:
 {% if grains.get('create_sample_bootstrap_script') %}
 create_empty_bootstrap_script:
   cmd.run:
-    - name: rhn-bootstrap --activation-keys=1-DEFAULT --no-up2date --hostname {{ grains['hostname'] }}.{{ grains['domain'] }} --traditional
+    - name: rhn-bootstrap --activation-keys=1-DEFAULT --hostname {{ grains['hostname'] }}.{{ grains['domain'] }}
     - creates: /srv/www/htdocs/pub/bootstrap/bootstrap.sh
     - require:
       - cmd: create_empty_activation_key


### PR DESCRIPTION
## What does this PR change?

In head we dropped traditional registration. A lot of bootstrap script parameters are gone as well.
create a standard bootstrap script as example.
