### PR TITLE
Remove deprecated `failovermethod` for RHEL/EL8

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -499,7 +499,6 @@ yum_repos:
   # repo for salt
   tools_pool_repo:
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
-    failovermethod: priority
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -508,7 +507,6 @@ yum_repos:
   epel:
     baseurl: http://download.fedoraproject.org/pub/epel/8/Everything/$basearch
     mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-8&arch=$basearch
-    failovermethod: priority
     enabled: true
     gpgcheck: false
     priority: 99
@@ -527,7 +525,6 @@ yum_repos:
   # repo for salt
   tools_pool_repo:
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
-    failovermethod: priority
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -536,7 +533,6 @@ yum_repos:
   epel:
     baseurl: http://download.fedoraproject.org/pub/epel/9/Everything/$basearch
     mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-9&arch=$basearch
-    failovermethod: priority
     enabled: true
     gpgcheck: false
     priority: 99
@@ -560,7 +556,6 @@ yum_repos:
   # repo for salt
   tools_pool_repo:
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
-    failovermethod: priority
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -569,7 +564,6 @@ yum_repos:
   epel:
     baseurl: http://download.fedoraproject.org/pub/epel/9/Everything/$basearch
     mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-9&arch=$basearch
-    failovermethod: priority
     enabled: true
     gpgcheck: false
     priority: 99


### PR DESCRIPTION
## What does this PR change?

The `failovermethod` parameter got removed in DNF starting with EL8. I discovered that when using the verbose parameter with DNF on Liberty Linux 9. See https://github.com/rpm-software-management/libdnf/blob/dnf-4-master/docs/release_notes.rst#0640-release-notes

Split out of https://github.com/uyuni-project/sumaform/pull/1287
