### PR TITLE
fix SLE Micro 5.3 provisioner

### DIFF
--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -7,7 +7,7 @@ FILE_ROOT="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 # Force direct call module executors on MicroOS images
 MODULE_EXEC=""
-if grep -q "cpe:/o:suse:suse-microos" /etc/os-release; then
+if grep -q "cpe:/o:suse:.*micro" /etc/os-release; then
 MODULE_EXEC="--module-executors=[direct_call]"
 fi
 


### PR DESCRIPTION
## What does this PR change?

`/etc/os-release` in SLE Micro 5.3 is:
```
NAME="SLE Micro"
VERSION="5.3"
VERSION_ID="5.3"
PRETTY_NAME="SUSE Linux Enterprise Micro 5.3"
ID="sle-micro"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sle-micro:5.3"

```
we need to adapt the script used as provisioner for the first deploy