### PR TITLE
update owner filter for ubuntu aws ami

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -190,7 +190,7 @@ data "aws_ami" "debian11" {
 data "aws_ami" "ubuntu2204" {
   most_recent = true
   name_regex  = "^ubuntu/images/hvm-ssd/ubuntu-jammy-22.04"
-  owners      = ["679593333241"]
+  owners      = ["099720109477"]
 
   filter {
     name   = "architecture"
@@ -211,7 +211,7 @@ data "aws_ami" "ubuntu2204" {
 data "aws_ami" "ubuntu2004" {
   most_recent = true
   name_regex  = "^ubuntu/images/hvm-ssd/ubuntu-focal-20.04"
-  owners      = ["679593333241"]
+  owners      = ["099720109477"]
 
   filter {
     name   = "architecture"
@@ -232,7 +232,7 @@ data "aws_ami" "ubuntu2004" {
 data "aws_ami" "ubuntu1804" {
   most_recent = true
   name_regex  = "^ubuntu/images/hvm-ssd/ubuntu-bionic-18.04"
-  owners      = ["679593333241"]
+  owners      = ["099720109477"]
 
   filter {
     name   = "architecture"
@@ -253,7 +253,7 @@ data "aws_ami" "ubuntu1804" {
 data "aws_ami" "ubuntu1604" {
   most_recent = true
   name_regex  = "^ubuntu/images/hvm-ssd/ubuntu-xenial-16.04"
-  owners      = ["679593333241"]
+  owners      = ["099720109477"]
 
   filter {
     name   = "architecture"


### PR DESCRIPTION
## What does this PR change?

change the image owner to the one mentioned in here: https://ubuntu.com/server/docs/cloud-images/amazon-ec2

I have tested the lookup and the returned AMI is valid from this list: https://cloud-images.ubuntu.com/locator/?_ga=2.257394819.988291425.1682329785-1164604681.1682329785
