### PR TITLE
Deprecate use_os_unreleased_updates flag

### DIFF
--- a/.ci-travis/salt-client-validation
+++ b/.ci-travis/salt-client-validation
@@ -20,7 +20,6 @@ roles: [client]
 mirror: null
 auto_register: false
 testsuite: true
-use_os_unreleased_updates: 0
 ipv6: {'accept_ra': true, 'enable': true}
 EOF
 

--- a/.ci-travis/salt-minion-validation
+++ b/.ci-travis/salt-minion-validation
@@ -20,7 +20,6 @@ roles: [client]
 mirror: null
 auto_connect_to_master: false
 testsuite: true
-use_os_unreleased_updates: 0
 ipv6: {'accept_ra': true, 'enable': true}
 EOF
 

--- a/.ci-travis/salt-server-validation
+++ b/.ci-travis/salt-server-validation
@@ -35,7 +35,6 @@ create_sample_activation_key: 0
 create_sample_bootstrap_script: 0
 publish_private_ssl_key: 0
 testsuite: true
-use_os_unreleased_updates: 0
 monitored: 0
 from_email: null
 traceback_email: null

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -794,9 +794,9 @@ module "locust" {
 }
 ```
 
-## Use Operating System updates (released and unreleased)
+## Use Operating System released updates
 
-It is possible to run SUSE Manager servers, proxies, clients and minions with the latest packages of the operating system (for now, only SLE is supported) instead of outdated ones, including updates currently in QAM, that is, upcoming updates. This is useful to spot regressions early, and can be activated via the `use_os_released_updates` (respectively `use_os_unreleased_updates`) flag. Libvirt example:
+It is possible to run SUSE Manager servers, proxies, clients and minions with the latest packages of the operating system (for now, only SLE is supported) instead of outdated ones. This is useful to spot regressions early, and can be activated via the `use_os_released_updates` flag. Libvirt example:
 
 ```hcl
 module "server" {
@@ -805,7 +805,7 @@ module "server" {
 
   name = "server"
   product_version = "head"
-  use_os_unreleased_updates = true
+  use_os_released_updates = true
 }
 ```
 

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -185,7 +185,6 @@ resource "null_resource" "host_salt_configuration" {
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
-        use_os_unreleased_updates = var.use_os_unreleased_updates
         install_salt_bundle       = var.install_salt_bundle
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
@@ -234,7 +233,6 @@ resource "null_resource" "host_salt_configuration" {
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
-        use_os_unreleased_updates = var.use_os_unreleased_updates
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
         additional_certs          = var.additional_certs

--- a/backend_modules/azure/host/main.tf
+++ b/backend_modules/azure/host/main.tf
@@ -186,7 +186,6 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
-        use_os_unreleased_updates = var.use_os_unreleased_updates
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
         additional_certs          = var.additional_certs

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -181,7 +181,6 @@ resource "null_resource" "provisioning" {
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
-        use_os_unreleased_updates = var.use_os_unreleased_updates
         install_salt_bundle       = var.install_salt_bundle
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
@@ -225,7 +224,6 @@ resource "null_resource" "provisioning" {
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
-        use_os_unreleased_updates = var.use_os_unreleased_updates
         install_salt_bundle       = var.install_salt_bundle
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only

--- a/backend_modules/null/host/main.tf
+++ b/backend_modules/null/host/main.tf
@@ -4,7 +4,6 @@ resource "null_resource" "domain" {
     name                          = var.name
     roles                         = yamlencode(var.roles)
     use_os_released_updates       = var.use_os_released_updates
-    use_os_unreleased_updates     = var.use_os_unreleased_updates
     install_salt_bundle           = var.install_salt_bundle
     additional_repos              = yamlencode(var.additional_repos)
     additional_repos_only         = var.additional_repos_only

--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -17,11 +17,6 @@ variable "use_os_released_updates" {
   default     = false
 }
 
-variable "use_os_unreleased_updates" {
-  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
-  default     = false
-}
-
 variable "disable_firewall" {
   description = "whether to disable the built-in firewall, opening up all ports"
   default     = true

--- a/backend_modules/ssh/host/main.tf
+++ b/backend_modules/ssh/host/main.tf
@@ -28,7 +28,6 @@ resource "null_resource" "provisioning" {
         hostname                  = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
-        use_os_unreleased_updates = var.use_os_unreleased_updates
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
         additional_certs          = var.additional_certs
@@ -81,7 +80,6 @@ resource "null_resource" "provisioning" {
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
-        use_os_unreleased_updates = var.use_os_unreleased_updates
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
         additional_certs          = var.additional_certs

--- a/modules/build_host/main.tf
+++ b/modules/build_host/main.tf
@@ -5,7 +5,6 @@ module "build_host" {
   name                          = var.name
   quantity                      = var.quantity
   use_os_released_updates       = var.use_os_released_updates
-  use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only

--- a/modules/build_host/variables.tf
+++ b/modules/build_host/variables.tf
@@ -26,11 +26,6 @@ variable "use_os_released_updates" {
   default     = false
 }
 
-variable "use_os_unreleased_updates" {
-  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
-  default     = false
-}
-
 variable "avahi_reflector" {
   description = "if using avahi, let the daemon be a reflector"
   default     = false

--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -5,7 +5,6 @@ module "client" {
   name                          = var.name
   quantity                      = var.quantity
   use_os_released_updates       = var.use_os_released_updates
-  use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -26,11 +26,6 @@ variable "use_os_released_updates" {
   default     = false
 }
 
-variable "use_os_unreleased_updates" {
-  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
-  default     = false
-}
-
 variable "disable_firewall" {
   description = "whether to disable the built-in firewall, opening up all ports"
   default     = true

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -6,7 +6,6 @@ module "host" {
   name                          = var.name
   roles                         = var.roles
   use_os_released_updates       = var.use_os_released_updates
-  use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only

--- a/modules/minion/main.tf
+++ b/modules/minion/main.tf
@@ -5,7 +5,6 @@ module "minion" {
   name                          = var.name
   quantity                      = var.quantity
   use_os_released_updates       = var.use_os_released_updates
-  use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -46,11 +46,6 @@ variable "use_os_released_updates" {
   default     = false
 }
 
-variable "use_os_unreleased_updates" {
-  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
-  default     = false
-}
-
 variable "avahi_reflector" {
   description = "if using avahi, let the daemon be a reflector"
   default     = false

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -26,7 +26,6 @@ module "proxy" {
   name                          = var.name
   quantity                      = var.quantity
   use_os_released_updates       = var.use_os_released_updates
-  use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -66,11 +66,6 @@ variable "use_os_released_updates" {
   default     = false
 }
 
-variable "use_os_unreleased_updates" {
-  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
-  default     = false
-}
-
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
   default     = {}

--- a/modules/registry/main.tf
+++ b/modules/registry/main.tf
@@ -5,7 +5,6 @@ module "registry" {
   name                          = var.name
   quantity                      = var.quantity
   use_os_released_updates       = var.use_os_released_updates
-  use_os_unreleased_updates     = var.use_os_unreleased_updates
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only
   additional_packages           = var.additional_packages

--- a/modules/registry/variables.tf
+++ b/modules/registry/variables.tf
@@ -12,11 +12,6 @@ variable "use_os_released_updates" {
   default     = false
 }
 
-variable "use_os_unreleased_updates" {
-  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
-  default     = false
-}
-
 variable "disable_firewall" {
   description = "whether to disable the built-in firewall, opening up all ports"
   default     = true

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -25,7 +25,6 @@ module "server" {
   base_configuration            = var.base_configuration
   name                          = var.name
   use_os_released_updates       = var.use_os_released_updates
-  use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -142,11 +142,6 @@ variable "use_os_released_updates" {
   default     = false
 }
 
-variable "use_os_unreleased_updates" {
-  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
-  default     = false
-}
-
 variable "from_email" {
   description = "email address used as sender for emails"
   default     = null

--- a/modules/sshminion/main.tf
+++ b/modules/sshminion/main.tf
@@ -5,7 +5,6 @@ module "sshminion" {
   name                          = var.name
   quantity                      = var.quantity
   use_os_released_updates       = var.use_os_released_updates
-  use_os_unreleased_updates     = var.use_os_unreleased_updates
   install_salt_bundle           = var.install_salt_bundle
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only

--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -22,11 +22,6 @@ variable "use_os_released_updates" {
   default     = false
 }
 
-variable "use_os_unreleased_updates" {
-  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
-  default     = false
-}
-
 variable "disable_firewall" {
   description = "whether to disable the built-in firewall, opening up all ports"
   default     = true

--- a/modules/virthost/main.tf
+++ b/modules/virthost/main.tf
@@ -8,7 +8,6 @@ module "virthost" {
   activation_key            = var.activation_key
   auto_connect_to_master    = var.auto_connect_to_master
   use_os_released_updates   = var.use_os_released_updates
-  use_os_unreleased_updates = var.use_os_unreleased_updates
   install_salt_bundle       = var.install_salt_bundle
   additional_repos          = var.additional_repos
   additional_repos_only     = var.additional_repos_only

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -31,11 +31,6 @@ variable "use_os_released_updates" {
   default     = false
 }
 
-variable "use_os_unreleased_updates" {
-  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
-  default     = false
-}
-
 variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default     = {}

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -9,7 +9,7 @@ include:
   {% endif %}
   - default.testsuite
 
-{% if grains.get('use_os_unreleased_updates') | default(False, true) or grains.get('use_os_released_updates') | default(False, true) %}
+{% if grains.get('use_os_released_updates') | default(False, true) %}
 update_packages:
   pkg.uptodate:
     - require:

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -115,15 +115,6 @@ os_ltss_repo:
     {% endif %}
     - refresh: True
 
-{% if grains.get('use_os_unreleased_updates') | default(False, true) %}
-test_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/11-SP4:/x86_64/update/
-    - refresh: True
-    - gpgcheck: 1
-    - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/11-SP4:/x86_64/update/repodata/repomd.xml.key
-{% endif %}
-
 tools_pool_repo:
   pkgrepo.managed:
     {% if grains.get('mirror') %}
@@ -166,15 +157,6 @@ os_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/
     - refresh: True
 
-{% if grains.get('use_os_unreleased_updates') | default(False, true) %}
-test_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP3:/x86_64/update/
-    - refresh: True
-    - gpgcheck: 1
-    - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP3:/x86_64/update/repodata/repomd.xml.key
-{% endif %}
-
 {% elif grains['osrelease'] == '12.4' %}
 
 os_pool_repo:
@@ -192,14 +174,6 @@ os_ltss_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP4-LTSS/x86_64/update/
     - refresh: True
 
-{% if grains.get('use_os_unreleased_updates') | default(False, true) %}
-test_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP4:/x86_64/update/
-    - refresh: True
-    - gpgcheck: 1
-    - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP4:/x86_64/update/repodata/repomd.xml.key
-{% endif %}
 {% elif grains['osrelease'] == '12.5' %}
 
 os_pool_repo:
@@ -216,15 +190,6 @@ os_update_repo:
 # os_ltss_repo:
 #   pkgrepo.managed:
 #           - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP5-LTSS/x86_64/update/
-
-{% if grains.get('use_os_unreleased_updates') | default(False, true) %}
-test_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP5:/x86_64/update/
-    - refresh: True
-    - gpgcheck: 1
-    - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP5:/x86_64/update/repodata/repomd.xml.key
-{% endif %}
 
 {% endif %}
 
@@ -376,13 +341,6 @@ os_ltss_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-LTSS/x86_64/update/
     - refresh: True
 
-{% if grains.get('use_os_unreleased_updates') | default(False, true) %}
-test_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Basesystem:/15:/x86_64/update/
-    - refresh: True
-    - gpgcheck: 1
-{% endif %}
 {% endif %} {# '15' == grains['osrelease'] #}
 
 {% if '15.1' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code')) %}


### PR DESCRIPTION
## What does this PR change?

This PR removes the `use_os_unreleased_updates` flag.

The plan is to start testing SLE updates with the build validation test suite. The MI numbers are passed through the usual json file.

The technical advantage over using `Maintenance:/Test:` aggregation of maintenance updates is that it is easier to spot the MI causing a regression, as we apply only one.

The organizational advantage is that we have not the bandwidth to follow another CI test suite that would retest periodically all features with the unreleased updates.
