### PR TITLE
Fix execution of "download_ubuntu_repo.sh" for mirror servers

### DIFF
--- a/salt/server/download_ubuntu_repo.sh
+++ b/salt/server/download_ubuntu_repo.sh
@@ -5,7 +5,7 @@ set -e
 DIR=/srv/www/htdocs/pub/$1
 mkdir -p $DIR
 cd $DIR
-wget --adjust-extension -r -np -A deb,dsc,tar.xz,tar.gz,gz,key,gpg,Packages,Release,Sources http://$2
+wget -r -np -A deb,dsc,tar.xz,tar.gz,gz,key,gpg,Packages,Release,Sources http://$2
 mv $2/* .
 HOST=$(echo $2 | awk -F/ '{print $1}')
 if [ -n "$HOST" -a x"$HOST" != "x/" ]; then

--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -33,7 +33,7 @@ another_test_repo:
 test_repo_debian_updates:
   cmd.script:
     - name: salt://server/download_ubuntu_repo.sh
-    - args: "TestRepoDebUpdates {{ grains.get('mirror') | default('download.opensuse.org', true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb"
+    - args: "TestRepoDebUpdates {{ grains.get('mirror') | default('download.opensuse.org', true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb/"
     - creates: /srv/www/htdocs/pub/TestRepoDebUpdates/Release
     - require:
       - pkg: testsuite_packages


### PR DESCRIPTION
## What does this PR change?

This PR reverts changes made at https://github.com/uyuni-project/sumaform/pull/1230 and properly fix the execution of `download_ubuntu_repo.sh` for "d.o.o" and also for other mirrors.
