### PR TITLE
QE: Enable testing_overlay repo for prs CI

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -88,7 +88,7 @@ testsuite_salt_packages:
   pkg.installed:
     - pkgs:
       - salt-ssh
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'nightly' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'nightly' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') %}
     - fromrepo: testing_overlay_devel_repo
 {% endif %}
     - require:


### PR DESCRIPTION
## What does this PR change?

This PR enables the use of `testing_overlay` repository for the PR CI. 