### PR TITLE
Controller: update Ruby to 2.7

### DIFF
--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -130,6 +130,7 @@ export IS_USING_SCC_REPOSITORIES="{{ grains.get('is_using_scc_repositories') }}"
 export CATCH_TIMEOUT_MESSAGE="{{ grains.get('catch_timeout_message') }}"
 export SERVER_INSTANCE_ID="{{ grains.get('server_instance_id') }}"
 export BETA_ENABLED="{{ grains.get('beta_enabled') }}"
+export GEM_PATH="/usr/lib64/ruby/gems/2.7.0"
 
 #### Generate certificates for Google Chrome
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -31,8 +31,10 @@ cucumber_requisites:
       - gcc
       - make
       - wget
-      - ruby
-      - ruby-devel
+      - libssh-devel
+      - ruby2.7
+      - ruby2.7-devel
+      - ruby2.7-rubygem-bundler
       - autoconf
       - ca-certificates-mozilla
       - automake
@@ -46,16 +48,41 @@ cucumber_requisites:
       - mozilla-nss-tools
       - postgresql-devel
       - unzip
-      # packaged ruby gems
-      - ruby2.5-rubygem-bundler
-      - twopence
-      - python-twopence
-      - twopence-devel
-      - twopence-shell-client
-      - twopence-test-server
-      - rubygem-twopence
+      #- twopence
+      #- python-twopence
+      - python-devel
+      #- twopence-devel
+      #- twopence-shell-client
+      #- twopence-test-server
+      #- rubygem-twopence
     - require:
       - sls: repos
+
+/usr/bin/gem:
+  file.symlink:
+    - target: /usr/bin/gem.ruby2.7
+    - force: True
+
+ruby_set_rake_version:
+  cmd.run:
+    - name: update-alternatives --set rake /usr/bin/rake.ruby.ruby2.7
+
+ruby_set_bundle_version:
+  cmd.run:
+    - name: update-alternatives --set bundle /usr/bin/bundle.ruby.ruby2.7
+
+# workaround until twopence is adjusted for Ruby 3.x
+twopence_install_from_source:
+  cmd.run:
+    - name: |
+        git clone https://github.com/nodeg/twopence.git /root/twopence
+        cd /root/twopence
+        git checkout update-ruby27
+        make
+        make install
+    - creates: /root/twopence
+    - require:
+      - pkg: cucumber_requisites
 
 install_chromium:
   pkg.installed:
@@ -77,10 +104,11 @@ create_syslink_for_chromedriver:
 
 install_gems_via_bundle:
   cmd.run:
-    - name: bundle.ruby2.5 install --gemfile Gemfile
+    - name: bundle.ruby2.7 install --gemfile Gemfile
     - cwd: /root/spacewalk/testsuite
     - require:
       - pkg: cucumber_requisites
+      - cmd: twopence_install_from_source
       - cmd: spacewalk_git_repository
 
 install_npm:

--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -13,6 +13,7 @@ include:
   - repos.jenkins
   - repos.server_containerized
   - repos.proxy_containerized
+  - repos.ruby
   {% endif %}
   - repos.additional
 

--- a/salt/repos/ruby.sls
+++ b/salt/repos/ruby.sls
@@ -1,0 +1,21 @@
+{% if grains['os'] == 'SUSE' and ('controller' in grains.get('roles')) %}
+
+ruby_add_devel_repository:
+    pkgrepo.managed:
+      - name: Ruby devel
+      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby/15.5/
+      - refresh: True
+      - gpgautoimport: True
+
+ruby_gems_add_devel_repository:
+    pkgrepo.managed:
+      - name: Ruby devel extensions
+      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/15.5/
+      - refresh: True
+      - gpgautoimport: True
+
+{% endif %}
+
+# WORKAROUND: see github:saltstack/salt#10852
+{{ sls }}_nop:
+  test.nop: []


### PR DESCRIPTION
## What does this PR change?

This will update the Ruby version on the controller from 2.5.9 to 2.7.

See https://github.com/SUSE/spacewalk/issues/17431
