### PR TITLE
Fix distinction between Salt and Salt bundle

### DIFF
--- a/salt/default/ids.sls
+++ b/salt/default/ids.sls
@@ -12,4 +12,8 @@ dbus_machine_id:
 
 minion_id_cleared:
   file.absent:
+{% if grains['install_salt_bundle'] %}
+    - name: /etc/venv-salt-minion/minion_id
+{% else %}
     - name: /etc/salt/minion_id
+{% endif %}

--- a/salt/default/minimal.sls
+++ b/salt/default/minimal.sls
@@ -17,9 +17,10 @@ include:
 minimal_package_update:
   pkg.latest:
     - pkgs:
-      - salt-minion
 {% if grains['install_salt_bundle'] %}
       - venv-salt-minion
+{% else %}
+      - salt-minion
 {% endif %}
 {% if grains['os_family'] == 'Suse' %}
       - zypper

--- a/salt/minion/init.sls
+++ b/salt/minion/init.sls
@@ -11,7 +11,11 @@ include:
 # https://build.opensuse.org/project/show/systemsmanagement:sumaform:images:microos
 minion_package:
   pkg.installed:
+{% if grains['install_salt_bundle'] %}
+    - name: venv-salt-minion
+{% else %}
     - name: salt-minion
+{% endif %}
     - require:
       - sls: default
 {% endif %}
@@ -36,7 +40,11 @@ reload_systemd_modules:
 
 minion_id:
   file.managed:
+{% if grains['install_salt_bundle'] %}
+    - name: /etc/venv-salt-minion/minion_id
+{% else %}
     - name: /etc/salt/minion_id
+{% endif %}
     - contents: {{ grains['hostname'] }}.{{ grains['domain'] }}
 
 {% if grains.get('auto_connect_to_master') %}
@@ -56,8 +64,13 @@ master_configuration:
 
 minion_service:
   service.running:
+{% if grains['install_salt_bundle'] %}
+    - name: venv-salt-minion
+    - enable: True
+{% else %}
     - name: salt-minion
     - enable: True
+{% endif %}
 {% if grains.get('auto_connect_to_master') %}
     - watch:
       - file: master_configuration

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -6,7 +6,11 @@
 minion_cucumber_requisites:
   pkg.installed:
     - pkgs:
+{% if grains['install_salt_bundle'] %}
+      - venv-salt-minion
+{% else %}
       - salt-minion
+{% endif %}
       - wget
     - require:
       - sls: default


### PR DESCRIPTION
## What does this PR change?

This fixes issue regarding the distinction between Salt and the Salt bundle in the `minimal` state.

- CentOS 7 (minion and client) is failing in BV in the deployment stage
- Alma / Rocky do not have the `venv-salt-minion` service running
- Liberty is trying to install `salt-minion`, although the package is not available and we specified in sumaform to use `venv-salt-minion`

```bash
10:28:26  │ Error: remote-exec provisioner error
10:28:26  │ 
10:28:26  │   with module.centos7-sshminion.module.sshminion.module.host.null_resource.provisioning[0],
10:28:26  │   on /home/jenkins/jenkins-build/workspace/uyuni-master-qe-build-validation-NUE/results/sumaform/backend_modules/libvirt/host/main.tf line 249, in resource "null_resource" "provisioning":
10:28:26  │  249:   provisioner "remote-exec" {
```
The sumaform log shows the following error.

### CentOS 7 client
```bash
[2023-05-15T08:06:19.744Z] module.centos7-client.module.client.module.host.null_resource.provisioning[0] (remote-exec):
ost.null_resource.provisioning[0] (remote-exec): ----------
ost.null_resource.provisioning[0] (remote-exec):           ID: minimal_package_update
ost.null_resource.provisioning[0] (remote-exec):     Function: pkg.latest
ost.null_resource.provisioning[0] (remote-exec):       Result: False
ost.null_resource.provisioning[0] (remote-exec):      Comment: No information found for 'salt-minion'.
ost.null_resource.provisioning[0] (remote-exec):      Started: 10:06:17.730952
ost.null_resource.provisioning[0] (remote-exec):     Duration: 1095.757 ms
ost.null_resource.provisioning[0] (remote-exec):      Changes:   
ost.null_resource.provisioning[0] (remote-exec): 
ost.null_resource.provisioning[0] (remote-exec): Summary for local
ost.null_resource.provisioning[0] (remote-exec): -------------
ost.null_resource.provisioning[0] (remote-exec): Succeeded: 48 (changed=8)
ost.null_resource.provisioning[0] (remote-exec): Failed:     1
ost.null_resource.provisioning[0] (remote-exec): -------------
ost.null_resource.provisioning[0] (remote-exec): Total states run:     49
ost.null_resource.provisioning[0] (remote-exec): Total run time:   42.346 s
```

