### PR TITLE
Revert 32a4b351a

### DIFF
--- a/salt/repos/testsuite.sls
+++ b/salt/repos/testsuite.sls
@@ -19,19 +19,19 @@ uyuni_key_for_fake_packages:
 
 test_repo_rpm_pool:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/
     - refresh: True
     - gpgcheck: 1
-    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/repodata/repomd.xml.key
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/repodata/repomd.xml.key
 
 {% elif grains['os_family'] == 'Debian' %}
 
 test_repo_deb_pool:
   pkgrepo.managed:
-    - name: deb http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb/ /
+    - name: deb http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb/ /
     - refresh: True
     - file: /etc/apt/sources.list.d/test_repo_deb_pool.list
-    - key_url: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb/Release.key
+    - key_url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/deb/Release.key
 
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## What does this PR change?
```
Failed to configure repo 'deb http://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/
Test-Packages:/Pool/deb/ /': E: The repository 'http://security.debian.org bullseye/updates Release' does
not have a Release file.
```
reason might be because directory listing of https://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/{deb,rpm}/ produces a 403 Forbidden.


