### PR TITLE
Remove 4.0 leftovers

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -9,7 +9,6 @@ Some modules have a `product_version` variable that determines the software prod
 
 Legal values for released software are:
 
-- `4.0-released`   (latest released Maintenance Update for SUSE Manager 4.0 and Tools)
 - `4.1-released`   (latest released Maintenance Update for SUSE Manager 4.1 and Tools)
 - `4.2-released`   (latest released Maintenance Update for SUSE Manager 4.2 and Tools)
 - `4.3-released`   (latest released Maintenance Update for SUSE Manager 4.3 and Tools)
@@ -17,7 +16,6 @@ Legal values for released software are:
 
 Legal values for work-in-progress software are:
 
-- `4.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.0)
 - `4.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.1)
 - `4.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.2)
 - `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
@@ -46,7 +44,7 @@ module "suse-minion" {
   name = "min-sles15sp1"
   image = "sles15sp1o"
   server_configuration = module.proxy.configuration
-  product_version = "4.0-nightly"
+  product_version = "4.2-nightly"
 }
 
 module "server" {
@@ -54,7 +52,7 @@ module "server" {
   base_configuration = module.base.configuration
 
   name = "server"
-  product_version = "4.0-released"
+  product_version = "4.2-released"
 }
 ```
 
@@ -877,7 +875,7 @@ An example follows:
 module "server" {
   source = "./modules/server"
   base_configuration = module.base.configuration
-  product_version = "4.0-nightly"
+  product_version = "4.2-nightly"
   name = "server"
   repository_disk_size = 500
   volume_provider_settings = {

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -1,7 +1,5 @@
 variable "testsuite-branch" {
   default = {
-    "4.0-released"   = "Manager-4.0"
-    "4.0-nightly"    = "Manager-4.0"
     "4.1-released"   = "Manager-4.1"
     "4.1-nightly"    = "Manager-4.1"
     "4.2-released"   = "Manager-4.2"

--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -138,10 +138,6 @@ scc:
     - SLE-Module-Containers15-SP4-Pool
     - SLE-Module-Containers15-SP4-Updates
     # SUSE Manager Server
-    - SLE-Product-SUSE-Manager-Server-4.0-Pool
-    - SLE-Product-SUSE-Manager-Server-4.0-Updates
-    - SLE-Module-SUSE-Manager-Server-4.0-Pool
-    - SLE-Module-SUSE-Manager-Server-4.0-Updates
     - SLE-Product-SUSE-Manager-Server-4.1-Pool
     - SLE-Product-SUSE-Manager-Server-4.1-Updates
     - SLE-Module-SUSE-Manager-Server-4.1-Pool
@@ -155,10 +151,6 @@ scc:
     - SLE-Module-SUSE-Manager-Server-4.3-Pool
     - SLE-Module-SUSE-Manager-Server-4.3-Updates
     # SUSE Manager Proxy
-    - SLE-Product-SUSE-Manager-Proxy-4.0-Pool
-    - SLE-Product-SUSE-Manager-Proxy-4.0-Updates
-    - SLE-Module-SUSE-Manager-Proxy-4.0-Pool
-    - SLE-Module-SUSE-Manager-Proxy-4.0-Updates
     - SLE-Product-SUSE-Manager-Proxy-4.1-Pool
     - SLE-Product-SUSE-Manager-Proxy-4.1-Updates
     - SLE-Module-SUSE-Manager-Proxy-4.1-Pool
@@ -172,10 +164,6 @@ scc:
     - SLE-Module-SUSE-Manager-Proxy-4.3-Pool
     - SLE-Module-SUSE-Manager-Proxy-4.3-Updates
     # Retail Branch Server
-    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Pool
-    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.0-Updates
-    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-Pool
-    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.0-Updates
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Pool
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Updates
     - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Pool
@@ -321,12 +309,6 @@ http:
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Proxy-4.2-POOL-x86_64-Media1
     archs: [x86_64]
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/ToSLE/SLE_15_SP3/
-    archs: [x86_64]
-
-  # SUSE Manager 4.0 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0/SLE_15_SP1
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/ToSLE/SLE_15_SP1/
     archs: [x86_64]
 
   # SUSE Manager 4.1 devel


### PR DESCRIPTION
## What does this PR change?

Remove SUSE Manager 4.0 leftovers. It was already removed from repositories list and other important places.

We will keep 4.1 in sumaform for the time being.
