### PR TITLE
Make 4.2 testsuite to use Salt Bundle only to bootstrap RHEL7 and clones

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -95,7 +95,7 @@ testsuite_salt_packages:
       - sls: repos
 {% endif %}
 
-{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.2-nightly", "4.2-released"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,
@@ -103,12 +103,19 @@ testsuite_salt_packages:
 # Once bootstrap repository contains the venv-salt-minion before running bootstrap
 # then these states can be removed
 
+# For 4.2 version, only RHEL 7 and clones will use the Salt Bundle.
+
 create_pillar_top_sls_to_assign_salt_bundle_config:
   file.managed:
     - name: /srv/pillar/top.sls
     - contents: |
         base:
+{%- if "4.2" in grains.get('product_version') | default('', true) %}
+          'G@os_family:RedHat and G@osmajorrelease:7':
+            - match: compound
+{%- else %}
           '*':
+{%- endif %}
             - salt_bundle_config
     - require:
         - sls: server


### PR DESCRIPTION
## What does this PR change?

This PR makes the 4.2 testsuite to use Salt Bundle to bootstrap only RHEL7 and clones, the rest of images still uses classic Salt minion package during bootstrapping.
