### PR TITLE
Make "cloud-init" to setup a repo that provides "venv-salt-minion" package

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -123,6 +123,15 @@ packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 
 %{ if image == "opensuse152o" }
+zypper:
+  # repo for salt
+  tools_pool_repo:
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+    enabled: true
+    gpgcheck: false
+    name: tools_pool_repo
+    priority: 98
+
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "qemu-guest-agent"]
 %{ else }
@@ -134,6 +143,15 @@ runcmd:
 %{ endif }
 
 %{ if image == "opensuse153o" || image == "opensuse153-ci-pr" || image == "opensuse153-ci-pr-client" || image == "opensuse154o" || image == "opensuse154-ci-pr" || image == "opensuse154-ci-pr-client" }
+zypper:
+  # repo for salt
+  tools_pool_repo:
+    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+    enabled: true
+    gpgcheck: false
+    name: tools_pool_repo
+    priority: 98
+
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns"]
 %{ else }
@@ -152,6 +170,12 @@ zypper:
       baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
       enabled: 1
       autorefresh: 1
+    - id: tools_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
+      enabled: true
+      gpgcheck: false
+      name: tools_pool_repo
+      priority: 98
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -168,6 +192,12 @@ zypper:
       baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-SERVER/12-SP5/x86_64/product/
       enabled: 1
       autorefresh: 1
+    - id: tools_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
+      enabled: true
+      gpgcheck: false
+      name: tools_pool_repo
+      priority: 98
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -190,6 +220,12 @@ zypper:
       baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product
       enabled: 1
       autorefresh: 1
+    - id: tools_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+      enabled: true
+      gpgcheck: false
+      name: tools_pool_repo
+      priority: 98
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -215,6 +251,12 @@ zypper:
       baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product
       enabled: 1
       autorefresh: 1
+    - id: tools_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+      enabled: true
+      gpgcheck: false
+      name: tools_pool_repo
+      priority: 98
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -240,6 +282,12 @@ zypper:
       baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-Module-Server-Applications/15-SP2/x86_64/product
       enabled: 1
       autorefresh: 1
+    - id: tools_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+      enabled: true
+      gpgcheck: false
+      name: tools_pool_repo
+      priority: 98
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -260,6 +308,12 @@ zypper:
       baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-Module-Basesystem/15-SP3/x86_64/product
       enabled: 1
       autorefresh: 1
+    - id: tools_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+      enabled: true
+      gpgcheck: false
+      name: tools_pool_repo
+      priority: 98
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -280,6 +334,12 @@ zypper:
       baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-Module-Basesystem/15-SP4/x86_64/product
       enabled: 1
       autorefresh: 1
+    - id: tools_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+      enabled: true
+      gpgcheck: false
+      name: tools_pool_repo
+      priority: 98
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
@@ -300,6 +360,12 @@ zypper:
       baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SLE-Module-Basesystem/15-SP5/x86_64/product
       enabled: 1
       autorefresh: 1
+    - id: tools_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+      enabled: true
+      gpgcheck: false
+      name: tools_pool_repo
+      priority: 98
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -426,6 +426,32 @@ packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ endif }
 
 %{ if image == "ubuntu1804o" }
