### PR TITLE
Disable auto_generate_bootstrap_repo when running the testsuite

### DIFF
--- a/salt/server/rhn.sls
+++ b/salt/server/rhn.sls
@@ -116,6 +116,17 @@ rhn_conf_c3p0_connection_debug_log:
 
 {% endif %}
 
+{% if grains.get('testsuite') | default(false, true) %}
+
+rhn_conf_disable_auto_generate_bootstrap_repo :
+  file.append:
+    - name: /etc/rhn/rhn.conf
+    - text: server.susemanager.auto_generate_bootstrap_repo = 0
+    - require:
+      - sls: server
+
+{% endif %}
+
 # catch-all to ensure we always have at least one state covering /etc/rhn/rhn.conf
 rhn_conf_present:
   file.touch:


### PR DESCRIPTION
## What does this PR change?

We want to be in control on what the server is doing during our testsuite to avoid any instability.
This PR disable the auto_generate_bootstrap_repo when testsuite is true on server side.
I reuse the testsuite variable to avoid adding new variable.
It tested the change and it works as expected.