### PR TITLE
Add tar package to alma and oracle 9 for finishing stage

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -615,9 +615,9 @@ runcmd:
   - systemctl restart sshd
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent", "dbus-tools"]
+packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent", "dbus-tools", "tar"]
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion", "dbus-tools"]
+packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion", "dbus-tools", "tar"]
 %{ endif }
 
 %{ endif }
@@ -728,9 +728,9 @@ runcmd:
   - systemctl restart sshd
 
   %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent", "dbus-tools"]
+packages: ["venv-salt-minion", "salt-minion", "avahi", "nss-mdns", "qemu-guest-agent", "dbus-tools", "tar"]
   %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion", "dbus-tools"]
+packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion", "dbus-tools", "tar"]
   %{ endif }
 
 %{ endif }


### PR DESCRIPTION
## What does this PR change?

Add tar package to alma and oracle 9 for finishing stage, it's needed:

```
00:52:25  When I extract the log files from all our active nodes # features/step_definitions/command_steps.rb:501
00:52:25        FAIL: tar cfvJP /tmp/suma-bv-43-min-oracle9.mgr.prv.suse.net-logs.tar.xz /var/log/ || [[ $? -eq 1 ]] returned status code = 1.
00:52:25        Output:
00:52:25        bash: line 1: tar: command not found

```
