### PR TITLE
Increase retries when waiting "cloud-init" to finish

### DIFF
--- a/salt/wait_for_salt.sh
+++ b/salt/wait_for_salt.sh
@@ -3,16 +3,16 @@
 if [ -x /usr/bin/cloud-init ]; then
     # Wait for cloud-init to finish
     NEXT_TRY=0
-    until [ $NEXT_TRY -eq 10 ] || ! cloud-init status | grep running
+    until [ $NEXT_TRY -eq 50 ] || ! cloud-init status | grep running
     do
             echo "cloud-init is still running. Retrying... [$NEXT_TRY]";
             sleep 10;
             ((NEXT_TRY++));
     done
 
-    if [ $NEXT_TRY -eq 10 ]
+    if [ $NEXT_TRY -eq 50 ]
     then
-            echo "cloud-init is still running after 10 retries";
+            echo "ERROR: cloud-init is still running after 50 retries";
             exit 1;
     fi
 fi


### PR DESCRIPTION
## What does this PR change?

As mentioned, this PR increases the waiting time for "cloud-init" to finish. We have noticed that in certain environments, the current waiting time (100 sec) was not really enough. 

This PR increases this to 500 sec.
