### PR TITLE
Prepare SLE micro properly

### DIFF
--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -43,11 +43,10 @@ dbus_enable_service:
 # TODO: replace 'pkg.latest' with 'pkg.installed' when fix to bsc#1163683 is applied to all the SLES versions we use
 avahi_pkg:
 {% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SLE Micro'  %}
-# WORKAROUND for sle micro we should not ask for the latest by just check that is installed. We are building our image for sumaform.
-  pkg.installed:
+  cmd.run:
+    - name: transactional-update -c package up avahi avahi-lang libavahi-common3 libavahi-core7
 {% else %}
   pkg.latest:
-{% endif %}
     - pkgs:
       {% if grains['os_family'] == 'Debian' %}
       - avahi-daemon
@@ -68,6 +67,7 @@ avahi_pkg:
       - libavahi-core7
       {% endif %}
       {% endif %}
+{% endif %}
 
 # WORKAROUND: watch does not really work with Salt 2016.11
 avahi_dead_before_config:

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -1,10 +1,6 @@
 include:
   - default.locale
-  {% if not grains['osfullname'] == 'SLE Micro' %}
-  # Dependencies already satisfied by the images
-  # https://build.opensuse.org/project/show/systemsmanagement:sumaform:images:microos
   - default.minimal
-  {% endif %}
   - default.pkgs
   - default.grub
   - default.sshd

--- a/salt/default/minimal.sls
+++ b/salt/default/minimal.sls
@@ -1,7 +1,3 @@
-# WORKAROUND
-# This file should already be excluded from SLE Micro with the 
-# first few lines in salt/default/init.sls
-{% if not grains['osfullname'] == 'SLE Micro' %}
 include:
   {% if grains['hostname'] and grains['domain'] %}
   - default.hostname
@@ -15,6 +11,14 @@ include:
   - default.time
 
 minimal_package_update:
+{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SLE Micro'  %}
+  cmd.run:
+{% if grains['install_salt_bundle'] %}
+    - name: transactional-update -c package up zypper libzypp venv-salt-minion
+{% else %}
+    - name: transactional-update -c package up zypper libzypp salt-minion
+{% endif %}
+{% else %}
   pkg.latest:
     - pkgs:
 {% if grains['install_salt_bundle'] %}


### PR DESCRIPTION
## What does this PR change?

Most of SLE Micro setup was disabled because of some problems with package updates. This resulted for example in no hostname for SLE Micro 5.1 and 5.2. We can't disable all initialization at once.

The idea with SLE Micro is to prepare all packages in the image and having no package to update in sumaform - merely to check everything is there. However, `pkg.install` does not do the job because it is impossible to acquire a rpm lock  on a read-only filesystem.

Fixes https://github.com/SUSE/spacewalk/issues/21792