### PR TITLE
Revert "PR testsuite should test like master"

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -339,7 +339,7 @@ lock_firewalld_prometheus_config_cmd:
      - name: zypper addlock firewalld-prometheus-config
 {% endif %}
 
-{% elif 'uyuni-master' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') %}
+{% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
 tools_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/


### PR DESCRIPTION
Reverts uyuni-project/sumaform#1211

Hi ! This is not correct. This PR is adding a repo from opensuse mirror infrastructure:

`baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/`

we are in purpose not using these repos in the `uyuni-pr`

We should use the repos from the worker instead:

See: https://github.com/SUSE/susemanager-ci/blob/master/jenkins_pipelines/environments/common/pipeline-pull-request.groovy#L250

