### PR TITLE
fix opensuse154-ci-pro name

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -131,7 +131,7 @@ runcmd:
   - zypper removerepo --all
 %{ endif }
 
-%{ if image == "opensuse153o" || image == "opensuse153-ci-pr" || image == "opensuse153-ci-pr-client" || image == "opensuse154o" || image == "opensuse154-ci-pr" || image == "opensuse154-ci-pr-client" }
+%{ if image == "opensuse153o" || image == "opensuse153-ci-pr" || image == "opensuse153-ci-pr-client" || image == "opensuse154o" || image == "opensuse154-ci-pro" || image == "opensuse154-ci-pr-client" }
 zypper:
   repos:
     - id: tools_pool_repo


### PR DESCRIPTION
## What does this PR change?

I missed a rename of opensuse154-ci-pr to opensuse154-ci-pro