+apt:
+  sources:
+    tools_pool_repo:
+      source: deb http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu1804-Uyuni-Client-Tools/xUbuntu_18.04 /
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v1.4.5 (GNU/Linux)
+
+        mQENBFsnulUBCADNjL4hvhVtSzqVDlMtFFFP28Acq+UNF8WKKMhbBirfOpXwwI1C
+        NR3i0CXPOce5eKShuuWAjD2E36e2XAp3rUAo/aCA7UgtJkMNKzzlTOcqHHxKTx6H
+        gvp0Fb6xTKywZ7VttGhwUynl+CsDuOst3ROXTNdb8XMfm4joH2FW5D3ACN2qNiv0
+        MVcFNKxQ98w8M9xJxdI8DuyngnSeZwAosNzEio3JhTPiTv9ngY2Z3AuYUcwTEt7o
+        feEN+ivAgYnn+a6DBKFBeCW7VUD3V+tH8/fKnkvI4gf2o3N7Ok+/uE+DPUBb+14f
+        +9dhBjd+7+pR3ayEZFjQns5XFShoYu2+CQspABEBAAG0UHN5c3RlbXNtYW5hZ2Vt
+        ZW50OlV5dW5pIE9CUyBQcm9qZWN0IDxzeXN0ZW1zbWFuYWdlbWVudDpVeXVuaUBi
+        dWlsZC5vcGVuc3VzZS5vcmc+iQE+BBMBCAAoBQJjQDEEAhsDBQkMNyavBgsJCAcD
+        AgYVCAIJCgsEFgIDAQIeAQIXgAAKCRCXLl1sDSCDPjsSCAC1v9YHwuP0kRt8VPlq
+        /RLgADb5TsUPOaDcZ/maKVxhL5EgY2mX1ViCO4Bm+VFL2ZSJEXth8/Zp/dZe80e9
+        tlZgag5uPQe9FV0IAHXYt91DYJlE7VuxvdhADIt9RcDmS4OrSAfQoroyh5OW3ZRW
+        Kqa68L6RBhiyuvBTaRCUdIhqDBjVCgMlLJxC5soOIVCEvMRzOxHqO0+gvKomvM1P
+        iK4cio2OcIqZb8vCyMIXtYniHqA0rUZD4U+EB9enmYcj9ZhWO9oQXZ0qCQN6ve/K
+        1Q7NjImT5oEHWGFeLmwWZMe2+djFcHiCQM1bFN1gC+2ASz5XPC7OKdrIi+E85gMo
+        cYu+iEYEExECAAYFAlsnulUACgkQOzARt2udZSO/4QCcDf+j/XRbJn2PudsSoyjw
+        3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
+        =8MsV
+        -----END PGP PUBLIC KEY BLOCK-----
 
 runcmd:
   # WORKAROUND: cloud-init in Ubuntu 18.04 does not take care of the following
@@ -526,6 +552,33 @@ packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ endif }
 %{ endif }
 %{ if image == "debian11o" }
+apt:
+  sources:
+    tools_pool_repo:
+      source: deb http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/Debian11-Uyuni-Client-Tools/Debian_11/ /
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v1.4.5 (GNU/Linux)
+
+        mQENBFsnulUBCADNjL4hvhVtSzqVDlMtFFFP28Acq+UNF8WKKMhbBirfOpXwwI1C
+        NR3i0CXPOce5eKShuuWAjD2E36e2XAp3rUAo/aCA7UgtJkMNKzzlTOcqHHxKTx6H
+        gvp0Fb6xTKywZ7VttGhwUynl+CsDuOst3ROXTNdb8XMfm4joH2FW5D3ACN2qNiv0
+        MVcFNKxQ98w8M9xJxdI8DuyngnSeZwAosNzEio3JhTPiTv9ngY2Z3AuYUcwTEt7o
+        feEN+ivAgYnn+a6DBKFBeCW7VUD3V+tH8/fKnkvI4gf2o3N7Ok+/uE+DPUBb+14f
+        +9dhBjd+7+pR3ayEZFjQns5XFShoYu2+CQspABEBAAG0UHN5c3RlbXNtYW5hZ2Vt
+        ZW50OlV5dW5pIE9CUyBQcm9qZWN0IDxzeXN0ZW1zbWFuYWdlbWVudDpVeXVuaUBi
+        dWlsZC5vcGVuc3VzZS5vcmc+iQE+BBMBCAAoBQJjQDEEAhsDBQkMNyavBgsJCAcD
+        AgYVCAIJCgsEFgIDAQIeAQIXgAAKCRCXLl1sDSCDPjsSCAC1v9YHwuP0kRt8VPlq
+        /RLgADb5TsUPOaDcZ/maKVxhL5EgY2mX1ViCO4Bm+VFL2ZSJEXth8/Zp/dZe80e9
+        tlZgag5uPQe9FV0IAHXYt91DYJlE7VuxvdhADIt9RcDmS4OrSAfQoroyh5OW3ZRW
+        Kqa68L6RBhiyuvBTaRCUdIhqDBjVCgMlLJxC5soOIVCEvMRzOxHqO0+gvKomvM1P
+        iK4cio2OcIqZb8vCyMIXtYniHqA0rUZD4U+EB9enmYcj9ZhWO9oQXZ0qCQN6ve/K
+        1Q7NjImT5oEHWGFeLmwWZMe2+djFcHiCQM1bFN1gC+2ASz5XPC7OKdrIi+E85gMo
+        cYu+iEYEExECAAYFAlsnulUACgkQOzARt2udZSO/4QCcDf+j/XRbJn2PudsSoyjw
+        3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
+        =8MsV
+        -----END PGP PUBLIC KEY BLOCK-----
+
 runcmd:
 #   HACK: cloud-init in Debian 11 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
@@ -539,6 +592,33 @@ packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "gnupg", "python3-
 %{ endif }
 %{ endif }
 %{ if image == "debian10o" }
