### PR TITLE
QE: Add `nested_vm_macs` variable

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -304,10 +304,12 @@ host_settings = {
 }
 ```
 
-Furthermore you have to specify another variable inside your `main.tf` that defines the hostname of the images you use:
+Furthermore you have to specify 2 other variable inside your `main.tf` that defines the hostname and the MAC addresses
+of the images you use, if needed:
 
 ```hcl
 nested_vm_hosts = ["hostname1"]
+nested_vm_macs  = ["aa:bb:cc:dd:ee:ff"]
 ```
 
 It should contain the same hostnames as the ones defined in the `hvm_disk_image` section you see above. This is a

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -33,6 +33,7 @@ module "controller" {
     cc_password  = var.base_configuration["cc_password"]
     git_username = var.git_username
     nested_vm_hosts = var.nested_vm_hosts
+    nested_vm_macs = var.nested_vm_macs
     git_password = var.git_password
     git_repo     = var.git_repo
     branch       = var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -678,3 +678,9 @@ variable "nested_vm_hosts" {
   type        = list(string)
   default     = ["min-nested"]
 }
+
+variable "nested_vm_macs" {
+  description = "MAC addresses for nested VMs if they are used, see README_TESTING.md"
+  type        = list(string)
+  default     = [""]
+}

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -352,6 +352,7 @@ module "controller" {
   branch                   = var.branch
   git_username             = var.git_username
   nested_vm_hosts          = var.nested_vm_hosts
+  nested_vm_macs           = var.nested_vm_macs
   git_password             = var.git_password
   git_repo                 = var.git_repo
   git_profiles_repo        = var.git_profiles_repo

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -153,3 +153,9 @@ variable "nested_vm_hosts" {
   type        = list(string)
   default     = ["min-nested"]
 }
+
+variable "nested_vm_macs" {
+  description = "MAC addresses for nested VMs if they are used, see README_TESTING.md"
+  type        = list(string)
+  default     = [""]
+}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -15,10 +15,10 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 {% if grains.get('monitoring_server') | default(false, true) %}export MONITORING_SERVER="{{ grains.get('monitoring_server') }}"{% else %}# no monitoring server defined {% endif %}
 
 # Salt bundle test specific hosts
+# At the moment we only need/support one nested VM in the test suite
 {%- if grains.get('nested_vm_hosts') %}
-{%- for name in grains['nested_vm_hosts'] %}
-export MIN_NESTED="{{ name }}.{{ grains.get('domain') }}"
-{%- endfor %}
+export MIN_NESTED="{{ grains.get('nested_vm_hosts') }}.{{ grains.get('domain') }}"
+export MAC_MIN_NESTED="{{ grains.get('nested_vm_macs') }}"
 {% else %}
 # no nested VMs defined
 {%- endif %}


### PR DESCRIPTION
## What does this PR change?

This will add a new variable to the `controller` and `cucumber_testsuite` module to be able to specify MAC addresses for a nested VM. We need this to be able to specify MAC addresses for the Salt bundle migration tests in our CI test suite. Before they were defined in an array in the test suite code which was not optimal.

I tested this locally. After deploying a environment, I see the correct exports.

```bash
uyuni-ctl:~ # cat .bashrc | grep NESTED
export MIN_NESTED="['uyuni-master-min-nested'].tf.local"
export MAC_MIN_NESTED="['aa:b2:93:01:00:df']"
```

### Links

- https://github.com/SUSE/spacewalk/issues/17238
- https://github.com/uyuni-project/sumaform/pull/1278
