### PR TITLE
Fix url issues for res8 in minimum_repositories_testsuite.yaml

### DIFF
--- a/salt/mirror/etc/minimum_repositories_testsuite.yaml
+++ b/salt/mirror/etc/minimum_repositories_testsuite.yaml
@@ -43,13 +43,13 @@ http:
   - url:  http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
     archs: [x86_64]
 
-  - url:  http://download.suse.de/download/ibs/SUSE/Updates/RES/7-CLIENT-TOOLS/x86_64/update/
+  - url:  http://download.suse.de/ibs/SUSE/Updates/RES/7-CLIENT-TOOLS/x86_64/update/
     archs: [x86_64]
 
-  - url:  http://download.suse.de/download/ibs/SUSE/Updates/RES/8-CLIENT-TOOLS/x86_64/update/
+  - url:  http://download.suse.de/ibs/SUSE/Updates/RES/8-CLIENT-TOOLS/x86_64/update/
     archs: [x86_64]
 
-  - url:  http://download.suse.de/download/ibs/SUSE/Products/RES/8-CLIENT-TOOLS/x86_64/update/
+  - url:  http://download.suse.de/ibs/SUSE/Products/RES/8-CLIENT-TOOLS/x86_64/update/
     archs: [x86_64]
 
   - url:  http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15-BETA/x86_64/product/

--- a/salt/server/additional_disk.sls
+++ b/salt/server/additional_disk.sls
@@ -16,7 +16,7 @@ parted:
 spacewalk_partition:
   cmd.run:
     - name: /usr/sbin/parted -s /dev/{{grains['data_disk_device']}} mklabel gpt && /usr/sbin/parted -s /dev/{{grains['data_disk_device']}} mkpart primary 0% 100% && sleep 1 && /sbin/mkfs.{{fstype}} {{partition_name}}
-    - unless: ls /dev/{{grains['data_disk_device']}}1
+    - unless: ls {{partition_name}}
     - require:
       - pkg: parted
 


### PR DESCRIPTION
## What does this PR change?
The urls were incorrect for res8 and res7 suma tool in minimum repo list.

As a remember, minimum_repositories_testsuite.yaml is the minimum list of repositories needed to run the testsuite in AWS.
It's used to create internal and external mirror with this repositories.


