### PR TITLE
Controller: update Ruby to 3.3 for HEAD/Uyuni/Uyuni Podman/5.x

### DIFF
--- a/.github/workflows/ci-validation/salt-client-validation
+++ b/.github/workflows/ci-validation/salt-client-validation
@@ -19,6 +19,7 @@ osrelease_info: [15, 5]
 
 # Set grain values in such a way that covers as many conditions as possible
 hostname: sumaform-test-client
+product_version: head
 install_salt_bundle: true
 gpg_keys: ['testkey.pub']
 domain: tf.local

--- a/.github/workflows/ci-validation/salt-controller-validation
+++ b/.github/workflows/ci-validation/salt-controller-validation
@@ -19,6 +19,7 @@ osrelease_info: [15, 5]
 
 # Set grain values in such a way that covers as many conditions as possible
 hostname: sumaform-test-ctl
+product_version: head
 install_salt_bundle: true
 gpg_keys: ['testkey.pub']
 domain: tf.local

--- a/.github/workflows/ci-validation/salt-minion-validation
+++ b/.github/workflows/ci-validation/salt-minion-validation
@@ -19,6 +19,7 @@ osrelease_info: [15, 5]
 
 # Set grain values in such a way that covers as many conditions as possible
 hostname: sumaform-test-minion
+product_version: head
 install_salt_bundle: true
 gpg_keys: ['testkey.pub']
 domain: tf.local

--- a/.github/workflows/ci-validation/salt-mirror-validation
+++ b/.github/workflows/ci-validation/salt-mirror-validation
@@ -19,6 +19,7 @@ osrelease_info: [15, 5]
 
 # Set grain values in such a way that covers as many conditions as possible
 hostname: sumaform-test-mirror
