### PR TITLE
Make sumaform to use "venv-salt-call" for deployments if available and wait for "cloud-init" to finish

### DIFF
--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -5,6 +5,18 @@
 
 FILE_ROOT="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
+if [ -x /usr/bin/venv-salt-call ]; then
+    echo "Salt Bundle detected! We use it for running sumaform deployment"
+    echo "Copying /etc/salt/grains to /etc/venv-salt-minion"
+    cp /etc/salt/grains /etc/venv-salt-minion/grains
+    SALT_CALL=venv-salt-call
+elif [ -x /usr/bin/salt-call ]; then
+    SALT_CALL=salt-call
+else
+    echo "Error: Cannot find venv-salt-call or salt-call on the system"
+    exit 1
+fi
+
 # Force direct call module executors on MicroOS images
 MODULE_EXEC=""
 if grep -q "cpe:/o:.*suse:.*micro" /etc/os-release; then
@@ -13,23 +25,23 @@ fi
 
 echo "starting first call to update salt and do minimal configuration"
 
-salt-call --local --file-root=$FILE_ROOT/ --log-level=info $MODULE_EXEC state.sls default.minimal ||:
+$SALT_CALL --local --file-root=$FILE_ROOT/ --log-level=info $MODULE_EXEC state.sls default.minimal ||:
 
 NEXT_TRY=0
-until [ $NEXT_TRY -eq 10 ] || salt-call --local test.ping
+until [ $NEXT_TRY -eq 10 ] || $SALT_CALL --local test.ping
 do
-        echo "It seems salt-call is not available after default.minimal state was applied. Retrying... [$NEXT_TRY]";
+        echo "It seems neither venv-salt-call or salt-call are available after default.minimal state was applied. Retrying... [$NEXT_TRY]";
         sleep 1;
         ((NEXT_TRY++));
 done
 
 if [ $NEXT_TRY -eq 10 ]
 then
-        echo "ERROR: salt-call is not available after 10 retries";
+        echo "ERROR: Neither venv-salt-call or salt-call are available after 10 retries";
 fi
 
 echo "apply highstate"
 
-salt-call --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color $MODULE_EXEC state.highstate || exit 1
+$SALT_CALL --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color $MODULE_EXEC state.highstate || exit 1
 
 chmod +x ${FILE_ROOT}/highstate.sh

--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -28,7 +28,7 @@ fi
 
 if [ -x /usr/bin/venv-salt-call ]; then
     echo "Salt Bundle detected! We use it for running sumaform deployment"
-    echo "Copying /etc/salt/grains to /etc/venv-salt-minion"
+    echo "Copying /etc/salt/grains to /etc/venv-salt-minion/grains"
     cp /etc/salt/grains /etc/venv-salt-minion/grains
     SALT_CALL=venv-salt-call
 elif [ -x /usr/bin/salt-call ]; then

--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -16,7 +16,7 @@ NEXT_TRY=0
 until [ $NEXT_TRY -eq 10 ] || ! cloud-init status | grep running
 do
         echo "cloud-init is still running. Retrying... [$NEXT_TRY]";
-        sleep 5;
+        sleep 10;
         ((NEXT_TRY++));
 done
 

--- a/salt/highstate.sh
+++ b/salt/highstate.sh
@@ -3,4 +3,13 @@
 # Applies the highstate - assumes the minimal state was already applied
 FILE_ROOT="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
-salt-call --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color state.highstate
+if [ -x /usr/bin/venv-salt-call ]; then
+    SALT_CALL=venv-salt-call
+elif [ -x /usr/bin/salt-call ]; then
+    SALT_CALL=salt-call
+else
+    echo "Error: Cannot find venv-salt-call or salt-call on the system"
+    exit 1
+fi
+
+$SALT_CALL --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color state.highstate

--- a/salt/post_provisioning_cleanup.sh
+++ b/salt/post_provisioning_cleanup.sh
@@ -3,17 +3,23 @@
 # If we are using Salt Bundle (venv-salt-minion), then we need to remove
 # the original Salt package installed on the instance.
 
+if [ -x /usr/bin/venv-salt-call ]; then
+    SALT_CALL=venv-salt-call
+elif [ -x /usr/bin/salt-call ]; then
+    SALT_CALL=salt-call
+else
+    echo "Error: Cannot find venv-salt-call or salt-call on the system"
+    exit 1
+fi
+
 # Nothing to do in case "install_salt_bundle" grain is not true
-INSTALL_SALT_BUNDLE=$(salt-call --local --log-level=quiet --output=txt grains.get install_salt_bundle)
+INSTALL_SALT_BUNDLE=$($SALT_CALL --local --log-level=quiet --output=txt grains.get install_salt_bundle)
 
 if [[ "$INSTALL_SALT_BUNDLE" != "local: True" ]]; then
     exit 0
 fi
 
 echo "This instance is configured to use Salt Bundle in /etc/salt/grains !"
-
-echo "Copying /etc/salt/grains to /etc/venv-salt-minion"
-cp /etc/salt/grains /etc/venv-salt-minion/grains
 
 if [ -x /usr/bin/dnf ]; then
     INSTALLER=yum

--- a/salt/wait_for_salt.sh
+++ b/salt/wait_for_salt.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 
+if [ -x /usr/bin/venv-salt-call ]; then
+    SALT_CALL=venv-salt-call
+elif [ -x /usr/bin/salt-call ]; then
+    SALT_CALL=salt-call
+else
+    echo "Error: Cannot find venv-salt-call or salt-call on the system"
+    exit 1
+fi
+
 # As Salt might be in the process of being installed by cloud-init, this script waits for it
 
 for i in {0..100}
 do
-  if salt-call --help &>/dev/null; then
+  if $SALT_CALL --help &>/dev/null; then
     break
   fi
   echo "Waiting for salt to be installed..."


### PR DESCRIPTION
## What does this PR change?

This PR makes sumaform to use `venv-salt-call` if available instead of  `salt-call` for running the provisioning of the new instances. As we are moving to Salt Bundle, there are instances now where classic `salt-call` is not really available.

Addtionally, this PR introduces a mechanism to check that `cloud-init` is not still running before we start with the provisioning, as it was detected that sometimes `salt-call` execution starts with `cloud-init` still installing packages on the instance.

