### PR TITLE
Adjust virthost for static nested VM hostname

### DIFF
--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -662,5 +662,5 @@ variable "is_using_scc_repositories" {
 variable "nested_vm_hosts" {
   description = "Hostnames for nested VMs if they are used, see README_TESTING.md"
   type        = list(string)
-  default     = ["leap-salt-migration", "sles-salt-migration"]
+  default     = ["min-nested"]
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -151,5 +151,5 @@ variable "login_timeout" {
 variable "nested_vm_hosts" {
   description = "Hostnames for nested VMs if they are used, see README_TESTING.md"
   type        = list(string)
-  default     = ["leap-salt-migration", "sles-salt-migration"]
+  default     = ["min-nested"]
 }

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -17,8 +17,7 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 # Salt bundle test specific hosts
 {%- if grains.get('nested_vm_hosts') %}
 {%- for name in grains['nested_vm_hosts'] %}
-{% set hostname = name.upper() | replace("-","_") -%}
-export {{ hostname }}="{{ name }}.{{ grains.get('domain') }}"
+export MIN_NESTED="{{ name }}.{{ grains.get('domain') }}"
 {%- endfor %}
 {% else %}
 # no nested VMs defined

--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -184,7 +184,7 @@ cloudinit-user-data-{{ os_type }}:
           path: /etc/nsswitch.conf
         runcmd:
         - hostnamectl hostname {{ salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hostname') }}.{{ grains.get('domain') }}
-{% if salt['grains.get']('hvm_disk_image:' ~ os_type ~ ':hostname') == 'sles' %}
+{% if os_type == 'sles' %}
         # add SLES 15 SP4 base repository
         - zypper --non-interactive ar "http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP4/x86_64/product/" SLE-Module-Basesystem15-SP4-Pool
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

After adding a static hostname for the nested VM in the infrastructure repository, I need to make adjustments here, too.

- `min-nested` is the default name for nested minions. Furthermore we only need one default hostname.
- `MIN_NESTED` is the default environment variable that is exposed on the controller.