### PR TITLE
Disable IPv6 for apt-get on Ubuntu 2004

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -439,6 +439,8 @@ apt:
 runcmd:
   # WORKAROUND: cloud-init in Ubuntu 20.04 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+  # WORKAROUND: disable IPv6 until we have it in Provo
+  - echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
 


### PR DESCRIPTION
## What does this PR change?

Disable IPv6 for apt-get on Ubuntu 2004, too. Follow up of https://github.com/uyuni-project/sumaform/pull/1240