### PR TITLE
do not hide configure-proxy issue

### DIFF
--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -206,7 +206,7 @@ ssl-building-ca-configuration:
 
 configure-proxy:
   cmd.run:
-    - name: configure-proxy.sh --non-interactive --rhn-user={{ grains.get('server_username') | default('admin', true) }} --rhn-password={{ grains.get('server_password') | default('admin', true) }} --answer-file=/root/config-answers.txt ; true
+    - name: configure-proxy.sh --non-interactive --rhn-user={{ grains.get('server_username') | default('admin', true) }} --rhn-password={{ grains.get('server_password') | default('admin', true) }} --answer-file=/root/config-answers.txt
     - env:
       - SSL_PASSWORD: spacewalk
     - creates: /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT


### PR DESCRIPTION
## What does this PR change?

Follow up of https://github.com/SUSE/spacewalk/issues/18094#issuecomment-1341160388

Currently it could happen that something goes wrong running configure-proxy.sh, but error is not visible (an example here https://github.com/SUSE/spacewalk/issues/18094#issuecomment-1341130039 ).  We should make this error visible 