### PR TITLE
Remove SUSE Manager 4.1

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -9,16 +9,12 @@ Some modules have a `product_version` variable that determines the software prod
 
 Legal values for released software are:
 
-- `4.0-released`   (latest released Maintenance Update for SUSE Manager 4.0 and Tools)
-- `4.1-released`   (latest released Maintenance Update for SUSE Manager 4.1 and Tools)
 - `4.2-released`   (latest released Maintenance Update for SUSE Manager 4.2 and Tools)
 - `4.3-released`   (latest released Maintenance Update for SUSE Manager 4.3 and Tools)
 - `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
 
 Legal values for work-in-progress software are:
 
-- `4.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.0)
-- `4.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.1)
 - `4.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.2)
 - `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
 - `4.3-beta`    (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
@@ -483,7 +479,7 @@ module "server" {
   base_configuration = module.base.configuration
 
   name = "server"
-  product_version = "4.1-nightly"
+  product_version = "4.3-nightly"
 }
 
 module "proxy" {
@@ -491,7 +487,7 @@ module "proxy" {
   base_configuration = module.base.configuration
 
   name = "proxy"
-  product_version = "4.1-nightly"
+  product_version = "4.3-nightly"
   server_configuration = module.server.configuration
 }
 
@@ -499,8 +495,8 @@ module "suse-client" {
   source = "./modules/client"
   base_configuration = module.base.configuration
 
-  name = "cli-sles12sp5"
-  image = "sles12sp5o"
+  name = "cli-sles15sp4"
+  image = "sles15sp4o"
   server_configuration = module.proxy.configuration
   quantity = 3
 }

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -1,9 +1,5 @@
 variable "testsuite-branch" {
   default = {
-    "4.0-released"   = "Manager-4.0"
-    "4.0-nightly"    = "Manager-4.0"
-    "4.1-released"   = "Manager-4.1"
-    "4.1-nightly"    = "Manager-4.1"
     "4.2-released"   = "Manager-4.2"
     "4.2-nightly"    = "Manager-4.2"
     "4.3-released"   = "Manager-4.3"

--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -138,14 +138,6 @@ scc:
     - SLE-Module-Containers15-SP4-Pool
     - SLE-Module-Containers15-SP4-Updates
     # SUSE Manager Server
-    - SLE-Product-SUSE-Manager-Server-4.0-Pool
-    - SLE-Product-SUSE-Manager-Server-4.0-Updates
-    - SLE-Module-SUSE-Manager-Server-4.0-Pool
-    - SLE-Module-SUSE-Manager-Server-4.0-Updates
-    - SLE-Product-SUSE-Manager-Server-4.1-Pool
-    - SLE-Product-SUSE-Manager-Server-4.1-Updates
-    - SLE-Module-SUSE-Manager-Server-4.1-Pool
-    - SLE-Module-SUSE-Manager-Server-4.1-Updates
     - SLE-Product-SUSE-Manager-Server-4.2-Pool
     - SLE-Product-SUSE-Manager-Server-4.2-Updates
     - SLE-Module-SUSE-Manager-Server-4.2-Pool
@@ -155,14 +147,6 @@ scc:
     - SLE-Module-SUSE-Manager-Server-4.3-Pool
     - SLE-Module-SUSE-Manager-Server-4.3-Updates
     # SUSE Manager Proxy
-    - SLE-Product-SUSE-Manager-Proxy-4.0-Pool
-    - SLE-Product-SUSE-Manager-Proxy-4.0-Updates
-    - SLE-Module-SUSE-Manager-Proxy-4.0-Pool
-    - SLE-Module-SUSE-Manager-Proxy-4.0-Updates
-    - SLE-Product-SUSE-Manager-Proxy-4.1-Pool
-    - SLE-Product-SUSE-Manager-Proxy-4.1-Updates
-    - SLE-Module-SUSE-Manager-Proxy-4.1-Pool
-    - SLE-Module-SUSE-Manager-Proxy-4.1-Updates
     - SLE-Product-SUSE-Manager-Proxy-4.2-Pool
     - SLE-Product-SUSE-Manager-Proxy-4.2-Updates
     - SLE-Module-SUSE-Manager-Proxy-4.2-Pool
@@ -172,14 +156,6 @@ scc:
     - SLE-Module-SUSE-Manager-Proxy-4.3-Pool
     - SLE-Module-SUSE-Manager-Proxy-4.3-Updates
     # Retail Branch Server
-    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Pool
-    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Updates
-    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-Pool
-    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-Updates
-    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Pool
-    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Updates
-    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Pool
-    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Updates
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.2-Pool
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.2-Updates
     - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.2-Pool
@@ -321,20 +297,6 @@ http:
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Proxy-4.2-POOL-x86_64-Media1
     archs: [x86_64]
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/ToSLE/SLE_15_SP3/
-    archs: [x86_64]
-
-  # SUSE Manager 4.0 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0/SLE_15_SP1
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/ToSLE/SLE_15_SP1/
-    archs: [x86_64]
-
-  # SUSE Manager 4.1 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1/SLE_15_SP2
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/ToSLE/SLE_15_SP2/
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1/images/repo/SLE-Module-SUSE-Manager-Testing-Overlay-4.1-POOL-x86_64-Media1/
     archs: [x86_64]
 
   # SUSE Manager 4.2 devel

--- a/salt/repos/proxy.sls
+++ b/salt/repos/proxy.sls
@@ -1,37 +1,5 @@
 {% if 'proxy' in grains.get('roles') %}
 
-{% if '4.1' in grains['product_version'] and not grains.get('proxy_registration_code')%}
-proxy_product_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Proxy/4.1/x86_64/product/
-    - refresh: True
-
-proxy_product_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Proxy/4.1/x86_64/update/
-    - refresh: True
-
-proxy_module_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Proxy/4.1/x86_64/product/
-    - refresh: True
-
-proxy_module_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Proxy/4.1/x86_64/update/
-    - refresh: True
-
-module_server_applications_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product/
-    - refresh: True
-
-module_server_applications_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/
-    - refresh: True
-{% endif %}
-
 {% if '4.2' in grains['product_version'] and not grains.get('proxy_registration_code') %}
 proxy_product_pool_repo:
   pkgrepo.managed:
@@ -171,26 +139,6 @@ module_server_applications_update_repo:
     - refresh: True
 
 {% endif %}
-{% endif %}
-
-{% if '4.1-nightly' in grains['product_version'] %}
-server_devel_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1/images/repo/SLE-Module-SUSE-Manager-Proxy-4.1-POOL-x86_64-Media1/
-    - refresh: True
-    - priority: 96
-
-server_devel_releasenotes_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1:/ToSLE/SLE_15_SP2/
-    - refresh: True
-    - priority: 96
-
-testing_overlay_devel_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1/images/repo/SLE-Module-SUSE-Manager-Testing-Overlay-4.1-POOL-x86_64-Media1/
-    - refresh: True
-    - priority: 96
 {% endif %}
 
 {% if '4.2-nightly' in grains['product_version'] %}

--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -1,57 +1,5 @@
 {% if 'server' in grains.get('roles') %}
 
-{% if '4.1' in grains['product_version'] and not grains.get('server_registration_code') %}
-server_product_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Product-SUSE-Manager-Server/4.1/x86_64/product/
-    - refresh: True
-
-server_product_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Server/4.1/x86_64/update/
-    - refresh: True
-
-server_module_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Server/4.1/x86_64/product/
-    - refresh: True
-
-server_module_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Server/4.1/x86_64/update/
-    - refresh: True
-
-module_server_applications_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product/
-    - refresh: True
-
-module_server_applications_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15-SP2/x86_64/update/
-    - refresh: True
-
-module_web_scripting_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Web-Scripting/15-SP2/x86_64/product/
-    - refresh: True
-
-module_web_scripting_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Web-Scripting/15-SP2/x86_64/update/
-    - refresh: True
-
-module_python2_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/15-SP2/x86_64/product/
-    - refresh: True
-
-module_python2_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Python2/15-SP2/x86_64/update/
-    - refresh: True
-{% endif %}
-
 {% if '4.2' in grains['product_version'] and not grains.get('server_registration_code') %}
 server_product_pool_repo:
   pkgrepo.managed:
@@ -231,26 +179,6 @@ module_web_scripting_update_repo:
     - refresh: True
 
 {% endif %}
-{% endif %}
-
-{% if '4.1-nightly' in grains['product_version'] %}
-testing_overlay_devel_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1/images/repo/SLE-Module-SUSE-Manager-Testing-Overlay-4.1-POOL-x86_64-Media1/
-    - refresh: True
-    - priority: 96
-
-server_devel_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1/images/repo/SLE-Module-SUSE-Manager-Server-4.1-POOL-x86_64-Media1/
-    - refresh: True
-    - priority: 96
-
-server_devel_releasenotes_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.1:/ToSLE/SLE_15_SP2/
-    - refresh: True
-    - priority: 96
 {% endif %}
 
 {% if '4.2-nightly' in grains['product_version'] %}

--- a/salt/scc/proxy.sls
+++ b/salt/scc/proxy.sls
@@ -1,20 +1,5 @@
 {% if 'proxy' in grains.get('roles') and grains.get('proxy_registration_code') %}
 
-{% if '4.1' in grains['product_version'] %}
-register_suse_manager_server_with_scc:
-   cmd.run:
-     - name: SUSEConnect --url https://scc.suse.com -r {{ grains.get("proxy_registration_code") }} -p SUSE-Manager-Proxy/4.1/x86_64
-add_sle_module_basesystem:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-basesystem/15.2/x86_64
-add_sle_module_server_application:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-server-applications/15.2/x86_64
-add_sle_module_suse_manager_server:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-suse-manager-proxy/4.1/x86_64
-{% endif %}
-
 {% if '4.2' in grains['product_version'] %}
 register_suse_manager_server_with_scc:
    cmd.run:

--- a/salt/scc/server.sls
+++ b/salt/scc/server.sls
@@ -1,27 +1,5 @@
 {% if 'server' in grains.get('roles') and grains.get('server_registration_code') %}
 
-{% if '4.1' in grains['product_version'] %}
-register_suse_manager_server_with_scc:
-   cmd.run:
-     - name: SUSEConnect --url https://scc.suse.com -r {{ grains.get("server_registration_code") }} -p SUSE-Manager-Server/4.1/x86_64
-add_sle_module_basesystem:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-basesystem/15.2/x86_64
-add_sle_module_python2:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-python2/15.2/x86_64
-add_sle_module_server_application:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-server-applications/15.2/x86_64
-add_sle_module_web_scripting:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-web-scripting/15.2/x86_64
-add_sle_module_suse_manager_server:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-suse-manager-server/4.1/x86_64
-{% endif %}
-
-
 {% if '4.2' in grains['product_version'] %}
 register_suse_manager_server_with_scc:
    cmd.run:


### PR DESCRIPTION
## What does this PR change?

Remove SUSE Manager 4.1 support (and 4.0 leftovers).
