### PR TITLE
Add RES8 test tool repository to minimal mirror list for AWS

### DIFF
--- a/salt/mirror/etc/minimum_repositories_testsuite.yaml
+++ b/salt/mirror/etc/minimum_repositories_testsuite.yaml
@@ -40,6 +40,9 @@ http:
   - url:  http://download.suse.de/download/ibs/SUSE/Updates/RES/8-CLIENT-TOOLS/x86_64/update/
     archs: [x86_64]
 
+  - url:  http://download.suse.de/download/ibs/SUSE/Products/RES/8-CLIENT-TOOLS/x86_64/update/
+    archs: [x86_64]
+
   - url:  http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15-BETA/x86_64/product/
     archs: [x86_64]
 


### PR DESCRIPTION
## What does this PR change?
Add RES8 test tool repository to minimal mirror list for AWS 