### CentOS 7 minion
```bash
ost.null_resource.provisioning[0] (remote-exec): ----------
ost.null_resource.provisioning[0] (remote-exec):           ID: minion_package
ost.null_resource.provisioning[0] (remote-exec):     Function: pkg.installed
ost.null_resource.provisioning[0] (remote-exec):         Name: salt-minion
ost.null_resource.provisioning[0] (remote-exec):       Result: False
ost.null_resource.provisioning[0] (remote-exec):      Comment: Error occurred installing package(s). Additional info follows:

ost.null_resource.provisioning[0] (remote-exec):               errors:
ost.null_resource.provisioning[0] (remote-exec):                   - Running scope as unit run-8406.scope.
ost.null_resource.provisioning[0] (remote-exec):                     Loaded plugins: fastestmirror, venv-yumnotify
ost.null_resource.provisioning[0] (remote-exec):                     Loading mirror speeds from cached hostfile
ost.null_resource.provisioning[0] (remote-exec):                      * base: mirror.keystealth.org
ost.null_resource.provisioning[0] (remote-exec):                      * epel: ix-denver.mm.fcix.net
ost.null_resource.provisioning[0] (remote-exec):                      * extras: veronanetworks.mm.fcix.net
ost.null_resource.provisioning[0] (remote-exec):                      * updates: mirror.hostduplex.com
ost.null_resource.provisioning[0] (remote-exec):                     No package salt-minion available.
ost.null_resource.provisioning[0] (remote-exec):                     Error: Nothing to do
ost.null_resource.provisioning[0] (remote-exec):      Started: 10:06:58.067528
ost.null_resource.provisioning[0] (remote-exec):     Duration: 2860.25 ms
ost.null_resource.provisioning[0] (remote-exec):      Changes:   
ost.null_resource.provisioning[0] (remote-exec): ----------
ost.null_resource.provisioning[0] (remote-exec):           ID: minion_cucumber_requisites
ost.null_resource.provisioning[0] (remote-exec):     Function: pkg.installed
ost.null_resource.provisioning[0] (remote-exec):       Result: False
ost.null_resource.provisioning[0] (remote-exec):      Comment: The following packages failed to install/update: salt-minion
ost.null_resource.provisioning[0] (remote-exec):               The following packages were installed/updated: wget
ost.null_resource.provisioning[0] (remote-exec):      Started: 10:06:53.059983
ost.null_resource.provisioning[0] (remote-exec):     Duration: 4967.758 ms
ost.null_resource.provisioning[0] (remote-exec):      Changes:
ost.null_resource.provisioning[0] (remote-exec): ----------
ost.null_resource.provisioning[0] (remote-exec):           ID: minion_id
ost.null_resource.provisioning[0] (remote-exec):     Function: file.managed
ost.null_resource.provisioning[0] (remote-exec):         Name: /etc/salt/minion_id
ost.null_resource.provisioning[0] (remote-exec):       Result: False
ost.null_resource.provisioning[0] (remote-exec):      Comment: Parent directory not present
ost.null_resource.provisioning[0] (remote-exec):      Started: 10:07:00.930690
ost.null_resource.provisioning[0] (remote-exec):     Duration: 2.232 ms
ost.null_resource.provisioning[0] (remote-exec):      Changes:   
ost.null_resource.provisioning[0] (remote-exec): ----------
ost.null_resource.provisioning[0] (remote-exec):           ID: minion_service
ost.null_resource.provisioning[0] (remote-exec):     Function: service.running
ost.null_resource.provisioning[0] (remote-exec):         Name: salt-minion
ost.null_resource.provisioning[0] (remote-exec):       Result: False
ost.null_resource.provisioning[0] (remote-exec):      Comment: The named service salt-minion is not available
ost.null_resource.provisioning[0] (remote-exec):      Started: 10:07:00.934389
ost.null_resource.provisioning[0] (remote-exec):     Duration: 8.579 ms
ost.null_resource.provisioning[0] (remote-exec):      Changes:   
ost.null_resource.provisioning[0] (remote-exec): ----------
ost.null_resource.provisioning[0] (remote-exec):           ID: minimal_package_update
ost.null_resource.provisioning[0] (remote-exec):     Function: pkg.latest
ost.null_resource.provisioning[0] (remote-exec):       Result: False
ost.null_resource.provisioning[0] (remote-exec):      Comment: No information found for 'salt-minion'.
ost.null_resource.provisioning[0] (remote-exec):      Started: 10:07:00.943273
ost.null_resource.provisioning[0] (remote-exec):     Duration: 1048.295 ms
ost.null_resource.provisioning[0] (remote-exec):      Changes: 
```

### Rocky 9

```
[root@uyuni-bv-master-min-rocky9 ~]# systemctl status venv-salt-minion
○ venv-salt-minion.service - The venvjailed Salt Minion
     Loaded: loaded (/usr/lib/systemd/system/venv-salt-minion.service; disabled; vendor preset: disabled)
     Active: inactive (dead)
```

