### PR TITLE
Work around "The repository does not have a Release file"

### DIFF
--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -326,7 +326,7 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - echo "PubkeyAcceptedKeyTypes=+ssh-rsa" >> /etc/ssh/sshd_config
   - systemctl restart sshd
-  # Work around security release/updates does not have a Release file
+  # WORKAROUND: security release/updates does not have a Release file
   - sed -i "s|bullseye/updates|bullseye-security|" /etc/apt/sources.list
 
 packages: ["salt-minion"]

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -565,10 +565,12 @@ apt:
         -----END PGP PUBLIC KEY BLOCK-----
 
 runcmd:
-#   HACK: cloud-init in Debian 11 does not take care of the following
+  # HACK: cloud-init in Debian 11 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
+  # WORKAROUND: security release/updates does not have a Release file
+  - sed -i "s|bullseye/updates|bullseye-security|" /etc/apt/sources.list
 
 bootcmd:
   # HACK: Make "gnupg" to be installed before configuring repos, so gpg key can be imported


### PR DESCRIPTION
## What does this PR change?

This PR works around https://the-codeslinger.com/2020/03/26/debian-bullseye-the-repository-does-not-have-a-release-file/ (it was already done for AWS, now doing it for libvirt as well).

I am not completely sure why this is needed: I had a look at the qcow2 file `debian11o` that we download, and its `/etc/apt/sources.list` file is correct...

