### PR TITLE
Disable IPv6 for apt-get until we have IPv6 in Provo

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -480,6 +480,8 @@ apt:
 runcmd:
   # WORKAROUND: cloud-init in Ubuntu 22.04 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+  # WORKAROUND: disable IPv6 until we have it in Provo
+  - echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
 


### PR DESCRIPTION
## What does this PR change?

Ubuntu 22.04 does not always fall back correctly to IPv6 when IPv6 route to the outside is missing, which is the case for now in Provo.

Remove these lines (and many other similar workarounds we did for IPv6 in the past) when IPv6 appears in Provo.
