### PR TITLE
`cucumber_testsuite` and `controller` changes for nested VMs

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -237,7 +237,7 @@ highstate on the virtual host.
 In order to use another or a cached image, use the `hvm_disk_image` variable.
 If the values inside the `hvm_disk_image` map are set to an empty map, no image will be copied to `/var/testsuite-data/`.
 For example, to use a local image, copy it to the `salt/virthost/` folder and set the `image` key inside the `leap`
-hashmap of `hvm_disk_image` to `"leap = salt://virthost/imagename.qcow2"`. See the [Virtual host](https://github.com/uyuni-project/sumaform/blob/master/README_TESTING.md#virtual-host) section inside of README_TESTING for an example
+hashmap of `hvm_disk_image` to `"leap = salt://virthost/imagename.qcow2"`. See the [Virtual host](https://github.com/uyuni-project/sumaform/blob/master/README_TESTING.md#virtual-host) section inside of README_TESTING for an example.
 
 ## Turning convenience features off
 

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -294,7 +294,7 @@ host_settings = {
     additional_grains = {
       hvm_disk_image = {
         leap = {
-          hostname = "..."
+          hostname = "hostname1"
           image = "..."
           hash = "..."
         }
@@ -303,3 +303,12 @@ host_settings = {
   }
 }
 ```
+
+Furthermore you have to specify another variable inside your `main.tf` that defines the hostname of the images you use:
+
+```hcl
+nested_vm_hosts = ["hostname1"]
+```
+
+It should contain the same hostnames as the ones defined in the `hvm_disk_image` section you see above. This is a
+workaround to not have to refactor parts of the current sumaform code.

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -32,6 +32,7 @@ module "controller" {
     cc_username  = var.base_configuration["cc_username"]
     cc_password  = var.base_configuration["cc_password"]
     git_username = var.git_username
+    nested_vm_hosts = var.nested_vm_hosts
     git_password = var.git_password
     git_repo     = var.git_repo
     branch       = var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -671,3 +671,8 @@ variable "is_using_scc_repositories" {
   description = "Specify to controller that server and proxy are using SCC repository and not internal repositories"
   default     = false
 }
+
+variable "nested_vm_hosts" {
+  description = "Hostnames for nested VMs if they are used, see README_TESTING.md"
+  type        = list(string)
+}

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -327,6 +327,7 @@ module "controller" {
 
   branch                   = var.branch
   git_username             = var.git_username
+  nested_vm_hosts          = var.nested_vm_hosts
   git_password             = var.git_password
   git_repo                 = var.git_repo
   git_profiles_repo        = var.git_profiles_repo

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -147,3 +147,8 @@ variable "login_timeout" {
   description = "How long the webUI login session cookie is valid"
   default     = null
 }
+
+variable "nested_vm_hosts" {
+  description = "Hostnames for nested VMs if they are used, see README_TESTING.md"
+  type        = list(string)
+}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -14,6 +14,16 @@ export SERVER="{{ grains.get('server') }}"
 export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 {% if grains.get('monitoring_server') | default(false, true) %}export MONITORING_SERVER="{{ grains.get('monitoring_server') }}"{% else %}# no monitoring server defined {% endif %}
 
+# Salt bundle test specific hosts
+{%- if grains.get('nested_vm_hosts') %}
+{%- for name in grains['nested_vm_hosts'] %}
+{% set hostname = name.upper() | replace("-","_") -%}
+export {{ hostname }}="{{ name }}.{{ grains.get('domain') }}"
+{%- endfor %}
+{% else %}
+# no nested VMs defined
+{%- endif %}
+
 # base goodies
 {% if grains.get('additional_network') | default(false, true) %}export PRIVATENET="{{ grains.get('additional_network') }}" {% else %}# no private network defined {% endif %}
 {% if grains.get('mirror') | default(false, true) %}export MIRROR="yes" {% else %}# no mirror used {% endif %}

--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -138,7 +138,6 @@ cloudinit-user-data-{{ os_type }}:
           {% for key in grains.get('authorized_keys') %}
           - {{ key }}
           {% endfor %}
-
         # adjust configuration files
         write_files:
         - content: |
@@ -147,9 +146,6 @@ cloudinit-user-data-{{ os_type }}:
            enable_legacy_startup_events: False
            enable_fqdns_grains: False
           path: /etc/salt/minion
-        - content: |
-           {{ salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hostname') }}.{{ grains.get('domain') }}
-          path: /etc/hostname
         - content: |
            [server]
            domain-name={{ grains.get('domain') }}
@@ -187,6 +183,7 @@ cloudinit-user-data-{{ os_type }}:
            netmasks:       files
           path: /etc/nsswitch.conf
         runcmd:
+        - hostnamectl hostname {{ salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hostname') }}.{{ grains.get('domain') }}
 {% if 'sles' in os_type %}
         # add SLES 15 SP4 base repository
         - zypper --non-interactive ar "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP4/x86_64/product/" SLE-Module-Basesystem15-SP4-Pool

--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -187,7 +187,7 @@ cloudinit-user-data-{{ os_type }}:
            netmasks:       files
           path: /etc/nsswitch.conf
         runcmd:
-{% if salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hostname') == 'sles' %}
+{% if 'sles' in os_type %}
         # add SLES 15 SP4 base repository
         - zypper --non-interactive ar "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP4/x86_64/product/" SLE-Module-Basesystem15-SP4-Pool
 {% endif %}


### PR DESCRIPTION
## Problem

In the `.bashrc` on the controller we need to set environment variables for all VMs we use in the test suite. For the nested VMs this becomes a problem since we create and define them only on the `virthost`.
We need to transfer information from the `virthost` minion to the `controller` if we use nested VM images.

## Possible solutions

All solutions regarding Salt cannot be achieved because the controller is not managed via Salt and therefore cannot interact with the Salt master.

### 1. Adjust sumaform: the currently used one

Adjust the `cucumber_testsuite` and `controller` module to be able to handle the `hvm_disk_image` variable of the `virthost`.

### 2. Salt Mine: Does not work
Using the [Salt Mine](https://docs.saltproject.io/en/3004/topics/mine/index.html#the-salt-mine) is not possible because it was disabled in SUMA due to performance issues in the past.

### 3. Salt Beacons/Reactors: Does not work

@meaksh pointed out to use beacons and reactors instead, which we already use for transactional systems like SLE Micro.

#### Links

- https://docs.saltproject.io/en/3004/topics/beacons/index.html
- https://docs.saltproject.io/en/3004/ref/beacons/all/salt.beacons.inotify.html
- https://docs.saltproject.io/en/3004/topics/reactor/index.html#beacons-and-reactors

## What does this PR change?

This PR will
- create a new terraform variable on the controller/cucumber_testsuite module. There is some duplication regarding defining the nested VM hostnames but after a discussion with Ricardo this is the easiest way without a major refactor of sumaform
- add the necessary variables for the nested VMs (if used) to the `.bashrc` file on the controller via Salt.
- updates `README_TESTING.md` and mention the new variable

The `.bashrc` changes look like the following after the deployment with this `main.tf`:

```hcl
$ cat main.tf
(...)
  host_settings = {
    server = {
      login_timeout = 28800
    }
    proxy = {
    }
    kvm-host = {
      name = "min-kvm"
      additional_grains = {
        hvm_disk_image = {
          leap = {
            hostname = "leap-salt-migration"
            image = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2"
            hash = "http://minima-mirror.mgr.prv.suse.net/distribution/leap/15.4/appliances/openSUSE-Leap-15.4-JeOS.x86_64-OpenStack-Cloud.qcow2.sha256"
          }
          sles = {
            hostname = "sles-salt-migration"
            image = "http://minima-mirror.mgr.prv.suse.net/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2"
            hash = "http://minima-mirror.mgr.prv.suse.net/install/SLE-15-SP4-Minimal-GM/SLES15-SP4-Minimal-VM.x86_64-OpenStack-Cloud-GM.qcow2.sha256"
          }
        }
      }
    }
  }
  nested_vm_hosts = ["leap-salt-migration","sles-salt-migration"]
}
```

```shell
$ cat .bashrc
#### Environment variables used by test suite
                                           
# base hosts                       
export SERVER="migration-srv.tf.local"
export PROXY="migration-pxy.tf.local"  
# no client defined                
# no minion defined          
# no build host defined                                                                                                                                                       
# no SSH minion defined                                                                
# no RedHat-like minion defined                                                        
# no Debian-like minion defined     
# no PXE boot MAC defined       
export VIRTHOST_KVM_URL="migration-min-kvm.tf.local"
export VIRTHOST_KVM_PASSWORD="linux"  
# no monitoring server defined 
(...)

# Salt bundle test specific
export LEAP_SALT_MIGRATION="leap-salt-migration.tf.local"
export SLES_SALT_MIGRATION="sles-salt-migration.tf.local"

```


