### PR TITLE
change remote debug tomcat configuration

### DIFF
--- a/salt/server/tomcat.sls
+++ b/salt/server/tomcat.sls
@@ -3,17 +3,13 @@
 include:
   - server.rhn
 
-tomcat_config:
-  file.replace:
-    - name: /etc/sysconfig/tomcat
-    - pattern: 'JAVA_OPTS="(?!-Xdebug)(.*)"'
+/etc/tomcat/conf.d/remote_debug.conf:
+  file.append:
     {% if grains['hostname'] and grains['domain'] %}
-    - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['hostname'] }}.{{ grains['domain'] }}:8000,server=y,suspend=n \1"'
+    - text: 'JAVA_OPTS=" $JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['hostname'] }}.{{ grains['domain'] }}:8000,server=y,suspend=n "'
     {% else %}
-    - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['fqdn'] }}:8000,server=y,suspend=n \1"'
+    - text: 'JAVA_OPTS=" $JAVA_OPTS -Xdebug -Xrunjdwp:transport=dt_socket,address={{ grains['fqdn'] }}:8000,server=y,suspend=n "'
     {% endif %}
-    - require:
-      - sls: server.rhn
 
 {% endif %}
 
@@ -33,7 +29,7 @@ tomcat_service:
     - name: tomcat
     - watch:
       {% if grains.get('java_debugging') %}
-      - file: tomcat_config
+      - file: /etc/tomcat/conf.d/remote_debug.conf
       {% endif %}
       - file: /etc/rhn/rhn.conf
       {% if grains.get('monitored') | default(false, true) %}

--- a/salt/server/tomcat.sls
+++ b/salt/server/tomcat.sls
@@ -4,10 +4,8 @@ include:
   - server.rhn
 
 tomcat_config_create:
-  file.managed:
+  file.touch:
     - name: /etc/tomcat/conf.d/remote_debug.conf
-    - contents: ''
-    - contents_newline: False
     - makedirs: True
 
 tomcat_config:


### PR DESCRIPTION
## What does this PR change?

I'm trying to clean up all the tomcat custom configuration in uyuni and sumaform. Currently we have configuration in:
- `/etc/sysconfig/tomcat`
- `/etc/tomcat.conf`
and apply them requires parsing the content with some regex.
This change is aligned with the ones that I'm having for `uyuni`, where each different configuration is in a different file in `/etc/tomcat/conf.d/*conf`

Fixes https://github.com/SUSE/spacewalk/issues/19824