### Liberty 9

```bash
host.null_resource.provisioning[0] (remote-exec):           ID: minion_cucumber_requisites
host.null_resource.provisioning[0] (remote-exec):     Function: pkg.installed
host.null_resource.provisioning[0] (remote-exec):       Result: False
host.null_resource.provisioning[0] (remote-exec):      Comment: Error occurred installing package(s). Additional info follows:
​
host.null_resource.provisioning[0] (remote-exec):               errors:
host.null_resource.provisioning[0] (remote-exec):                   - Running scope as unit: run-rdecd5910fccc44049eb84f39f3da41d0.scope
host.null_resource.provisioning[0] (remote-exec):                     Last metadata expiration check: 0:00:13 ago on Sun May 21 14:36:30 2023.
host.null_resource.provisioning[0] (remote-exec):                     No match for argument: salt-minion
host.null_resource.provisioning[0] (remote-exec):                     Error: Unable to find a match: salt-minion
host.null_resource.provisioning[0] (remote-exec):      Started: 14:36:40.984571
host.null_resource.provisioning[0] (remote-exec):     Duration: 2746.647 ms
host.null_resource.provisioning[0] (remote-exec):      Changes:   
host.null_resource.provisioning[0] (remote-exec): ----------
host.null_resource.provisioning[0] (remote-exec):           ID: minion_package
host.null_resource.provisioning[0] (remote-exec):     Function: pkg.installed
host.null_resource.provisioning[0] (remote-exec):         Name: salt-minion
host.null_resource.provisioning[0] (remote-exec):       Result: False
host.null_resource.provisioning[0] (remote-exec):      Comment: Error occurred installing package(s). Additional info follows:
​
host.null_resource.provisioning[0] (remote-exec):               errors:
host.null_resource.provisioning[0] (remote-exec):                   - Running scope as unit: run-ra55322afbe9c42298591d07bea04d0ed.scope
host.null_resource.provisioning[0] (remote-exec):                     Last metadata expiration check: 0:00:14 ago on Sun May 21 14:36:30 2023.
host.null_resource.provisioning[0] (remote-exec):                     No match for argument: salt-minion
host.null_resource.provisioning[0] (remote-exec):                     Error: Unable to find a match: salt-minion
host.null_resource.provisioning[0] (remote-exec):      Started: 14:36:43.732305
host.null_resource.provisioning[0] (remote-exec):     Duration: 1473.987 ms
host.null_resource.provisioning[0] (remote-exec):      Changes:   
host.null_resource.provisioning[0] (remote-exec): ----------
host.null_resource.provisioning[0] (remote-exec):           ID: minion_id
host.null_resource.provisioning[0] (remote-exec):     Function: file.managed
host.null_resource.provisioning[0] (remote-exec):         Name: /etc/salt/minion_id
host.null_resource.provisioning[0] (remote-exec):       Result: False
host.null_resource.provisioning[0] (remote-exec):      Comment: Parent directory not present
host.null_resource.provisioning[0] (remote-exec):      Started: 14:36:45.206873
host.null_resource.provisioning[0] (remote-exec):     Duration: 2.655 ms
host.null_resource.provisioning[0] (remote-exec):      Changes:   
host.null_resource.provisioning[0] (remote-exec): ----------
host.null_resource.provisioning[0] (remote-exec):           ID: minion_service
host.null_resource.provisioning[0] (remote-exec):     Function: service.running
host.null_resource.provisioning[0] (remote-exec):         Name: salt-minion
host.null_resource.provisioning[0] (remote-exec):       Result: False
host.null_resource.provisioning[0] (remote-exec):      Comment: The named service salt-minion is not available
host.null_resource.provisioning[0] (remote-exec):      Started: 14:36:45.211511
host.null_resource.provisioning[0] (remote-exec):     Duration: 17.048 ms
host.null_resource.provisioning[0] (remote-exec):      Changes:   
host.null_resource.provisioning[0] (remote-exec): ----------
host.null_resource.provisioning[0] (remote-exec):           ID: minimal_package_update
host.null_resource.provisioning[0] (remote-exec):     Function: pkg.latest
host.null_resource.provisioning[0] (remote-exec):       Result: False
host.null_resource.provisioning[0] (remote-exec):      Comment: No information found for 'salt-minion'.
host.null_resource.provisioning[0] (remote-exec):      Started: 14:36:45.229191
host.null_resource.provisioning[0] (remote-exec):     Duration: 811.91 ms
host.null_resource.provisioning[0] (remote-exec):      Changes:   
host.null_resource.provisioning[0] (remote-exec): 
host.null_resource.provisioning[0] (remote-exec): Summary for local
host.null_resource.provisioning[0] (remote-exec): -------------
```

