### PR TITLE
Differentiate between Uyuni Master and Stable

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -87,7 +87,7 @@ bootcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
-    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -526,7 +526,7 @@ packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
 yum_repos:
   # repo for salt
   tools_pool_repo:
-    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
     failovermethod: priority
     enabled: true
     gpgcheck: false
@@ -559,7 +559,7 @@ packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion", "dbus-tools"]
 yum_repos:
   # repo for salt
   tools_pool_repo:
-    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9/
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
     failovermethod: priority
     enabled: true
     gpgcheck: false
@@ -679,7 +679,7 @@ packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
 yum_repos:
   # repo for salt
   tools_pool_repo:
-    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/EL9-Uyuni-Client-Tools/EL_9
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9
     enabled: true
     gpgcheck: false
     name: tools_pool_repo

--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -41,7 +41,11 @@ proxy-packages:
 {% if install_proxy_container_packages %}
 
 {% if 'uyuni' in grains.get('product_version') %}
+  {% if '-released' in grains.get('product_version') %}
+    {% set client_tools_repo =  grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/' %}
+  {% else %}
     {% set client_tools_repo =  grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/' %}
+  {% endif %}
 
 galaxy_key:
   file.managed:

--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -177,7 +177,7 @@ cloudinit-user-data-{{ os_type }}:
         - zypper --non-interactive ar "http://download.opensuse.org/update/leap/15.4/oss/" os_update_repo
         - zypper --non-interactive ar "http://download.opensuse.org/update/leap/15.4/sle/" sle_update_repo
         - zypper --non-interactive ar "http://download.opensuse.org/update/leap/15.4/backports/" backports_update_repo
-        - zypper --non-interactive ar -p 98 "http://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/" tools_pool_repo
+        - zypper --non-interactive ar -p 98 "http://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/" tools_pool_repo
         - zypper --non-interactive --gpg-auto-import-keys ref
         - zypper --non-interactive install venv-salt-minion
         - rm /etc/venv-salt-minion/minion


### PR DESCRIPTION
## What does this PR change?

- Switch all EL9 clients to the Uyuni Stable client tools since they are now released
- Fix client tools for the Uyuni Proxy
