### PR TITLE
fix default filter and increase default timeout to 4 hours

### DIFF
--- a/salt/server/rhn.sls
+++ b/salt/server/rhn.sls
@@ -85,12 +85,12 @@ rhn_conf_forward_reg:
 
 {% endif %}
 
-{% if grains.get('c3p0_connection_timeout') | default(true, true) %}
+{% if grains.get('c3p0_connection_timeout') | default(true, false) %}
 
 rhn_conf_c3p0_connection_timeout:
   file.append:
     - name: /etc/rhn/rhn.conf
-    - text: hibernate.c3p0.unreturnedConnectionTimeout = {{ grains.get('c3p0_connection_timeout') | default(900, true) }}
+    - text: hibernate.c3p0.unreturnedConnectionTimeout = {{ grains.get('c3p0_connection_timeout') | default(14400, true) }}
     - require:
       - sls: server
 


### PR DESCRIPTION
## What does this PR change?

The default filter was used wrong. When the second parameter is true, it will use the default for
undefined, empty string and false .

Setting the grain to "false" result in "true" due to this filter.

Additionally 15 minutes timeout is too short for metadata generation on slow hardware and big repos like RES7.
Increased the default to 4 hours.
