### PR TITLE
Use by default chrony except in specific cases

### DIFF
--- a/salt/default/time.sls
+++ b/salt/default/time.sls
@@ -23,9 +23,7 @@ timezone_setting:
 
 {% if grains['use_ntp'] %}
 
-{% if grains['osfullname'] == 'SLES' %}
-
-{% if grains['osrelease'] == '11.4' %}
+{% if ((grains['osfullname'] == 'SLES') and (grains['osrelease'] == '11.4')) or ((grains['os_family'] == 'Debian') and (grains['osrelease'] == '10')) or (grains['osfullname'] == 'Leap') %}
 
 ntp_pkg:
   pkg.installed:
@@ -58,23 +56,4 @@ chrony_enable_service:
     - enable: true
 
 {% endif %}
-
-{% elif grains['osfullname'] == 'Leap' %}
-
-ntp_pkg:
-  pkg.installed:
-    - name: ntp
-
-ntp_conf_file:
-  file.managed:
-    - name: /etc/ntp.conf
-    - source: salt://default/ntp.conf
-
-ntp_enable_service:
-  service.running:
-    - name: ntpd
-    - enable: true
-
-{% endif %}
-
 {% endif %}

--- a/salt/default/time.sls
+++ b/salt/default/time.sls
@@ -23,7 +23,10 @@ timezone_setting:
 
 {% if grains['use_ntp'] %}
 
-{% if ((grains['osfullname'] == 'SLES') and (grains['osrelease'] == '11.4')) or ((grains['os_family'] == 'Debian') and (grains['osrelease'] == '10')) or (grains['osfullname'] == 'Leap') %}
+{% if ((grains['osfullname'] == 'SLES') and (grains['osrelease'] == '11.4'))
+   or ((grains['os_family'] == 'Debian') and (grains['osrelease'] == '10'))
+   or (grains['osfullname'] == 'Leap')
+%}
 
 ntp_pkg:
   pkg.installed:


### PR DESCRIPTION
## What does this PR change?

Use by default chrony except in specific cases, SLES 11.4, Debian 10 and Leap. Those use ntp.

Without this we don't set ntp or chrony in ubuntu, debian, ol, almalinux, rocky and in BV where we do use them we see failures because the clock drifts.
