### PR TITLE
Align Rocky 9 tools repo with Rocky 8

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -643,7 +643,7 @@ packages: ["avahi", "nss-mdns", "salt-minion"]
 yum_repos:
   # repo for salt
   tools_pool_repo:
-    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9
     enabled: true
     gpgcheck: false
     name: tools_pool_repo


### PR DESCRIPTION
## What does this PR change?

Was there a good reason for using a different path as for Rocky 8 for the tools ?

This PR aligns the path for both distros.