+product_version: head
 install_salt_bundle: true
 gpg_keys: ['testkey.pub']
 domain: tf.local

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -39,6 +39,7 @@ module "controller" {
     git_repo     = var.git_repo
     branch       = var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch
     mirror       = var.no_mirror == true ? null :  var.base_configuration["mirror"]
+    product_version      = var.product_version
 
     server            = var.server_configuration["hostname"]
     proxy             = var.proxy_configuration["hostname"]

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -755,3 +755,8 @@ variable "server_instance_id" {
   description = "Server instance ID"
   default     = null
 }
+
+variable "product_version" {
+  description = "A valid SUSE Manager version (eg. 4.2-nightly, head) see README_ADVANCED.md"
+  default     = "released"
+}

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -757,6 +757,6 @@ variable "server_instance_id" {
 }
 
 variable "product_version" {
-  description = "A valid SUSE Manager version (eg. 4.2-nightly, head) see README_ADVANCED.md"
+  description = "A valid SUSE Manager version (eg. 4.3-nightly, head) see README_ADVANCED.md"
   default     = "released"
 }

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -501,6 +501,7 @@ module "controller" {
   server_http_proxy        = var.server_http_proxy
   custom_download_endpoint = var.custom_download_endpoint
   swap_file_size           = null
+  product_version          = var.product_version
 
   additional_repos  = lookup(local.additional_repos, "controller", {})
   additional_repos_only  = lookup(local.additional_repos_only, "controller", false)

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -115,6 +115,11 @@ export CATCH_TIMEOUT_MESSAGE="{{ grains.get('catch_timeout_message') }}"
 export SERVER_INSTANCE_ID="{{ grains.get('server_instance_id') }}"
 export BETA_ENABLED="{{ grains.get('beta_enabled') }}"
 
+# Ruby specific settings
+{% if '4.3' not in grains.get('product_version') %}
+export GEM_PATH="/usr/lib64/ruby/gems/3.3.0"
+{% endif %}
+
 #### Generate certificates for Google Chrome
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then
   wget http://$SERVER/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$SERVER.cert

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -116,6 +116,7 @@ export SERVER_INSTANCE_ID="{{ grains.get('server_instance_id') }}"
 export BETA_ENABLED="{{ grains.get('beta_enabled') }}"
 
 # Ruby specific settings
+# For 4.3 we currently still use Ruby 2.5
 {% if '4.3' not in grains.get('product_version') %}
 export GEM_PATH="/usr/lib64/ruby/gems/3.3.0"
 {% endif %}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -118,7 +118,7 @@ export BETA_ENABLED="{{ grains.get('beta_enabled') }}"
 # Ruby specific settings
 # For 4.3 we currently still use Ruby 2.5
 {% if '4.3' not in grains.get('product_version') %}
-export GEM_PATH="/usr/lib64/ruby/gems/3.3.0"
+export GEM_PATH="/usr/lib64/ruby/gems/3.1.0"
 {% endif %}
 
 #### Generate certificates for Google Chrome

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -118,7 +118,7 @@ export BETA_ENABLED="{{ grains.get('beta_enabled') }}"
 # Ruby specific settings
 # For 4.3 we currently still use Ruby 2.5
 {% if '4.3' not in grains.get('product_version') %}
-export GEM_PATH="/usr/lib64/ruby/gems/3.1.0"
+export GEM_PATH="/usr/lib64/ruby/gems/3.3.0"
 {% endif %}
 
 #### Generate certificates for Google Chrome

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -115,21 +115,6 @@ ruby_set_rdoc_version:
 ruby_set_ri_version:
   cmd.run:
     - name: update-alternatives --set ri /usr/bin/ri.ruby.ruby3.3
-
-
-# WORKAROUND: Build twopence from source due to Ruby 3 not being available
-#             openSUSE Leap 15.5/15.6
-twopence_install_from_source:
-  cmd.run:
-    - name: |
-        git clone https://github.com/openSUSE/twopence.git /root/twopence
-        cd /root/twopence
-        make
-        make install
-        ldconfig
-    - creates: /root/twopence
-    - require:
-      - pkg: cucumber_requisites
 {% endif %}
 
 install_chromium:
@@ -169,7 +154,6 @@ install_gems_via_bundle:
     - cwd: /root/spacewalk/testsuite
     - require:
       - pkg: cucumber_requisites
-      - cmd: twopence_install_from_source
       - cmd: spacewalk_git_repository
 {% endif %}
 

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -67,8 +67,8 @@ cucumber_requisites:
       - wget
       - libssh-devel
       - python-devel
-      - ruby3.1
-      - ruby3.1-devel
+      - ruby3.3
+      - ruby3.3-devel
       - autoconf
       - ca-certificates-mozilla
       - automake
@@ -87,34 +87,34 @@ cucumber_requisites:
 
 /usr/bin/ruby:
   file.symlink:
-    - target: /usr/bin/ruby.ruby3.1
+    - target: /usr/bin/ruby.ruby3.3
     - force: True
 
 /usr/bin/gem:
   file.symlink:
-    - target: /usr/bin/gem.ruby3.1
+    - target: /usr/bin/gem.ruby3.3
     - force: True
 
 /usr/bin/irb:
   file.symlink:
-    - target: /usr/bin/irb.ruby3.1
+    - target: /usr/bin/irb.ruby3.3
     - force: True
 
 ruby_set_rake_version:
   cmd.run:
-    - name: update-alternatives --set rake /usr/bin/rake.ruby.ruby3.1
+    - name: update-alternatives --set rake /usr/bin/rake.ruby.ruby3.3
 
 ruby_set_bundle_version:
   cmd.run:
-    - name: update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.1
+    - name: update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.3
 
 ruby_set_rdoc_version:
   cmd.run:
-    - name: update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.1
+    - name: update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.3
 
 ruby_set_ri_version:
   cmd.run:
-    - name: update-alternatives --set ri /usr/bin/ri.ruby.ruby3.1
+    - name: update-alternatives --set ri /usr/bin/ri.ruby.ruby3.3
 {% endif %}
 
 install_chromium:
@@ -150,7 +150,7 @@ install_gems_via_bundle:
 {% else %}
 install_gems_via_bundle:
   cmd.run:
-    - name: bundle.ruby3.1 install --gemfile Gemfile
+    - name: bundle.ruby3.3 install --gemfile Gemfile
     - cwd: /root/spacewalk/testsuite
     - require:
       - pkg: cucumber_requisites

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -122,10 +122,11 @@ ruby_set_ri_version:
 twopence_install_from_source:
   cmd.run:
     - name: |
-        git clone https://github.com/nodeg/twopence.git /root/twopence
+        git clone https://github.com/openSUSE/twopence.git /root/twopence
         cd /root/twopence
         make
         make install
+        ldconfig
     - creates: /root/twopence
     - require:
       - pkg: cucumber_requisites
@@ -160,14 +161,7 @@ install_gems_via_bundle:
     - cwd: /root/spacewalk/testsuite
     - require:
       - pkg: cucumber_requisites
-      - cmd: spacewalk_git_repositoryo
-
-# https://github.com/gkushang/cucumber-html-reporter
-install_cucumber_html_reporter_via_npm:
-  cmd.run:
-    - name: npm install cucumber-html-reporter@5.5.0 --save-dev
-    - require:
-      - pkg: install_npm
+      - cmd: spacewalk_git_repository
 {% else %}
 install_gems_via_bundle:
   cmd.run:
@@ -177,14 +171,14 @@ install_gems_via_bundle:
       - pkg: cucumber_requisites
       - cmd: twopence_install_from_source
       - cmd: spacewalk_git_repository
-
-install_cucumber_html_reporter_via_npm:
-  cmd.run:
-    - name: npm install cucumber-html-reporter@7.1.1 --save-dev
-    - require:
-      - pkg: install_npm
 {% endif %}
 
+# https://github.com/gkushang/cucumber-html-reporter
+install_cucumber_html_reporter_via_npm:
+  cmd.run:
+    - name: npm install cucumber-html-reporter@5.5.0 --save-dev
+    - require:
+      - pkg: install_npm
 
 fix_cucumber_html_reporter_style:
   file.append:

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -67,8 +67,8 @@ cucumber_requisites:
       - wget
       - libssh-devel
       - python-devel
-      - ruby3.3
-      - ruby3.3-devel
+      - ruby3.1
+      - ruby3.1-devel
       - autoconf
       - ca-certificates-mozilla
       - automake
@@ -87,34 +87,34 @@ cucumber_requisites:
 
 /usr/bin/ruby:
   file.symlink:
-    - target: /usr/bin/ruby.ruby3.3
+    - target: /usr/bin/ruby.ruby3.1
     - force: True
 
 /usr/bin/gem:
   file.symlink:
-    - target: /usr/bin/gem.ruby3.3
+    - target: /usr/bin/gem.ruby3.1
     - force: True
 
 /usr/bin/irb:
   file.symlink:
-    - target: /usr/bin/irb.ruby3.3
+    - target: /usr/bin/irb.ruby3.1
     - force: True
 
 ruby_set_rake_version:
   cmd.run:
-    - name: update-alternatives --set rake /usr/bin/rake.ruby.ruby3.3
+    - name: update-alternatives --set rake /usr/bin/rake.ruby.ruby3.1
 
 ruby_set_bundle_version:
   cmd.run:
-    - name: update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.3
+    - name: update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.1
 
 ruby_set_rdoc_version:
   cmd.run:
-    - name: update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.3
+    - name: update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.1
 
 ruby_set_ri_version:
   cmd.run:
-    - name: update-alternatives --set ri /usr/bin/ri.ruby.ruby3.3
+    - name: update-alternatives --set ri /usr/bin/ri.ruby.ruby3.1
 {% endif %}
 
 install_chromium:
@@ -150,7 +150,7 @@ install_gems_via_bundle:
 {% else %}
 install_gems_via_bundle:
   cmd.run:
-    - name: bundle.ruby3.3 install --gemfile Gemfile
+    - name: bundle.ruby3.1 install --gemfile Gemfile
     - cwd: /root/spacewalk/testsuite
     - require:
       - pkg: cucumber_requisites

--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -15,6 +15,11 @@ include:
   - repos.testsuite
   - repos.tools
   - repos.jenkins
+  - repos.server_containerized
+  - repos.proxy_containerized
+  {% if '4.3' not in grains.get('product_version') %}
+  - repos.ruby
+  {% endif %}
   {% endif %}
   - repos.additional
 

--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -15,8 +15,6 @@ include:
   - repos.testsuite
   - repos.tools
   - repos.jenkins
-  - repos.server_containerized
-  - repos.proxy_containerized
   {% if '4.3' not in grains.get('product_version') %}
   - repos.ruby
   {% endif %}

--- a/salt/repos/ruby.sls
+++ b/salt/repos/ruby.sls
@@ -1,0 +1,21 @@
+{% if grains['os'] == 'SUSE' and ('controller' in grains.get('roles')) %}
+
+ruby_add_devel_repository:
+    pkgrepo.managed:
+      - name: ruby_devel
+      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby/15.5/
+      - refresh: True
+      - gpgautoimport: True
+
+ruby_gems_add_devel_repository:
+    pkgrepo.managed:
+      - name: ruby_devel_extensions
+      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/15.5/
+      - refresh: True
+      - gpgautoimport: True
+
+{% endif %}
+
+# WORKAROUND: see github:saltstack/salt#10852
+{{ sls }}_nop:
+  test.nop: []


### PR DESCRIPTION
# What does this PR change?

Prerequisite for https://github.com/uyuni-project/uyuni/pull/6559 / https://github.com/uyuni-project/uyuni/pull/9181. See also the issue https://github.com/SUSE/spacewalk/issues/17431. I only merge this PR, once everything in Uyuni is ready.

This will

- change the used Ruby version to 3.3 by adding and installing if via the Ruby devel repos (no Ruby > 2.5.9 in Leap 15.5/15.6 :cry: )
- ~build Twopence from source since there is no way we can build it in OBS with Ruby 3 on openSUSE Leap 15.5/15.6~
- adding the `product_version` variable to the controller grain, that we will use, to still be able to use Ruby 2.5 on 4.3
- fix the CI tests by including the checked `product_version` as a variable


Later on, I will also update Ruby in spacewalk for 4.3, but first we need it in master and giving it some time there.

## TODO

- [x] Add logic to only use the new Ruby version in Uyuni/Uyuni Podman/HEAD and 5.x. No 4.3 until later
- [x] Change the repository for Twopence once https://github.com/openSUSE/twopence/pull/81 will be merged
- [ ] Remove the Chromium/Chromedriver version constraints (126 was the version that caused issues), 128 is available in Leap in the meantime

# Links
- https://github.com/SUSE/spacewalk/issues/17431
- https://github.com/uyuni-project/uyuni/pull/6559 / https://github.com/uyuni-project/uyuni/pull/9181
