### PR TITLE
Do not remove empty line before if condition

### DIFF
--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -16,7 +16,7 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 
 # Salt bundle test specific hosts
 # At the moment we only need/support one nested VM in the test suite
-{%- if grains.get('nested_vm_host') %}export MIN_NESTED="{{ grains.get('nested_vm_host') }}.{{ grains.get('domain') }}"{% else %}# no nested VM hostname defined {%- endif %}
+{% if grains.get('nested_vm_host') %}export MIN_NESTED="{{ grains.get('nested_vm_host') }}.{{ grains.get('domain') }}"{% else %}# no nested VM hostname defined {%- endif %}
 {% if grains.get('nested_vm_mac') %}export MAC_MIN_NESTED="{{ grains.get('nested_vm_mac') }}"{% else %}# no nested VM MAC address defined {%- endif %}
 
 # base goodies


### PR DESCRIPTION
## What does this PR change?

This will not remove the empty line before the `if` condition. See

```bash
# Salt bundle test specific hosts
# At the moment we only need/support one nested VM in the test suiteexport MIN_NESTED="suma-pr4-min-nested.mgr.prv.suse.net"
export MAC_MIN_NESTED="aa:b2:93:01:00:3b"
````
