### PR TITLE
Correctly handle eip bastion variable

### DIFF
--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -15,6 +15,7 @@ module "base_backend" {
   testsuite                = var.testsuite
   provider_settings        = var.provider_settings
   images                   = var.images
+  use_eip_bastion          = var.use_eip_bastion
 }
 
 output "configuration" {
@@ -31,5 +32,6 @@ output "configuration" {
     name_prefix              = var.name_prefix
     use_shared_resources     = var.use_shared_resources
     testsuite                = var.testsuite
+    use_eip_bastion          = var.use_eip_bastion
   }, module.base_backend.configuration)
 }


### PR DESCRIPTION
## What does this PR change?

When setting false to eip bastion in main.tf base, the variable is not correctly setup in sumaform.

Fix the base module to correctly handle the variable.