### PR TITLE
Add repo to humanname when adding additionnal rapository.

### DIFF
--- a/salt/repos/additional.sls
+++ b/salt/repos/additional.sls
@@ -2,7 +2,7 @@
 {% for label, url in grains['additional_repos'].items() %}
 {{ label }}_repo:
   pkgrepo.managed:
-    - humanname: {{ label }}
+    - humanname: {{ label }}_repo
   {%- if grains['os_family'] == 'Debian' %}
   {%- if 'uyuni-pr' in grains.get('product_version', '') %}
     - name: deb [trusted=yes] {{ url }} /


### PR DESCRIPTION
Fix deployment issue : 
```
          ID: 28935_repo
    Function: pkgrepo.managed
      Result: False
     Comment: Failed to configure repo '28935_repo': sequence item 9: expected str instance, int found
     Started: 05:00:31.625197
    Duration: 216.064 ms
```

## What does this PR change?

It seems `pkgrepo.managed:` in salt when humanname variable is only number and -/_ is not correctly supported.
I tried to force label to string but I had the same issue ( `{% set label_str = label | string %}` ).

This just add repo string extension after label ( done automatically by sumaform previously but still failing sumaform deployment )