### PR TITLE
Aws set private ip and support multiple environments

### DIFF
--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -28,16 +28,18 @@ locals {
 module "network" {
   source = "../network"
 
-  availability_zone  = local.availability_zone
-  region             = local.region
-  ssh_allowed_ips    = local.ssh_allowed_ips
-  name_prefix        = local.name_prefix
-  create_network     = local.create_network
-  create_db_network  = local.create_db_network
-  private_network    = local.private_network
-  additional_network = local.additional_network
-  public_subnet_id   = local.public_subnet_id
-  vpc_id             = local.vpc_id
+  availability_zone         = local.availability_zone
+  region                    = local.region
+  ssh_allowed_ips           = local.ssh_allowed_ips
+  name_prefix               = local.name_prefix
+  create_network            = local.create_network
+  create_private_network    = local.create_private_network
+  create_additional_network = local.create_additional_network
+  create_db_network         = local.create_db_network
+  private_network           = local.private_network
+  additional_network        = local.additional_network
+  public_subnet_id          = local.public_subnet_id
+  vpc_id                    = local.vpc_id
 }
 
 locals {
@@ -103,7 +105,7 @@ module "bastion" {
   base_configuration            = local.configuration_output
   image                         = lookup(var.provider_settings, "bastion_image", "opensuse154o")
   name                          = "bastion"
-  connect_to_additional_network = true
+  //connect_to_additional_network = true
   provider_settings = {
     instance_type   = "t3a.micro"
     public_instance = true

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -105,7 +105,6 @@ module "bastion" {
   base_configuration            = local.configuration_output
   image                         = lookup(var.provider_settings, "bastion_image", "opensuse154o")
   name                          = "bastion"
-  //connect_to_additional_network = true
   provider_settings = {
     instance_type   = "t3a.micro"
     public_instance = true

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -8,6 +8,8 @@ locals {
   key_file = lookup(var.provider_settings, "key_file", null)
 
   create_network                       = lookup(var.provider_settings, "create_network", true)
+  create_private_network               = lookup(var.provider_settings, "create_private_network", true)
+  create_additional_network            = lookup(var.provider_settings, "create_additional_network", true)
   create_db_network                    = lookup(var.provider_settings, "create_db_network", false)
   public_subnet_id                     = lookup(var.provider_settings, "public_subnet_id", null)
   private_subnet_id                    = lookup(var.provider_settings, "private_subnet_id", null)
@@ -16,9 +18,11 @@ locals {
   public_security_group_id             = lookup(var.provider_settings, "public_security_group_id", null)
   private_security_group_id            = lookup(var.provider_settings, "private_security_group_id", null)
   private_additional_security_group_id = lookup(var.provider_settings, "private_additional_security_group_id", null)
+  vpc_id                               = lookup(var.provider_settings, "vpc_id", null)
   bastion_host                         = lookup(var.provider_settings, "bastion_host", null)
 
   additional_network = lookup(var.provider_settings, "additional_network", "172.16.2.0/24")
+  private_network    = lookup(var.provider_settings, "private_network", "172.16.1.0/24")
 }
 
 module "network" {
@@ -30,7 +34,10 @@ module "network" {
   name_prefix        = local.name_prefix
   create_network     = local.create_network
   create_db_network  = local.create_db_network
+  private_network    = local.private_network
   additional_network = local.additional_network
+  public_subnet_id   = local.public_subnet_id
+  vpc_id             = local.vpc_id
 }
 
 locals {
@@ -47,7 +54,7 @@ locals {
     name_prefix              = var.name_prefix
     use_shared_resources     = var.use_shared_resources
     testsuite                = var.testsuite
-    additional_network = local.additional_network
+    additional_network       = local.additional_network
 
     region            = local.region
     availability_zone = local.availability_zone
@@ -74,15 +81,20 @@ locals {
       rhel9       = { ami = data.aws_ami.rhel9.image_id},
     }
     },
-    local.create_network ? module.network.configuration : {
+    module.network.configuration,
+    !local.create_network ? {
       public_subnet_id                     = local.public_subnet_id
-      private_subnet_id                    = local.private_subnet_id
-      private_additional_subnet_id         = local.private_additional_subnet_id
       db_private_subnet_name               = local.db_private_subnet_name
       public_security_group_id             = local.public_security_group_id
+    } : {},
+    !local.create_private_network ? {
+      private_subnet_id                    = local.private_subnet_id
       private_security_group_id            = local.private_security_group_id
+    } : {},
+    !local.create_additional_network ? {
+      private_additional_subnet_id         = local.private_additional_subnet_id
       private_additional_security_group_id = local.private_additional_security_group_id
-  })
+    } : {})
 }
 
 module "bastion" {

--- a/backend_modules/aws/network/main.tf
+++ b/backend_modules/aws/network/main.tf
@@ -16,24 +16,27 @@ resource "aws_vpc" "main" {
   }
 }
 
+data "aws_vpc" "selected" {
+  count = var.create_network ? 0 : 1
+
+  id = var.vpc_id
+}
+
+locals {
+  l_vpc_id         = var.create_network ? aws_vpc.main[0].id : data.aws_vpc.selected[0].id
+  l_vpc_cidr_block = var.create_network ? aws_vpc.main[0].cidr_block : data.aws_vpc.selected[0].cidr_block
+}
+
 resource "aws_internet_gateway" "main" {
   count = var.create_network ? 1 : 0
 
-  vpc_id = local.vpc_id
+  vpc_id = local.l_vpc_id
 
   tags = {
     Name = "${var.name_prefix}internet-gateway"
   }
 }
 
-data "aws_vpc" "selected" {
-  id = var.vpc_id
-}
-
-locals {
-  vpc_id         = var.create_network ? aws_vpc.main[0].id : data.aws_vpc.selected.id
-  vpc_cidr_block = var.create_network ? aws_vpc.main[0].cidr_block : data.aws_vpc.selected.cidr_block
-}
 
 resource "aws_eip" "nat_eip" {
   count = var.create_network ? 1 : 0
@@ -58,13 +61,14 @@ resource "aws_nat_gateway" "nat" {
 }
 
 data "aws_nat_gateway" "default" {
+  count = var.create_network ? 0 : 1
   subnet_id = var.public_subnet_id
 }
 
 resource "aws_route_table" "public" {
   count = var.create_network ? 1 : 0
 
-  vpc_id = local.vpc_id
+  vpc_id = local.l_vpc_id
 
   route {
     cidr_block = "0.0.0.0/0"
@@ -79,7 +83,7 @@ resource "aws_route_table" "public" {
 resource "aws_route_table" "additional-public" {
   count = var.create_db_network ? 1 : 0
 
-  vpc_id = local.vpc_id
+  vpc_id = local.l_vpc_id
 
   route {
     cidr_block = "0.0.0.0/0"
@@ -94,18 +98,18 @@ resource "aws_route_table" "additional-public" {
 resource "aws_main_route_table_association" "vpc_internet" {
   count = var.create_network ? 1 : 0
 
-  vpc_id         = local.vpc_id
+  vpc_id         = local.l_vpc_id
   route_table_id = aws_route_table.public[0].id
 }
 
 resource "aws_route_table" "private" {
   count = var.create_private_network ? 1 : 0
 
-  vpc_id = local.vpc_id
+  vpc_id = local.l_vpc_id
 
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = data.aws_nat_gateway.default.id
+    nat_gateway_id = var.create_network ? aws_nat_gateway.nat[0].id : data.aws_nat_gateway.default[0].id
   }
 
   tags = {
@@ -117,7 +121,7 @@ resource "aws_subnet" "public" {
   count = var.create_network ? 1 : 0
 
   availability_zone       = var.availability_zone
-  vpc_id                  = local.vpc_id
+  vpc_id                  = local.l_vpc_id
   cidr_block              = "172.16.0.0/24"
   map_public_ip_on_launch = true
 
@@ -130,7 +134,7 @@ resource "aws_subnet" "additional-public" {
   count = var.create_db_network ? 1 : 0
 
   availability_zone       = var.availability_zone == "${var.region}b" ? "${var.region}a" : "${var.region}b"
-  vpc_id                  = local.vpc_id
+  vpc_id                  = local.l_vpc_id
   cidr_block              = "172.16.3.0/24"
   map_public_ip_on_launch = true
 
@@ -157,7 +161,7 @@ resource "aws_subnet" "private" {
   count = var.create_private_network ? 1 : 0
 
   availability_zone       = var.availability_zone
-  vpc_id                  = local.vpc_id
+  vpc_id                  = local.l_vpc_id
   cidr_block              = var.private_network
   map_public_ip_on_launch = false
 
@@ -174,10 +178,10 @@ resource "aws_route_table_association" "private" {
 }
 
 resource "aws_subnet" "private_additional" {
-  count = var.create_additional_network? 1: 0
+  count = var.create_additional_network ? 1 : 0
 
   availability_zone       = var.availability_zone
-  vpc_id                  = local.vpc_id
+  vpc_id                  = local.l_vpc_id
   cidr_block              = var.additional_network
   map_public_ip_on_launch = false
 
@@ -189,7 +193,7 @@ resource "aws_subnet" "private_additional" {
 resource "aws_security_group" "rds" {
   count = var.create_db_network? 1: 0
   name   = "rds-security-id"
-  vpc_id = local.vpc_id
+  vpc_id = local.l_vpc_id
 
   ingress {
     from_port   = 5432
@@ -221,7 +225,7 @@ resource "aws_db_subnet_group" "private" {
 }
 
 resource "aws_route_table_association" "private_additional" {
-  count = var.create_additional_network? 1: 0
+  count = var.create_additional_network? 1 : 0
 
   subnet_id      = aws_subnet.private_additional[0].id
   route_table_id = aws_route_table.private[0].id
@@ -241,7 +245,7 @@ resource "aws_vpc_dhcp_options" "dhcp_options" {
 resource "aws_vpc_dhcp_options_association" "vpc_dhcp_options" {
   count = var.create_network ? 1 : 0
 
-  vpc_id          = local.vpc_id
+  vpc_id          = local.l_vpc_id
   dhcp_options_id = aws_vpc_dhcp_options.dhcp_options[0].id
 }
 
@@ -250,7 +254,7 @@ resource "aws_security_group" "public" {
 
   name        = "${var.name_prefix}-public-security-group"
   description = "Allow inbound connections from the private subnet; allow SSH connections from whitelisted IPs; allow all outbound connections"
-  vpc_id      = local.vpc_id
+  vpc_id      = local.l_vpc_id
 
   ingress {
     from_port   = 22
@@ -287,13 +291,13 @@ resource "aws_security_group" "private" {
 
   name        = "${var.name_prefix}-private-security-group"
   description = "Allow all inbound and outbound connections within the VPC"
-  vpc_id      = local.vpc_id
+  vpc_id      = local.l_vpc_id
 
   ingress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [local.vpc_cidr_block]
+    cidr_blocks = [local.l_vpc_cidr_block]
   }
 
   egress {
@@ -313,11 +317,11 @@ resource "aws_security_group" "private" {
 }
 
 resource "aws_security_group" "private_additional" {
-  count = var.create_additional_network? 1: 0
+  count = var.create_additional_network? 1 : 0
 
   name        = "${var.name_prefix}-private-additional-security-group"
   description = "Allow only internal connections"
-  vpc_id      = local.vpc_id
+  vpc_id      = local.l_vpc_id
 
   ingress {
     from_port   = 0
@@ -345,18 +349,18 @@ resource "aws_security_group" "private_additional" {
 output "configuration" {
   depends_on = [aws_route_table_association.private, aws_route_table_association.private_additional , aws_route_table_association.public]
   value = merge(var.create_network ? {
-    public_subnet_id             = length(aws_subnet.public) > 0? aws_subnet.public[0].id: null
-    db_private_subnet_name       = length(aws_db_subnet_group.private) > 0? aws_db_subnet_group.private[0].name: null
+    public_subnet_id             = length(aws_subnet.public) > 0 ? aws_subnet.public[0].id: null
+    db_private_subnet_name       = length(aws_db_subnet_group.private) > 0 ? aws_db_subnet_group.private[0].name: null
 
-    public_security_group_id     = length(aws_security_group.public) > 0? aws_security_group.public[0].id: null
-    private_db_security_group_id = length(aws_security_group.rds) > 0? aws_security_group.rds[0].id: null
+    public_security_group_id     = length(aws_security_group.public) > 0 ? aws_security_group.public[0].id: null
+    private_db_security_group_id = length(aws_security_group.rds) > 0 ? aws_security_group.rds[0].id: null
   } : {},
   var.create_private_network ? {
-    private_subnet_id            = length(aws_subnet.private) > 0? aws_subnet.private[0].id: null
-    private_security_group_id    = length(aws_security_group.private) > 0? aws_security_group.private[0].id: null
+    private_subnet_id            = length(aws_subnet.private) > 0 ? aws_subnet.private[0].id: null
+    private_security_group_id    = length(aws_security_group.private) > 0 ? aws_security_group.private[0].id: null
   } : {},
   var.create_additional_network ? {
-    private_additional_subnet_id         = length(aws_subnet.private_additional) > 0? aws_subnet.private_additional[0].id: null
-    private_additional_security_group_id = length(aws_security_group.private_additional) > 0? aws_security_group.private_additional[0].id: null
+    private_additional_subnet_id         = length(aws_subnet.private_additional) > 0 ? aws_subnet.private_additional[0].id: null
+    private_additional_security_group_id = length(aws_security_group.private_additional) > 0 ? aws_security_group.private_additional[0].id: null
   } : {})
 }

--- a/backend_modules/aws/network/variables.tf
+++ b/backend_modules/aws/network/variables.tf
@@ -18,9 +18,29 @@ variable "name_prefix" {
   default     = "sumaform"
 }
 
+variable "private_network" {
+  description = "network cidr_block (of the form 172.16.x.x/24)"
+  default = "172.16.1.0/24"
+}
+
 variable "additional_network" {
   description = "Additional network cidr_block (of the form 172.16.x.x/24)"
   default = "172.16.2.0/24"
+}
+
+variable "create_private_network" {
+  description = "defined if a new private network should be created"
+  default     = true
+}
+
+variable "public_subnet_id" {
+  description = "optional public subnet id"
+  default = null
+}
+
+variable "create_additional_network" {
+  description = "defined if a new additional private network should be created"
+  default     = true
 }
 
 variable "create_network" {
@@ -31,4 +51,9 @@ variable "create_network" {
 variable "create_db_network" {
   description = "defined if a new network should be created"
   default     = false
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where networks should be created in (optional)"
+  default     = null
 }


### PR DESCRIPTION
## What does this PR change?

This PR is implementing 2 things:

1. possibility to create new private and additional private networks with instances for a given public network and VPC. This allow multiple separated environments in the same Cloud VPC using the same mirror and bastion host
2. assign fixed private IP addresses to the instances. Together with "Route 53" we can have dedicated names for our instances.
