### PR TITLE
Configure c3p0 connection timeout

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -81,6 +81,8 @@ module "server" {
     accept_all_ssl_protocols       = var.accept_all_ssl_protocols
     login_timeout                  = var.login_timeout
     db_configuration               = var.db_configuration
+    c3p0_connection_timeout        = var.c3p0_connection_timeout
+    c3p0_connection_debug          = var.c3p0_connection_debug
   }
 
 

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -273,3 +273,13 @@ variable "db_configuration" {
     port               = "5432"
   }
 }
+
+variable "c3p0_connection_timeout" {
+  description = "c3p0 connections will be closed after this timeout"
+  default     = 900
+}
+
+variable "c3p0_connection_debug" {
+  description = "log additional info regarding leaked c3p0 connections"
+  default     = false
+}

--- a/salt/server/rhn.sls
+++ b/salt/server/rhn.sls
@@ -85,6 +85,37 @@ rhn_conf_forward_reg:
 
 {% endif %}
 
+{% if grains.get('c3p0_connection_timeout') | default(true, true) %}
+
+rhn_conf_c3p0_connection_timeout:
+  file.append:
+    - name: /etc/rhn/rhn.conf
+    - text: hibernate.c3p0.unreturnedConnectionTimeout = {{ grains.get('c3p0_connection_timeout') | default(900, true) }}
+    - require:
+      - sls: server
+
+{% endif %}
+
+{% if grains.get('c3p0_connection_debug') | default(false, true) %}
+
+rhn_conf_c3p0_connection_debug:
+  file.append:
+    - name: /etc/rhn/rhn.conf
+    - text: hibernate.c3p0.debugUnreturnedConnectionStackTraces = true
+    - require:
+      - sls: server
+
+rhn_conf_c3p0_connection_debug_log:
+  file.line:
+    - name: /srv/tomcat/webapps/rhn/WEB-INF/classes/log4j2.xml
+    - content: '    <Logger name="com.mchange.v2.resourcepool.BasicResourcePool" level="info" />'
+    - after: "<Loggers>"
+    - mode: ensure
+    - require:
+      - sls: server
+
+{% endif %}
+
 # catch-all to ensure we always have at least one state covering /etc/rhn/rhn.conf
 rhn_conf_present:
   file.touch:


### PR DESCRIPTION
## What does this PR change?

This PR configures c3p0 connection timeout. It is useful for detecting leaked connections, like in https://github.com/SUSE/spacewalk/pull/21717

It configures timeout 900s by default. It can be changed by setting grain
`c3p0_connection_timeout = <timeout>`
or disabled with
`c3p0_connection_timeout = false`

Additional debug output can be enabled with
`c3p0_connection_debug = true`

It is disabled by default, because it causes certain overhead.