+apt:
+  sources:
+    tools_pool_repo:
+      source: deb http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Stable:/Debian10-Uyuni-Client-Tools/Debian_10/ /
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v1.4.5 (GNU/Linux)
+
+        mQENBFsnulUBCADNjL4hvhVtSzqVDlMtFFFP28Acq+UNF8WKKMhbBirfOpXwwI1C
+        NR3i0CXPOce5eKShuuWAjD2E36e2XAp3rUAo/aCA7UgtJkMNKzzlTOcqHHxKTx6H
+        gvp0Fb6xTKywZ7VttGhwUynl+CsDuOst3ROXTNdb8XMfm4joH2FW5D3ACN2qNiv0
+        MVcFNKxQ98w8M9xJxdI8DuyngnSeZwAosNzEio3JhTPiTv9ngY2Z3AuYUcwTEt7o
+        feEN+ivAgYnn+a6DBKFBeCW7VUD3V+tH8/fKnkvI4gf2o3N7Ok+/uE+DPUBb+14f
+        +9dhBjd+7+pR3ayEZFjQns5XFShoYu2+CQspABEBAAG0UHN5c3RlbXNtYW5hZ2Vt
+        ZW50OlV5dW5pIE9CUyBQcm9qZWN0IDxzeXN0ZW1zbWFuYWdlbWVudDpVeXVuaUBi
+        dWlsZC5vcGVuc3VzZS5vcmc+iQE+BBMBCAAoBQJjQDEEAhsDBQkMNyavBgsJCAcD
+        AgYVCAIJCgsEFgIDAQIeAQIXgAAKCRCXLl1sDSCDPjsSCAC1v9YHwuP0kRt8VPlq
+        /RLgADb5TsUPOaDcZ/maKVxhL5EgY2mX1ViCO4Bm+VFL2ZSJEXth8/Zp/dZe80e9
+        tlZgag5uPQe9FV0IAHXYt91DYJlE7VuxvdhADIt9RcDmS4OrSAfQoroyh5OW3ZRW
+        Kqa68L6RBhiyuvBTaRCUdIhqDBjVCgMlLJxC5soOIVCEvMRzOxHqO0+gvKomvM1P
+        iK4cio2OcIqZb8vCyMIXtYniHqA0rUZD4U+EB9enmYcj9ZhWO9oQXZ0qCQN6ve/K
+        1Q7NjImT5oEHWGFeLmwWZMe2+djFcHiCQM1bFN1gC+2ASz5XPC7OKdrIi+E85gMo
+        cYu+iEYEExECAAYFAlsnulUACgkQOzARt2udZSO/4QCcDf+j/XRbJn2PudsSoyjw
+        3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
+        =8MsV
+        -----END PGP PUBLIC KEY BLOCK-----
+
 runcmd:
 #   HACK: cloud-init in Debian 10 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -458,6 +458,11 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
 
+bootcmd:
+  # HACK: Make "gnupg" to be installed before configuring repos, so gpg key can be imported
+  - DEBIAN_FRONTEND=noninteractive apt-get -yq update
+  - DEBIAN_FRONTEND=noninteractive apt-get -yq install gnupg
+
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi-daemon", "qemu-guest-agent"]
 %{ else }
@@ -585,6 +590,11 @@ runcmd:
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
 
+bootcmd:
+  # HACK: Make "gnupg" to be installed before configuring repos, so gpg key can be imported
+  - DEBIAN_FRONTEND=noninteractive apt-get -yq update
+  - DEBIAN_FRONTEND=noninteractive apt-get -yq install gnupg
+
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi-daemon", "qemu-guest-agent", "gnupg", "python3-apt"]
 %{ else }
@@ -624,6 +634,11 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
+
+bootcmd:
+  # HACK: Make "gnupg" to be installed before configuring repos, so gpg key can be imported
+  - DEBIAN_FRONTEND=noninteractive apt-get -yq update
+  - DEBIAN_FRONTEND=noninteractive apt-get -yq install gnupg
 
 %{ if install_salt_bundle }
 packages: ["venv-salt-minion", "avahi-daemon", "qemu-guest-agent", "apt-transport-https", "python-apt", "python3-apt"]


### PR DESCRIPTION
## What does this PR change?

This PR makes `cloud-init` to configure corresponding Client Tools channels in SLE/openSUSE images, in order to have a configured repository which is able to provide `venv-salt-minion` package to run the deployment.

This should fix the current issue we see on our testsuites deployments: https://github.com/SUSE/spacewalk/issues/21545

I've tested deployments of SLE12SP4 and SLE15SP4/SP3 instances with these changes and they were successful.