### PR TITLE
Increase default RAM on virthost

### DIFF
--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -109,7 +109,7 @@ Some roles such as `suse_manager` or `mirror` have specific defaults that overri
 | grafana      | `{memory=4096}`                                                                                                |
 | build_host   | `{vcpu=2}`                                                                                                     |
 | pxe_boot     | `{xslt=templatefile("${path.module}/pxe_boot.xsl", {manufacturer=local.manufacturer, product=local.product})}` |
-| virthost     | `{memory=3072, vcpu=3, cpu_model = "host-passthrough", xslt=file("${path.module}/virthost.xsl")}`              |
+| virthost     | `{memory=4096, vcpu=3, cpu_model = "host-passthrough", xslt=file("${path.module}/virthost.xsl")}`              |
 
 ## Accessing VMs
 

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -20,7 +20,7 @@ locals {
     contains(var.roles, "build_host") ? { vcpu = 2 } : {},
     contains(var.roles, "controller") ? { memory = 2048 } : {},
     contains(var.roles, "grafana") ? { memory = 4096 } : {},
-    contains(var.roles, "virthost") ? { memory = 3072, vcpu = 3 } : {},
+    contains(var.roles, "virthost") ? { memory = 4096, vcpu = 3 } : {},
     contains(var.roles, "jenkins") ? { memory = 16384, vcpu = 4 } : {},
     var.provider_settings,
     contains(var.roles, "virthost") ? { cpu_model = "host-passthrough", xslt = file("${path.module}/virthost.xsl") } : {},


### PR DESCRIPTION
## What does this PR change?

This will increase the default RAM to 4GB on the virthost due to more demand when working with nested VMs in our test suite.

See https://github.com/SUSE/spacewalk/issues/17238

