### PR TITLE
Adjust c3p0 connection timeout

### DIFF
--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -276,8 +276,8 @@ variable "db_configuration" {
 
 variable "c3p0_connection_timeout" {
   description = "c3p0 connections will be closed after this timeout"
-  # WORKAROUND: this is causing problems in the testsuite, disable it for now
-  default     = false
+  # 3 hours - this should be enough for repo metadata generation
+  default     = 10800
 }
 
 variable "c3p0_connection_debug" {

--- a/salt/server/rhn.sls
+++ b/salt/server/rhn.sls
@@ -85,12 +85,12 @@ rhn_conf_forward_reg:
 
 {% endif %}
 
-{% if grains.get('c3p0_connection_timeout') | default(true, true) %}
+{% if grains.get('c3p0_connection_timeout') | default(false, true) %}
 
 rhn_conf_c3p0_connection_timeout:
   file.append:
     - name: /etc/rhn/rhn.conf
-    - text: hibernate.c3p0.unreturnedConnectionTimeout = {{ grains.get('c3p0_connection_timeout') | default(900, true) }}
+    - text: hibernate.c3p0.unreturnedConnectionTimeout = {{ grains.get('c3p0_connection_timeout') | default(10800, true) }}
     - require:
       - sls: server
 


### PR DESCRIPTION
## What does this PR change?

This should be the final tuning for 3p0 connection timeout.

Manager 4.3 and uyuni is fixed to work with this setting. 
The workaround apparently did not work because of the default in sls file. Anyway, it is no longer needed.

The default timeout is set to 3 hours, because processing of RES7 repos on 4.2 takes up to 2 hours.

