### PR TITLE
Fix for Cobbler on `uyuni-released` version

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -41,8 +41,8 @@ test_repo_debian_updates:
       - pkg: testsuite_salt_packages
       {% endif %}
 
-# modify cobbler to be executed from remote-machines..
-{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly"] %}
+# modify Cobbler to be executed from remote-machines..
+{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-released", "uyuni-pr", "head", "4.3-released", "4.3-nightly"] %}
 {% set cobbler_use_settings_yaml = grains.get('product_version') | default('', true) in products_using_new_cobbler_version %}
 
 cobbler_configuration:


### PR DESCRIPTION
## What does this PR change?

This adds `uyuni-released` to the `products_using_new_cobbler_version` variable since it is also using the new Cobbler version.

Split out of https://github.com/uyuni-project/sumaform/pull/1287