### PR TITLE
Parameterize `hvm_disk_image` variable

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -232,7 +232,7 @@ The generated virtual host will be setup with:
 - a `default` virtual storage pool of `dir` type targeting `/var/lib/libvirt/images`
 - and a VM template disk image located in `/var/testsuite-data/disk-image-template.qcow2`.
 
-The template disk image is the `opensuse153` image used by sumaform and is downloaded when applying the highstate on the virtual host.
+The template disk image is the `opensuse154` image used by sumaform and is downloaded when applying the highstate on the virtual host.
 In order to use another or a cached image, use the `hvm_disk_image` variable.
 If the `hvm_disk_image` is set to the empty string, no image will be copied in `/var/testsuite-data/`.
 For example, to use a local image copy it in `salt/virthost/` folder and set `hvm_disk_image = "salt://virthost/imagename.qcow2"`

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -230,12 +230,14 @@ The generated virtual host will be setup with:
 
 - a `default` virtual network or `nat` type with `192.168.42.1/24` IP addresses,
 - a `default` virtual storage pool of `dir` type targeting `/var/lib/libvirt/images`
-- and a VM template disk image located in `/var/testsuite-data/disk-image-template.qcow2`.
+- and a VM template disk image located in `/var/testsuite-data/`.
 
-The template disk image is the `opensuse154` image used by sumaform and is downloaded when applying the highstate on the virtual host.
+The openSUSE Leap template (`leap`) disk image is `opensuse154o` used by sumaform and is downloaded when applying the
+highstate on the virtual host.
 In order to use another or a cached image, use the `hvm_disk_image` variable.
