### PR TITLE
Only remove salt-minion

### DIFF
--- a/salt/post_provisioning_cleanup.sh
+++ b/salt/post_provisioning_cleanup.sh
@@ -33,7 +33,7 @@ fi
 
 echo "Removing Salt packages, except Salt Bundle (venv-salt-minion) ..."
 if [[ "$INSTALLER" == "zypper" ]]; then
-zypper -q --non-interactive remove salt salt-minion python3-salt python2-salt > /dev/null 2>&1 ||:
+zypper -q --non-interactive remove salt-minion > /dev/null 2>&1 ||:
 elif [[ "$INSTALLER" == "yum" ]]; then
 yum -y remove salt salt-minion python3-salt python2-salt > /dev/null 2>&1 ||:
 elif [[ "$INSTALLER" == "apt" ]]; then


### PR DESCRIPTION
## What does this PR change?

We can have venv-salt-minion in combination with salt-master and salt-api. Actually, we use venv-salt-minion with sumaform to install all the necessary packages, including salt/python3-salt (salt-master and salt-api).

What is incompatible, is having salt-minion and venv-salt-minion. See https://github.com/SUSE/spacewalk/issues/21704 .

However, if we remove salt and python3-salt, this removes patterns-uyuni_server. (see https://github.com/SUSE/spacewalk/issues/21704 ).

Thus, what we really need is to remove salt-minion if venv-salt-minion is installed.

This fixes https://github.com/SUSE/spacewalk/issues/21704
