### PR TITLE
Manage proper configuration file if the minion is Bundle managed

### DIFF
--- a/salt/minion/init.sls
+++ b/salt/minion/init.sls
@@ -50,7 +50,11 @@ minion_id:
 {% if grains.get('auto_connect_to_master') %}
 master_configuration:
   file.managed:
+    {% if grains.get('install_salt_bundle') %}
+    - name: /etc/venv-salt-minion/minion.d/master.conf
+    {% else %}
     - name: /etc/salt/minion.d/master.conf
+    {% endif %}
     - contents: |
         master: {{grains['server']}}
         server_id_use_crc: adler32


### PR DESCRIPTION
## What does this PR change?

Creating a minion with `install_salt_bundle = true` was failing with the following error:
```
---------
         ID: master_configuration
   Function: file.managed
       Name: /etc/salt/minion.d/master.conf
     Result: False
    Comment: Parent directory not present
    Started: 09:31:23.345210
   Duration: 0.943 ms
    Changes:
---------
         ID: minion_service
   Function: service.running
       Name: venv-salt-minion
     Result: False
    Comment: One or more requisite failed: minion.master_configuration
    Started: 09:31:23.346503
   Duration: 0.002 ms
    Changes:
---------
```

Now it's the file `/etc/venv-salt-minion/minion.d/master.conf` that keeps the master configuration in the minion in case we want it to be managed with Salt Bundle.