### PR TITLE
Enable EL9 key for all versions

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -448,6 +448,16 @@ install_recommends:
 
 {% set release = grains.get('osmajorrelease', None)|int() %}
 
+{# Soon this key will be used for all non-suse repos. When it happens, replace galaxy_key with this #}
+suse_el9_key:
+  file.managed:
+    - name: /tmp/suse_el9.key
+    - source: salt://default/gpg_keys/suse_el9.key
+  cmd.wait:
+    - name: rpm --import /tmp/suse_el9.key
+    - watch:
+      - file: suse_el9_key
+
 galaxy_key:
   file.managed:
     - name: /tmp/galaxy.key
@@ -534,15 +544,9 @@ tools_pool_repo:
     - refresh: True
     - require:
       - cmd: galaxy_key
-
-suse_el9_key:
-  file.managed:
-    - name: /tmp/suse_el9.key
-    - source: salt://default/gpg_keys/suse_el9.key
-  cmd.wait:
-    - name: rpm --import /tmp/suse_el9.key
-    - watch:
-      - file: suse_el9_key
+    {% if release >= 9 %}
+      - cmd: suse_el9_key
+    {% endif %}
 
 suse_res7_key:
   file.managed:
@@ -591,6 +595,9 @@ tools_update_repo:
     - refresh: True
     - require:
       - cmd: galaxy_key
+    {% if release >= 9 %}
+      - cmd: suse_el9_key
+    {% endif %}
 
 {% elif 'head' in grains.get('product_version') | default('', true) %}
 
@@ -606,6 +613,9 @@ tools_update_repo:
     - refresh: True
     - require:
       - cmd: galaxy_key
+    {% if release >= 9 %}
+      - cmd: suse_el9_key
+    {% endif %}
 
 {% elif 'uyuni-master' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') %}
 


### PR DESCRIPTION
https://github.com/uyuni-project/sumaform/pull/1345 added the keys only for `Manager`. This fixes it for other versions as well.

Fixes https://github.com/SUSE/spacewalk/issues/21955