### PR TITLE
sles12sp4 ami not available anymore on AWS

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -124,27 +124,6 @@ data "aws_ami" "sles12sp5" {
   }
 }
 
-data "aws_ami" "sles12sp4" {
-  most_recent = true
-  name_regex  = "^suse-sles-12-sp4-byos-v"
-  owners      = ["679593333241"]
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
 data "aws_ami" "rocky8" {
   most_recent = true
   name_regex  = "^Rocky-8-ec2-8"

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -72,7 +72,6 @@ locals {
       sles15sp3o   = { ami = data.aws_ami.sles15sp3o.image_id },
       sles15sp4o   = { ami = data.aws_ami.sles15sp4o.image_id },
       sles12sp5   = { ami = data.aws_ami.sles12sp5.image_id },
-      sles12sp4   = { ami = data.aws_ami.sles12sp4.image_id },
       rocky8      = { ami = data.aws_ami.rocky8.image_id, ssh_user = "rocky" },
       debian11    = { ami = data.aws_ami.debian11.image_id, ssh_user= "admin" },
       ubuntu2204  = { ami = data.aws_ami.ubuntu2204.image_id, ssh_user = "ubuntu" },


### PR DESCRIPTION
## What does this PR change?

Remove sles12sp4 ami search because sles12sp4 was removed from AWS