### PR TITLE
Fix logic error for nested VM parameters

### DIFF
--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -16,13 +16,8 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 
 # Salt bundle test specific hosts
 # At the moment we only need/support one nested VM in the test suite
-{%- if grains.get('nested_vm_host') %}
-export MIN_NESTED="{{ grains.get('nested_vm_host')  }}.{{ grains.get('domain') }}"
-{% elif grains.get('nested_vm_mac') %}
-export MAC_MIN_NESTED="{{ grains.get('nested_vm_mac')  }}"
-{% else %}
-# no nested VMs defined
-{%- endif %}
+{%- if grains.get('nested_vm_host') %}export MIN_NESTED="{{ grains.get('nested_vm_host') }}.{{ grains.get('domain') }}"{% else %}# no nested VM hostname defined {%- endif %}
+{% if grains.get('nested_vm_mac') %}export MAC_MIN_NESTED="{{ grains.get('nested_vm_mac') }}"{% else %}# no nested VM MAC address defined {%- endif %}
 
 # base goodies
 {% if grains.get('additional_network') | default(false, true) %}export PRIVATENET="{{ grains.get('additional_network') }}" {% else %}# no private network defined {% endif %}


### PR DESCRIPTION
## What does this PR change?

This fixes a logic issue for the nested VM parameters in the Jinja templates on the controller. We basically need need 2 distinct `if` conditions instead of an `elseif`. Furthermore it aligns the formatting to the other code.
