### PR TITLE
overwrite host FQDN via provider settings

### DIFF
--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -10,6 +10,7 @@ locals {
     instance_with_eip = false
     volume_size     = 50
     private_ip      = null
+    overwrite_fqdn  = null
     bastion_host    = lookup(var.base_configuration, "bastion_host", null)
     instance_type = "t3.micro" },
     contains(var.roles, "server") ? { instance_type = "t3.medium" } : {},
@@ -30,6 +31,7 @@ locals {
   private_security_group_id            = var.base_configuration.private_security_group_id
   private_additional_security_group_id = var.base_configuration.private_additional_security_group_id
   private_ip                           = local.provider_settings["private_ip"]
+  overwrite_fqdn                       = local.provider_settings["overwrite_fqdn"]
 
   resource_name_prefix = "${var.base_configuration["name_prefix"]}${var.name}"
 
@@ -261,7 +263,7 @@ output "configuration" {
   depends_on = [aws_instance.instance, null_resource.host_salt_configuration]
   value = {
     ids          = length(aws_instance.instance) > 0 ? aws_instance.instance[*].id : []
-    hostnames    = length(aws_instance.instance) > 0 ? aws_instance.instance.*.private_dns : []
+    hostnames    = length(aws_instance.instance) > 0 ? (local.overwrite_fqdn != null ? concat([local.overwrite_fqdn], aws_instance.instance.*.private_dns) : aws_instance.instance.*.private_dns) : []
     public_names = length(aws_instance.instance) > 0 ? aws_instance.instance.*.public_dns : []
     macaddrs     = length(aws_instance.instance) > 0 ? aws_instance.instance.*.private_ip : []
   }

--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -120,3 +120,9 @@ variable "volume_provider_settings" {
   description = "Map of volume-provider-specific settings, see the backend-specific README file"
   default     = {}
 }
+
+variable "overwrite_fqdn" {
+  description = "use the specified FQDN as hostname for the system"
+  type        = string
+  default     = null
+}

--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -30,6 +30,25 @@ legacy_permanent_hostname:
     - follow_symlinks: False
     - contents: {{ grains['hostname'] }}.{{ grains['domain'] }}
 
+{% if grains['os_family'] == 'Suse' %}
+change_searchlist:
+  file.replace:
+    - name: /etc/sysconfig/network/config
+    - pattern: NETCONFIG_DNS_STATIC_SEARCHLIST=.*
+    - repl: NETCONFIG_DNS_STATIC_SEARCHLIST="{{ grains['domain'] }}"
+
+netconfig_update:
+  cmd.run:
+    - name: netconfig update
+    - require:
+      - file: change_searchlist
+{% else %}
+change_searchlist:
+  file.append:
+    - name: /etc/resolv.conf
+    - text: search {{ grains['domain'] }}
+{% endif %}
+
 # set the hostname and FQDN name in /etc/hosts
 # this is not needed if a proper DNS server is in place, but when using avahi this
 # might not be the case. The script tries to to use real IP addresses in order not

--- a/salt/server/setup_env.sh
+++ b/salt/server/setup_env.sh
@@ -8,6 +8,9 @@ CERT_STATE="Bayern"
 CERT_COUNTRY="DE"
 CERT_EMAIL="galaxy-noise@suse.de"
 CERT_PASS="spacewalk"
+{%- if grains.get('provider') == 'aws' %}
+CERT_CNAMES="{{ grains.get('hostname') }}.{{ grains.get('domain') }}"
+{%- endif %}
 USE_EXISTING_CERTS="N"
 MANAGER_DB_NAME="susemanager"
 MANAGER_DB_HOST="{{ grains.get('db_configuration')['hostname'] }}"


### PR DESCRIPTION
## What does this PR change?

In AWS we use Route 53 to provide meaningful hostnames for the systems.
We also make use of some tricks with CNAMES. 
To be able to use these hostnames, this PR add the possibility to overwrite the FQDN with a given value in the provider settings.

See also https://github.com/SUSE/spacewalk/issues/19888