### PR TITLE
Do not use "/etc/salt/grains" as the place to deploy sumaform grains

### DIFF
--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -213,12 +213,6 @@ resource "null_resource" "host_salt_configuration" {
     destination = "/tmp"
   }
 
-  provisioner "remote-exec" {
-    inline = [
-      "bash /tmp/salt/wait_for_salt.sh",
-    ]
-  }
-
   provisioner "file" {
 
     content = yamlencode(merge(
@@ -256,7 +250,12 @@ resource "null_resource" "host_salt_configuration" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv /tmp/grains /etc/salt/grains",
+      "bash /tmp/salt/wait_for_salt.sh",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
       "sudo rm -rf /root/salt",
       "sudo mv /tmp/salt /root",
       "sudo bash /root/salt/first_deployment_highstate.sh"

--- a/backend_modules/azure/host/main.tf
+++ b/backend_modules/azure/host/main.tf
@@ -167,12 +167,6 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
     destination = "/tmp"
   }
 
-  provisioner "remote-exec" {
-    inline = [
-      "bash /tmp/salt/wait_for_salt.sh",
-    ]
-  }
-
   provisioner "file" {
 
     content = yamlencode(merge(
@@ -208,7 +202,12 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv /tmp/grains /etc/salt/grains",
+      "bash /tmp/salt/wait_for_salt.sh",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
       "sudo rm -rf /root/salt",
       "sudo mv /tmp/salt /root",
       "sudo bash /root/salt/first_deployment_highstate.sh"

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -241,9 +241,9 @@ resource "null_resource" "provisioning" {
   }
 
   provisioner "remote-exec" {
-    inline = local.cloud_init ? [
+    inline = [
       "bash /root/salt/wait_for_salt.sh",
-    ] : ["bash -c \"echo 'no cloud init, nothing to do'\""]
+    ]
   }
 
   provisioner "remote-exec" {

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -206,12 +206,6 @@ resource "null_resource" "provisioning" {
     destination = "/root"
   }
 
-  provisioner "remote-exec" {
-    inline = local.cloud_init ? [
-      "bash /root/salt/wait_for_salt.sh",
-    ] : ["bash -c \"echo 'no cloud init, nothing to do'\""]
-  }
-
   provisioner "file" {
     content = yamlencode(merge(
       {
@@ -243,7 +237,13 @@ resource "null_resource" "provisioning" {
         provider                      = "libvirt"
       },
     var.grains))
-    destination = "/etc/salt/grains"
+    destination = "/tmp/grains"
+  }
+
+  provisioner "remote-exec" {
+    inline = local.cloud_init ? [
+      "bash /root/salt/wait_for_salt.sh",
+    ] : ["bash -c \"echo 'no cloud init, nothing to do'\""]
   }
 
   provisioner "remote-exec" {

--- a/backend_modules/ssh/host/main.tf
+++ b/backend_modules/ssh/host/main.tf
@@ -68,6 +68,12 @@ resource "null_resource" "provisioning" {
     destination = "/opt"
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "bash /opt/salt/wait_for_salt.sh",
+    ]
+  }
+
   provisioner "file" {
     content = yamlencode(merge(
       {
@@ -97,7 +103,7 @@ resource "null_resource" "provisioning" {
         data_disk_device              = contains(var.roles, "suse_manager_server") || contains(var.roles, "suse_manager_proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdb" : null
       },
     var.grains))
-    destination = "/etc/salt/grains"
+    destination = "/tmp/grains"
   }
 
   provisioner "remote-exec" {

--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -11,25 +11,7 @@ if grep -q "cpe:/o:.*suse:.*micro" /etc/os-release; then
 MODULE_EXEC="--module-executors=[direct_call]"
 fi
 
-# Wait for cloud-init to finish
-NEXT_TRY=0
-until [ $NEXT_TRY -eq 10 ] || ! cloud-init status | grep running
-do
-        echo "cloud-init is still running. Retrying... [$NEXT_TRY]";
-        sleep 10;
-        ((NEXT_TRY++));
-done
-
-if [ $NEXT_TRY -eq 10 ]
-then
-        echo "cloud-init is still running after 10 retries";
-	exit 1;
-fi
-
 if [ -x /usr/bin/venv-salt-call ]; then
-    echo "Salt Bundle detected! We use it for running sumaform deployment"
-    echo "Copying /etc/salt/grains to /etc/venv-salt-minion/grains"
-    cp /etc/salt/grains /etc/venv-salt-minion/grains
     SALT_CALL=venv-salt-call
 elif [ -x /usr/bin/salt-call ]; then
     SALT_CALL=salt-call
@@ -40,10 +22,10 @@ fi
 
 echo "starting first call to update salt and do minimal configuration"
 
-$SALT_CALL --local --file-root=$FILE_ROOT/ --log-level=info $MODULE_EXEC state.sls default.minimal ||:
+${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info $MODULE_EXEC state.sls default.minimal ||:
 
 NEXT_TRY=0
-until [ $NEXT_TRY -eq 10 ] || $SALT_CALL --local test.ping
+until [ $NEXT_TRY -eq 10 ] || ${SALT_CALL} --local test.ping
 do
         echo "It seems neither venv-salt-call or salt-call are available after default.minimal state was applied. Retrying... [$NEXT_TRY]";
         sleep 1;
@@ -57,6 +39,6 @@ fi
 
 echo "apply highstate"
 
-$SALT_CALL --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color $MODULE_EXEC state.highstate || exit 1
+${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color $MODULE_EXEC state.highstate || exit 1
 
 chmod +x ${FILE_ROOT}/highstate.sh

--- a/salt/highstate.sh
+++ b/salt/highstate.sh
@@ -12,4 +12,4 @@ else
     exit 1
 fi
 
-$SALT_CALL --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color state.highstate
+${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color state.highstate

--- a/salt/post_provisioning_cleanup.sh
+++ b/salt/post_provisioning_cleanup.sh
@@ -13,13 +13,13 @@ else
 fi
 
 # Nothing to do in case "install_salt_bundle" grain is not true
-INSTALL_SALT_BUNDLE=$($SALT_CALL --local --log-level=quiet --output=txt grains.get install_salt_bundle)
+INSTALL_SALT_BUNDLE=$(${SALT_CALL} --local --log-level=quiet --output=txt grains.get install_salt_bundle)
 
 if [[ "$INSTALL_SALT_BUNDLE" != "local: True" ]]; then
     exit 0
 fi
 
-echo "This instance is configured to use Salt Bundle in /etc/salt/grains !"
+echo "This instance is configured to use Salt Bundle in grains !"
 
 if [ -x /usr/bin/dnf ]; then
     INSTALLER=yum

--- a/salt/wait_for_salt.sh
+++ b/salt/wait_for_salt.sh
@@ -1,19 +1,38 @@
 #!/bin/bash
 
+# Wait for cloud-init to finish
+NEXT_TRY=0
+until [ $NEXT_TRY -eq 10 ] || ! cloud-init status | grep running
+do
+        echo "cloud-init is still running. Retrying... [$NEXT_TRY]";
+        sleep 10;
+        ((NEXT_TRY++));
+done
+
+if [ $NEXT_TRY -eq 10 ]
+then
+        echo "cloud-init is still running after 10 retries";
+	exit 1;
+fi
+
 if [ -x /usr/bin/venv-salt-call ]; then
+    echo "Salt Bundle detected! We use it for running sumaform deployment"
+    echo "Copying /tmp/grains to /etc/venv-salt-minion/grains"
+    cp /tmp/grains /etc/venv-salt-minion/grains
     SALT_CALL=venv-salt-call
 elif [ -x /usr/bin/salt-call ]; then
+    echo "Classic Salt detected! We use it for running sumaform deployment"
+    echo "Copying /tmp/grains to /etc/salt/grains"
+    cp /tmp/grains /etc/salt/grains
     SALT_CALL=salt-call
 else
     echo "Error: Cannot find venv-salt-call or salt-call on the system"
     exit 1
 fi
 
-# As Salt might be in the process of being installed by cloud-init, this script waits for it
-
 for i in {0..100}
 do
-  if $SALT_CALL --help &>/dev/null; then
+  if ${SALT_CALL} --help &>/dev/null; then
     break
   fi
   echo "Waiting for salt to be installed..."

--- a/salt/wait_for_salt.sh
+++ b/salt/wait_for_salt.sh
@@ -1,18 +1,20 @@
 #!/bin/bash
 
-# Wait for cloud-init to finish
-NEXT_TRY=0
-until [ $NEXT_TRY -eq 10 ] || ! cloud-init status | grep running
-do
-        echo "cloud-init is still running. Retrying... [$NEXT_TRY]";
-        sleep 10;
-        ((NEXT_TRY++));
-done
+if [ -x /usr/bin/cloud-init ]; then
+    # Wait for cloud-init to finish
+    NEXT_TRY=0
+    until [ $NEXT_TRY -eq 10 ] || ! cloud-init status | grep running
+    do
+            echo "cloud-init is still running. Retrying... [$NEXT_TRY]";
+            sleep 10;
+            ((NEXT_TRY++));
+    done
 
-if [ $NEXT_TRY -eq 10 ]
-then
-        echo "cloud-init is still running after 10 retries";
-	exit 1;
+    if [ $NEXT_TRY -eq 10 ]
+    then
+            echo "cloud-init is still running after 10 retries";
+            exit 1;
+    fi
 fi
 
 if [ -x /usr/bin/venv-salt-call ]; then


### PR DESCRIPTION
## What does this PR change?

This PR is a continuation of https://github.com/uyuni-project/sumaform/pull/1264, in order to fix some issues:

- Grains are deployed after initial `wait_for_salt.sh` script runs, so grains are not properly captured in case of Salt Bundle.
- Sumaform deploys grains to `/etc/salt/grains` and this directory might not exist if there is only Salt Bundle.

In order to fix these issues, this PR does the following changes:

- sumaform grains are now set to `/tmp/grains` instead of directly to `/etc/salt/grains` (which might not exist)
- the deployment of `/tmp/grains` is now done before initial `wait_for_salt.sh` execution.
- the initial stage, `wait_for_salt.sh`, waits for cloud-init and then check the expected salt installed, then it copies grains to `/etc/salt/grains` or `/etc/venv-salt-minion/grains` accordingly.

So, deployment would run like this:

1) VM creation.
2) cloud-init starts execution.
3) Grains are deployed by sumaform to `/tmp/grains`
4) Sumaform executes `wait_for_salt.sh` (waits until cloudinit finished and set grains to corresponding `/etc/` path, and corresponding "salt-call" or "venv-salt-call" is available)
5) Sumaform executes `first_deployment_highstate.sh` (apply Salt states using `salt-call` or `venv-salt-call` accordingly)
6) Rest of execution.