### PR TITLE
Fix "download_ubuntu_repo.sh" after changes in d.o.o repos

### DIFF
--- a/salt/server/download_ubuntu_repo.sh
+++ b/salt/server/download_ubuntu_repo.sh
@@ -5,7 +5,7 @@ set -e
 DIR=/srv/www/htdocs/pub/$1
 mkdir -p $DIR
 cd $DIR
-wget -r -np -A deb,dsc,tar.xz,tar.gz,gz,key,gpg,Packages,Release,Sources http://$2
+wget --adjust-extension -r -np -A deb,dsc,tar.xz,tar.gz,gz,key,gpg,Packages,Release,Sources http://$2
 mv $2/* .
 HOST=$(echo $2 | awk -F/ '{print $1}')
 if [ -n "$HOST" -a x"$HOST" != "x/" ]; then


### PR DESCRIPTION
## What does this PR change?

The latest upgrade of HTML pages from download.opensuse.org is causing that our script for downloading ubuntu repos is now producing a non-zero retcode that is breaking our automation. The issue is caused because latest upgrades in the HTML from d.o.o is making our script to raise some exception while wget is recursively downloading.

This PR simply fixes the script by passing `--adjust-extension` to wget command in order to prevent the mess.