### PR TITLE
Revert "Containerized proxy services installed in 4.3-*, uyuni-* and head test environments"

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -10,7 +10,7 @@ include:
 
 {% set install_proxy_container_packages = false %}
 {% if grains.get('proxy_containerized') | default(false, true) or grains.get('testsuite') | default(false, true)%}
-{% if grains.get('product_version') | regex_match('(head|uyuni|4\.3).*') and grains.get('provider') != 'aws'%}
+{% if ('head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version')) and grains.get('provider') != 'aws'%}
     {% set install_proxy_container_packages = true %}
 {% endif %}
 {% endif %}
@@ -40,16 +40,10 @@ proxy-packages:
 
 {% if install_proxy_container_packages %}
 
-{% if 'uyuni' in grains.get('product_version') %}
-    {% set client_tools_repo =  grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/' %}
-{% elif '4.3' in grains.get('product_version') %}
-  {% if '-released' in grains.get('product_version') %}
-    {% set client_tools_repo = grains.get("mirror") | default("download.suse.de/ibs", true) ~ '/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/' %}
-  {% else %}
-    {% set client_tools_repo =  grains.get("mirror") | default("download.suse.de", true) ~ '/ibs/Devel:/Galaxy:/Manager:/4.3:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/' %}
-  {% endif %}
+{% if 'head' in grains.get('product_version') %}
+    {% set client_tools_repo =  grains.get("mirror") | default("download.suse.de/ibs", true) ~ '/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/' %}
 {% else %}
-    {% set client_tools_repo =  grains.get("mirror") | default("download.suse.de", true) ~ '/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/' %}
+    {% set client_tools_repo =  grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/' %}
 {% endif %}
 
 proxy_client_tools_repo:

--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -111,19 +111,6 @@ module_server_applications_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP4/x86_64/update/
     - refresh: True
 
-# repositories needed for containerized proxy
-{% if grains.get('proxy_containerized') | default(false, true) or grains.get('testsuite') | default(false, true) %}
-containers_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15-SP4/x86_64/product/
-    - refresh: True
-
-containers_updates_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15-SP4/x86_64/update/
-    - refresh: True
-{% endif %}
-
 {% endif %}
 
 
@@ -135,7 +122,7 @@ proxy_pool_repo:
     - priority: 97
 {% endif %}
 
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') %}
 {% if grains['osfullname'] == 'Leap' %}
 proxy_pool_repo:
   pkgrepo.managed:
@@ -182,19 +169,6 @@ module_server_applications_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP4/x86_64/update/
     - refresh: True
-
-# repositories needed for containerized proxy
-{% if grains.get('proxy_containerized') | default(false, true) or grains.get('testsuite') | default(false, true) %}
-containers_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15-SP4/x86_64/product/
-    - refresh: True
-
-containers_updates_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15-SP4/x86_64/update/
-    - refresh: True
-{% endif %}
 
 {% endif %}
 {% endif %}
@@ -257,6 +231,48 @@ testing_overlay_devel_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.3/images/repo/SLE-Module-SUSE-Manager-Testing-Overlay-4.3-POOL-x86_64-Media1/
     - refresh: True
     - priority: 96
+{% endif %}
+
+# repositories needed for containerized proxy
+{% if grains.get('proxy_containerized') | default(false, true) or grains.get('testsuite') | default(false, true)%}
+
+# temporary hack since for now we only want to add this on head and uyuni
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') %}
+
+{% if grains['osfullname'] == 'Leap' %}
+{% set ca_path = 'openSUSE_Leap_' + grains['osrelease'] %}
+{% endif %}
+
+{% if grains['osfullname'] != 'Leap' %}
+{% if grains['osrelease'] == '15.1' %}
+{% set ca_path = 'SLE_15_SP1' %}
+{% elif grains['osrelease'] == '15.2' %}
+{% set ca_path = 'SLE_15_SP2' %}
+{% elif grains['osrelease'] == '15.3' %}
+{% set ca_path = 'SLE_15_SP3' %}
+{% elif grains['osrelease'] == '15.4' %}
+{% set ca_path = 'SLE_15_SP4' %}
+{% endif %}
+{% endif %}
+
+ca_certificates_suse_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/CA/{{ca_path}}/
+    - refresh: True
+
+{% if 'head' in grains.get('product_version') %}
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15-SP4/x86_64/product/
+    - refresh: True
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15-SP4/x86_64/update/
+    - refresh: True
+{% endif %}
+
+{% endif %}
 {% endif %}
 
 {% endif %}

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -172,7 +172,7 @@ server_pool_repo:
     - priority: 97
 {% endif %}
 
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') %}
 {% if grains['osfullname'] == 'Leap' %}
 server_pool_repo:
   pkgrepo.managed:

--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -88,7 +88,7 @@ testsuite_salt_packages:
   pkg.installed:
     - pkgs:
       - salt-ssh
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'nightly' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'nightly' in grains.get('product_version') %}
     - fromrepo: testing_overlay_devel_repo
 {% endif %}
     - require:


### PR DESCRIPTION
Reverts uyuni-project/sumaform#1189


Reverting as it's breaking Uyuni PR deployments.

```
Oscar Barrios Torrero
  [9:15 AM](https://suse.slack.com/archives/C02DRMDU69E/p1668154508564349)
https://ci.suse.de/view/Manager/view/Uyuni-PRs/job/uyuni-prs-ci-tests/1928/
[9:15](https://suse.slack.com/archives/C02DRMDU69E/p1668154511191259)
image.png
 
image.png


[9:15](https://suse.slack.com/archives/C02DRMDU69E/p1668154522969099)
Ah, yes, Erwan shared already
[9:15](https://suse.slack.com/archives/C02DRMDU69E/p1668154540911849)
I will take a look to latest commits in Sumaform
[9:18](https://suse.slack.com/archives/C02DRMDU69E/p1668154718228429)
Last commit is on me and 
[@Cedric Bosdonnat](https://suse.slack.com/team/U02CL734EH5)
[9:18](https://suse.slack.com/archives/C02DRMDU69E/p1668154719005309)
https://github.com/uyuni-project/sumaform/commit/cffdfe60baafa9110b12d17e910e63a7952d7716
[9:18](https://suse.slack.com/archives/C02DRMDU69E/p1668154727404989)
Well I merged he coded lol
[9:19](https://suse.slack.com/archives/C02DRMDU69E/p1668154759375329)
But I'm not sure if that could be or not related
[9:20](https://suse.slack.com/archives/C02DRMDU69E/p1668154803188999)
{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'nightly' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') %}
    - fromrepo: testing_overlay_devel_repo
[9:20](https://suse.slack.com/archives/C02DRMDU69E/p1668154809564489)
YES, it's related
[9:20](https://suse.slack.com/archives/C02DRMDU69E/p1668154832169569)
[@Ricardo Mateus](https://suse.slack.com/team/U02D0UD7H6E)
 fyi too ^^^
[9:22](https://suse.slack.com/archives/C02DRMDU69E/p1668154965837759)
In theory, I think we should be using this repo in uyuni-pr
[9:22](https://suse.slack.com/archives/C02DRMDU69E/p1668154969622669)
{% if grains['osfullname'] == 'Leap' %}
testing_overlay_devel_repo:
  pkgrepo.managed:
    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/
    - refresh: True
    - priority: 96
(edited)
[9:22](https://suse.slack.com/archives/C02DRMDU69E/p1668154974408189)
coming from server.sls
[9:23](https://suse.slack.com/archives/C02DRMDU69E/p1668155011712319)
But the error says that nothing with this name has been injected


Oscar Barrios Torrero
  [9:28 AM](https://suse.slack.com/archives/C02DRMDU69E/p1668155317951929)
The repo seems available in minima, just it failed creating it http://minima-mirror.mgr.prv.suse.net/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/
[9:33](https://suse.slack.com/archives/C02DRMDU69E/p1668155583760379)
This is all what we have in our broken deployment on the server
[9:33](https://suse.slack.com/archives/C02DRMDU69E/p1668155588285249)
suma-pr1-srv:/etc/zypp/repos.d # cat *
[master_repo_other_repo]
enabled=1
autorefresh=1
baseurl=http://jenkins-worker-prs.mgr.prv.suse.net/workspace/suma-pr1/repos/systemsmanagement:Uyuni:Master:Other/openSUSE_Leap_15.4/x86_64
type=rpm-md
priority=95
gpgcheck=0
[master_repo_repo]
enabled=1
autorefresh=1
baseurl=http://jenkins-worker-prs.mgr.prv.suse.net/workspace/suma-pr1/repos/systemsmanagement:Uyuni:Master/openSUSE_Leap_15.4/x86_64
type=rpm-md
priority=95
gpgcheck=0
[master_sumaform_tools_repo_repo]
enabled=1
autorefresh=1
baseurl=http://jenkins-worker-prs.mgr.prv.suse.net/workspace/suma-pr1/repos/systemsmanagement:sumaform:tools/openSUSE_Leap_15.4/x86_64
type=rpm-md
priority=95
gpgcheck=0
[non_os_pool_repo]
enabled=1
autorefresh=1
baseurl=http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/repo/non-oss/
type=rpm-md
priority=95
gpgcheck=0
[os_additional_repo_repo]
enabled=1
autorefresh=1
baseurl=http://minima-mirror.mgr.prv.suse.net/jordi/dummy/
type=rpm-md
priority=95
gpgcheck=0
[os_pool_repo]
enabled=1
autorefresh=1
baseurl=http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/repo/oss/
type=rpm-md
priority=95
gpgcheck=0
[os_update_repo]
enabled=1
autorefresh=1
baseurl=http://minima-mirror.mgr.prv.suse.net/jordi/some-updates/
type=rpm-md
priority=95
gpgcheck=0
[pull_request_repo_repo]
enabled=1
autorefresh=1
baseurl=http://jenkins-worker-prs.mgr.prv.suse.net/workspace/suma-pr1/repos/systemsmanagement:Uyuni:Master:PR:5900/openSUSE_Leap_15.4/x86_64
type=rpm-md
priority=95
gpgcheck=0
[test_packages_repo_repo]
enabled=1
autorefresh=1
baseurl=http://jenkins-worker-prs.mgr.prv.suse.net/workspace/suma-pr1/repos/systemsmanagement:Uyuni:Test-Packages:Pool/rpm/x86_64
type=rpm-md
priority=95
gpgcheck=0
[9:33](https://suse.slack.com/archives/C02DRMDU69E/p1668155604688479)
No trace of that testing overlay repo
[9:37](https://suse.slack.com/archives/C02DRMDU69E/p1668155827116349)
Retriggering the server.sls don't show nothing about that repo neither
[9:37](https://suse.slack.com/archives/C02DRMDU69E/p1668155831439159)
suma-pr1-srv:~/salt # salt-call --local --file-root /root/salt/ state.apply repos

local:
----------
          ID: disable_all_local_repos
    Function: cmd.run
        Name: zypper mr -d --all
      Result: True
     Comment: Command "zypper mr -d --all" run
     Started: 09:35:05.250750
    Duration: 4394.422 ms
     Changes:   
              ----------
              pid:
                  15071
              retcode:
                  0
              stderr:
              stdout:
                  Repository 'master_repo_other_repo' has been successfully disabled.
                  Repository 'master_repo_repo' has been successfully disabled.
                  Repository 'master_sumaform_tools_repo_repo' has been successfully disabled.
                  Repository 'non_os_pool_repo' has been successfully disabled.
                  Repository 'os_additional_repo_repo' has been successfully disabled.
                  Repository 'os_pool_repo' has been successfully disabled.
                  Repository 'os_update_repo' has been successfully disabled.
                  Repository 'pull_request_repo_repo' has been successfully disabled.
                  Repository 'test_packages_repo_repo' has been successfully disabled.
----------
          ID: allow_vendor_changes
    Function: file.managed
        Name: /etc/zypp/vendors.d/opensuse
      Result: True
     Comment: File /etc/zypp/vendors.d/opensuse is in the correct state
     Started: 09:35:09.647096
    Duration: 234.565 ms
     Changes:   
----------
          ID: master_repo_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'master_repo_repo'
     Started: 09:35:09.882088
    Duration: 137.634 ms
     Changes:   
              ----------
              enabled:
                  ----------
                  new:
                      True
                  old:
                      False
----------
          ID: master_repo_other_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'master_repo_other_repo'
     Started: 09:35:10.020977
    Duration: 148.477 ms
     Changes:   
              ----------
              enabled:
                  ----------
                  new:
                      True
                  old:
                      False
----------
          ID: master_sumaform_tools_repo_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'master_sumaform_tools_repo_repo'
     Started: 09:35:10.171027
    Duration: 157.827 ms
     Changes:   
              ----------
              enabled:
                  ----------
                  new:
                      True
                  old:
                      False
----------
          ID: non_os_pool_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'non_os_pool_repo'
     Started: 09:35:10.330391
    Duration: 155.887 ms
     Changes:   
              ----------
              enabled:
                  ----------
                  new:
                      True
                  old:
                      False
----------
          ID: os_additional_repo_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'os_additional_repo_repo'
     Started: 09:35:10.487696
    Duration: 152.714 ms
     Changes:   
              ----------
              enabled:
                  ----------
                  new:
                      True
                  old:
                      False
----------
          ID: os_pool_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'os_pool_repo'
     Started: 09:35:10.641981
    Duration: 153.953 ms
     Changes:   
              ----------
              enabled:
                  ----------
                  new:
                      True
                  old:
                      False
----------
          ID: os_update_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'os_update_repo'
     Started: 09:35:10.797383
    Duration: 155.196 ms
     Changes:   
              ----------
              enabled:
                  ----------
                  new:
                      True
                  old:
                      False
----------
          ID: pull_request_repo_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'pull_request_repo_repo'
     Started: 09:35:10.954020
    Duration: 142.018 ms
     Changes:   
              ----------
              enabled:
                  ----------
                  new:
                      True
                  old:
                      False
----------
          ID: test_packages_repo_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'test_packages_repo_repo'
     Started: 09:35:11.097491
    Duration: 161.919 ms
     Changes:   
              ----------
              enabled:
                  ----------
                  new:
                      True
                  old:
                      False
----------
          ID: repos.additional_nop
    Function: test.nop
      Result: True
     Comment: Success!
     Started: 09:35:11.261033
    Duration: 6.943 ms
     Changes:   
----------
          ID: refresh_repos
    Function: cmd.run
        Name: zypper --non-interactive --gpg-auto-import-keys refresh --force; exit 0
      Result: True
     Comment: Command "zypper --non-interactive --gpg-auto-import-keys refresh --force; exit 0" run
     Started: 09:35:11.268729
    Duration: 19393.849 ms
     Changes:   
              ----------
              pid:
                  15092
              retcode:
                  0
              stderr:
                  Repository 'pull_request_repo_repo' is invalid.
                  [pull_request_repo_repo|http://jenkins-worker-prs.mgr.prv.suse.net/workspace/suma-pr1/repos/systemsmanagement:Uyuni:Master:PR:5900/openSUSE_Leap_15.4/x86_64] Valid metadata not found at specified URL
                  History:
                   - [pull_request_repo_repo|http://jenkins-worker-prs.mgr.prv.suse.net/workspace/suma-pr1/repos/systemsmanagement:Uyuni:Master:PR:5900/openSUSE_Leap_15.4/x86_64] Repository type can't be determined.
                  
                  Please check if the URIs defined for this repository are pointing to a valid repository.
                  Skipping repository 'pull_request_repo_repo' because of the above error.
                  Some of the repositories have not been refreshed because of an error.
              stdout:
                  Forcing raw metadata refresh
                  Retrieving repository 'master_repo_other_repo' metadata [.done]
                  Forcing building of repository cache
                  Building repository 'master_repo_other_repo' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'master_repo_repo' metadata [.done]
                  Forcing building of repository cache
                  Building repository 'master_repo_repo' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'master_sumaform_tools_repo_repo' metadata [.done]
                  Forcing building of repository cache
                  Building repository 'master_sumaform_tools_repo_repo' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'non_os_pool_repo' metadata [.done]
                  Forcing building of repository cache
                  Building repository 'non_os_pool_repo' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'os_additional_repo_repo' metadata [.done]
                  Forcing building of repository cache
                  Building repository 'os_additional_repo_repo' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'os_pool_repo' metadata [.done]
                  Forcing building of repository cache
                  Building repository 'os_pool_repo' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'os_update_repo' metadata [.done]
                  Forcing building of repository cache
                  Building repository 'os_update_repo' cache [....done]
                  Forcing raw metadata refresh
                  Retrieving repository 'pull_request_repo_repo' metadata [.error]
                  Forcing raw metadata refresh
                  Retrieving repository 'test_packages_repo_repo' metadata [.done]
                  Forcing building of repository cache
                  Building repository 'test_packages_repo_repo' cache [....done]
----------
          ID: repos_nop
    Function: test.nop
      Result: True
     Comment: Success!
     Started: 09:35:30.665881
    Duration: 9.913 ms
     Changes:   

Summary for local
-------------
Succeeded: 14 (changed=11)
Failed:     0
-------------
Total states run:     14
Total run time:   25.405 s
[9:38](https://suse.slack.com/archives/C02DRMDU69E/p1668155929189019)
And we indeed have uyuni-pr as product_version
[9:38](https://suse.slack.com/archives/C02DRMDU69E/p1668155932714549)
suma-pr1-srv:~/salt/repos # salt-call --local grains.get product_version
local:
    uyuni-pr
[9:38](https://suse.slack.com/archives/C02DRMDU69E/p1668155938832609)
```