### PR TITLE
Create /var/lib/dbus directory if it does not exist yet

### DIFF
--- a/salt/default/ids.sls
+++ b/salt/default/ids.sls
@@ -1,6 +1,6 @@
 systemd_machine_id:
   cmd.run:
-    - name: rm -f /etc/machine-id && rm -f /var/lib/dbus/machine-id && dbus-uuidgen --ensure && systemd-machine-id-setup && touch /etc/machine-id-already-setup
+    - name: rm -f /etc/machine-id && rm -f /var/lib/dbus/machine-id && mkdir -p /var/lib/dbus && dbus-uuidgen --ensure && systemd-machine-id-setup && touch /etc/machine-id-already-setup
     - creates: /etc/machine-id-already-setup
     - onlyif: test -f /usr/bin/systemd-machine-id-setup -o -f /bin/systemd-machine-id-setup
 


### PR DESCRIPTION
## What does this PR change?

Create /var/lib/dbus directory if it does not exist yet to avoid this error:
```
# dbus-uuidgen --ensure
Could not create /var/lib/dbus/machine-id.hqgEmrC1: No such file or directory
```