-If the `hvm_disk_image` is set to the empty string, no image will be copied in `/var/testsuite-data/`.
-For example, to use a local image copy it in `salt/virthost/` folder and set `hvm_disk_image = "salt://virthost/imagename.qcow2"`
+If the values inside the `hvm_disk_image` map are set to an empty map, no image will be copied to `/var/testsuite-data/`.
+For example, to use a local image, copy it to the `salt/virthost/` folder and set the `image` key inside the `leap`
+hashmap of `hvm_disk_image` to `"leap = salt://virthost/imagename.qcow2"`. See the [Virtual host](https://github.com/uyuni-project/sumaform/blob/master/README_TESTING.md#virtual-host) section inside of README_TESTING for an example
 
 ## Turning convenience features off
 

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -290,11 +290,16 @@ You may need to change the KVM image download. To do it, use the `additional_gra
 
 ```hcl
 host_settings = {
-    kvm-host = {
-        additional_grains = {
-            hvm_disk_image = ".."
-            hvm_disk_image_hash = "..."
+  kvm-host = {
+    additional_grains = {
+      hvm_disk_image = {
+        leap = {
+          hostname = "..."
+          image = "..."
+          hash = "..."
         }
+      }
     }
+  }
 }
 ```

--- a/modules/virthost/main.tf
+++ b/modules/virthost/main.tf
@@ -20,7 +20,6 @@ module "virthost" {
   roles                     = ["minion", "virthost"]
   additional_grains = merge({
     hvm_disk_image      = var.hvm_disk_image
-    hvm_disk_image_hash = var.hvm_disk_image_hash
     sles_registration_code = var.sles_registration_code
   },var.additional_grains)
 

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -80,13 +80,15 @@ variable "ipv6" {
 }
 
 variable "hvm_disk_image" {
-  description = "URL to the disk image to use for KVM guests"
-  default     = "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
-}
-
-variable "hvm_disk_image_hash" {
-  description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
-  default     = "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+  description = "Definition of the HVM disk images"
+  type = map(map(string))
+  default = {
+    leap = {
+      hostname = "leap154"
+      image = "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
+      hash = "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+    }
+  }
 }
 
 variable "image" {

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -81,12 +81,12 @@ variable "ipv6" {
 
 variable "hvm_disk_image" {
   description = "URL to the disk image to use for KVM guests"
-  default     = "https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2"
+  default     = "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
 }
 
 variable "hvm_disk_image_hash" {
   description = "Hash of the HVM disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
-  default     = "https://download.opensuse.org/distribution/leap/15.3/appliances/openSUSE-Leap-15.3-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
+  default     = "https://download.opensuse.org/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
 }
 
 variable "image" {

--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -58,20 +58,6 @@ fake_virt_what:
     - mode: 655
     - contents: "# Fake from sumaform to mock physical machine"
 
-{% if grains['hvm_disk_image'] %}
-disk-image-template.qcow2:
-  file.managed:
-    - name: /var/testsuite-data/disk-image-template.qcow2
-    - source: {{ grains['hvm_disk_image'] }}
-    {% if grains['hvm_disk_image_hash'] %}
-    - source_hash: {{ grains['hvm_disk_image_hash'] }}
-    {% else %}
-    - skip_verify: True
-    {% endif %}
-    - mode: 655
-    - makedirs: True
-{% endif %}
-
 ifcfg-eth0:
   file.managed:
     - name: /etc/sysconfig/network/ifcfg-eth0
@@ -87,6 +73,146 @@ ifcfg-br0:
         BOOTPROTO=dhcp
         BRIDGE=yes
         BRIDGE_PORTS=eth0
+
+{% if grains['hvm_disk_image'] %}
+{% for os_type in grains.get('hvm_disk_image') %}
+{{ os_type }}-disk-image-template.qcow2:
+  file.managed:
+    - name: /var/testsuite-data/{{ os_type }}-disk-image-template.qcow2
+    - source: {{ salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':image') }}
+    {% if salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hash') %}
+    - source_hash: {{ salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hash') }}
+    {% else %}
+    - skip_verify: True
+    {% endif %}
+    - mode: 655
+    - makedirs: True
+
+### adjustments for cloud init and the test suite ---
+# https://cloudinit.readthedocs.io/en/latest/topics/examples.html
+rezise-{{ os_type }}-disk-image-template:
+  cmd.run:
+    - name: qemu-img resize /var/testsuite-data/{{ os_type }}-disk-image-template.qcow2 3G
+    - requires:
+      - pgk: qemu-tools
+      - file: /var/testsuite-data/{{ os_type }}-disk-image-template.qcow2
+
+cloudinit-directory-{{ os_type }}:
+  file.directory:
+    - name: /var/testsuite-data/cloudinit
+
+cloudinit-meta-data-{{ os_type }}:
+  file.managed:
+    - name: /var/testsuite-data/cloudinit/meta-data
+    - contents: |
+        instance-id: {{ salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hostname') }}
+        local-hostname: {{ salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hostname') }}.{{ grains.get('domain') }}
+
+cloudinit-network-config-{{ os_type }}:
+  file.managed:
+    - name: /var/testsuite-data/cloudinit/network-config
+    - contents: |
+        network:
+          version: 1
+          config:
+          - type: physical
+            name: eth0
+            subnets:
+              - type: dhcp
+
+cloudinit-user-data-{{ os_type }}:
+  file.managed:
+    - name: /var/testsuite-data/cloudinit/user-data
+    - contents: |
+        #cloud-config
+        # vim: syntax=yaml
+
+        # root user configuration
+        disable_root: false
+        ssh_pwauth: true
+        chpasswd:
+          expire: false
+          list: |
+            root:linux
+        ssh_authorized_keys:
+          {% for key in grains.get('authorized_keys') %}
+          - {{ key }}
+          {% endfor %}
+
+        # adjust configuration files
+        write_files:
+        - content: |
+           master: {{ grains.get('server') }}
+           server_id_use_crc: adler32
+           enable_legacy_startup_events: False
+           enable_fqdns_grains: False
+          path: /etc/salt/minion
+        - content: |
+           {{ salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hostname') }}.{{ grains.get('domain') }}
+          path: /etc/hostname
+        - content: |
+           [server]
+           domain-name={{ grains.get('domain') }}
+           use-ipv4=yes
+           use-ipv6=no
+           ratelimit-interval-usec=1000000
+           ratelimit-burst=1000
+           [wide-area]
+           enable-wide-area=yes
+           [publish]
+           publish-hinfo=no
+           publish-workstation=no
+          path: /etc/avahi/avahi-daemon.conf
+        - content: |
+           .local
+           .tf.local
+           .{{ grains.get('domain') }}
+          path: /etc/mdns.allow
+        - content: |
+           passwd:         compat
+           group:          compat
+           shadow:         compat
+           hosts:          files mdns [NOTFOUND=return] dns
+           networks:       files dns
+           aliases:        files usrfiles
+           ethers:         files usrfiles
+           gshadow:        files usrfiles
+           netgroup:       files nis
+           protocols:      files usrfiles
+           publickey:      files
+           rpc:            files usrfiles
+           services:       files usrfiles
+           automount:      files nis
+           bootparams:     files
+           netmasks:       files
+          path: /etc/nsswitch.conf
+        runcmd:
+{% if salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hostname') == 'sles' %}
+        # add SLES 15 SP4 base repository
+        - zypper --non-interactive ar "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP4/x86_64/product/" SLE-Module-Basesystem15-SP4-Pool
+{% endif %}
+        - zypper --non-interactive ref
+        - zypper --non-interactive install avahi
+        - rm /etc/avahi/avahi-daemon.conf
+        - mv /etc/avahi/avahi-daemon.conf.rpmorig /etc/avahi/avahi-daemon.conf
+        - rm /etc/nsswitch.conf
+        - mv /etc/nsswitch.confbak /etc/nsswitch.conf
+        - systemctl enable avahi-daemon.service
+        - systemctl start avahi-daemon.service
+        - systemctl restart salt-minion.service
+
+create-vm-cloudinit-disk-{{ os_type }}:
+  cmd.run:
+    - name: mkisofs -o /var/testsuite-data/cloudinit-disk-{{ os_type }}.iso -volid cidata -joliet -rock /var/testsuite-data/cloudinit
+    - creates: /var/testsuite-data/cloudinit-disk-{{ os_type }}.iso
+    - requires:
+      - pkg: mkisofs
+      - file: /var/testsuite-data/cloudinit/network-config
+      - file: /var/testsuite-data/cloudinit/user-data
+      - file: /var/testsuite-data/cloudinit/meta-data
+{% endfor %}
+{% endif %}
+###---
 
 reboot:
   module.run:


### PR DESCRIPTION
## What does this PR change?

This will add the possibility to parameterize the `hvm_disk_image` variable and use more than 1 image. 

### TODO before merging

- [x] Check CI pipelines `main.tf` if they use the changes variable: https://github.com/SUSE/susemanager-ci/search?q=hvm_disk_image
- [x] Adjust files in `susemanager-ci`: https://github.com/SUSE/susemanager-ci/pull/709
- [x] Expand the README
- [x] simplify the variables and create a `map(map(string))` instead of multiple `map(string)` if possible
- [x] only leave the default vor openSUSE Leap which is publicly available and remove the SLES part
- [x] Rebase and squash commits


See https://github.com/SUSE/spacewalk/issues/17238