### PR TITLE
Fix time state to use ntpd in Leap

### DIFF
--- a/salt/default/time.sls
+++ b/salt/default/time.sls
@@ -25,7 +25,6 @@ timezone_setting:
 
 {% if ((grains['osfullname'] == 'SLES') and (grains['osrelease'] == '11.4'))
    or ((grains['os_family'] == 'Debian') and (grains['osrelease'] == '10'))
-   or (grains['osfullname'] == 'Leap')
 %}
 
 ntp_pkg:
@@ -40,6 +39,22 @@ ntp_conf_file:
 ntp_enable_service:
   service.running:
     - name: ntp
+    - enable: true
+
+{% elif  grains['osfullname'] == 'Leap' %}
+
+ntp_pkg:
+  pkg.installed:
+    - name: ntp
+
+ntp_conf_file:
+  file.managed:
+    - name: /etc/ntp.conf
+    - source: salt://default/ntp.conf
+
+ntp_enable_service:
+  service.running:
+    - name: ntpd
     - enable: true
 
 {% else %}


### PR DESCRIPTION
## What does this PR change?

Fix time state to use ntpd in Leap instead of ntp. Partially reverts https://github.com/uyuni-project/sumaform/pull/1256 and fixes the issue for the controller in HEAD. 
