### PR TITLE
Revert nested VM variables from list to string

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -305,12 +305,12 @@ host_settings = {
 ```
 
 Furthermore you have to specify 2 other variable inside your `main.tf` that defines the hostname and the MAC addresses
-of the images you use, if needed:
+of the image you use, if needed:
 
 ```hcl
-nested_vm_hosts = ["hostname1"]
-nested_vm_macs  = ["aa:bb:cc:dd:ee:ff"]
+nested_vm_host = "hostname1"
+nested_vm_mac  = "aa:bb:cc:dd:ee:ff"
 ```
 
-It should contain the same hostnames as the ones defined in the `hvm_disk_image` section you see above. This is a
+It should contain the same hostname as the one defined in the `hvm_disk_image` section you see above. This is a
 workaround to not have to refactor parts of the current sumaform code.

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -32,8 +32,8 @@ module "controller" {
     cc_username  = var.base_configuration["cc_username"]
     cc_password  = var.base_configuration["cc_password"]
     git_username = var.git_username
-    nested_vm_hosts = var.nested_vm_hosts
-    nested_vm_macs = var.nested_vm_macs
+    nested_vm_host = var.nested_vm_host
+    nested_vm_mac = var.nested_vm_mac
     git_password = var.git_password
     git_repo     = var.git_repo
     branch       = var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -673,14 +673,14 @@ variable "is_using_scc_repositories" {
   default     = false
 }
 
-variable "nested_vm_hosts" {
-  description = "Hostnames for nested VMs if they are used, see README_TESTING.md"
-  type        = list(string)
-  default     = ["min-nested"]
+variable "nested_vm_host" {
+  description = "Hostname for a nested VM if it is used, see README_TESTING.md"
+  type        = string
+  default     = "min-nested"
 }
 
-variable "nested_vm_macs" {
-  description = "MAC addresses for nested VMs if they are used, see README_TESTING.md"
-  type        = list(string)
-  default     = [""]
+variable "nested_vm_mac" {
+  description = "MAC address for a nested VM if it is used, see README_TESTING.md"
+  type        = string
+  default     = ""
 }

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -351,8 +351,8 @@ module "controller" {
 
   branch                   = var.branch
   git_username             = var.git_username
-  nested_vm_hosts          = var.nested_vm_hosts
-  nested_vm_macs           = var.nested_vm_macs
+  nested_vm_host          = var.nested_vm_host
+  nested_vm_mac           = var.nested_vm_mac
   git_password             = var.git_password
   git_repo                 = var.git_repo
   git_profiles_repo        = var.git_profiles_repo

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -148,14 +148,14 @@ variable "login_timeout" {
   default     = null
 }
 
-variable "nested_vm_hosts" {
-  description = "Hostnames for nested VMs if they are used, see README_TESTING.md"
-  type        = list(string)
-  default     = ["min-nested"]
+variable "nested_vm_host" {
+  description = "Hostname for a nested VM if it is used, see README_TESTING.md"
+  type        = string
+  default     = "min-nested"
 }
 
-variable "nested_vm_macs" {
-  description = "MAC addresses for nested VMs if they are used, see README_TESTING.md"
-  type        = list(string)
-  default     = [""]
+variable "nested_vm_mac" {
+  description = "MAC address for a nested VM if it is used, see README_TESTING.md"
+  type        = string
+  default     = ""
 }

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -16,13 +16,10 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 
 # Salt bundle test specific hosts
 # At the moment we only need/support one nested VM in the test suite
-{%- if grains.get('nested_vm_hosts') %}
-{%- for name in grains['nested_vm_hosts'] %}
-export MIN_NESTED="{{ name }}.{{ grains.get('domain') }}"
-{%- endfor %}
-{%- for mac in grains['nested_vm_macs'] %}
-export MAC_MIN_NESTED="{{ mac }}"
-{%- endfor %}
+{%- if grains.get('nested_vm_host') %}
+export MIN_NESTED="{{ grains.get('nested_vm_host')  }}.{{ grains.get('domain') }}"
+{% elif grains.get('nested_vm_mac') %}
+export MAC_MIN_NESTED="{{ grains.get('nested_vm_mac')  }}"
 {% else %}
 # no nested VMs defined
 {%- endif %}


### PR DESCRIPTION
## What does this PR change?

Revert the nested VM variables from a list to a string since we only support one nested VM in the test suite for now.
