### PR TITLE
Add a needed package to Oracle and Alma 9

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -611,9 +611,9 @@ runcmd:
   - systemctl restart sshd
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent", "dbus-tools"]
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
+packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion", "dbus-tools"]
 %{ endif }
 
 %{ endif }
@@ -724,9 +724,9 @@ runcmd:
   - systemctl restart sshd
 
   %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent", "dbus-tools"]
   %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
+packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion", "dbus-tools"]
   %{ endif }
 
 %{ endif }


### PR DESCRIPTION
## What does this PR change?

otherwise this fails:

```
default/ids.sls:    - name: rm -f /etc/machine-id && rm -f /var/lib/dbus/machine-id && mkdir -p /var/lib/dbus && dbus-uuidgen --ensure && systemd-machine-id-setup && touch /etc/machine-id-already-setup
```

the dbus-uuidgen is contained in the package dbus-tools