### PR TITLE
Add netavark on podman hosts for IPv6-capable networks

### DIFF
--- a/salt/server_containerized/install_podman.sls
+++ b/salt/server_containerized/install_podman.sls
@@ -1,9 +1,11 @@
 include:
   - server_containerized.install_common
 
-podman_package:
+podman_packages:
   pkg.installed:
-    - name: podman
+    - pkgs:
+      - podman
+      - netavark
     - require:
       {% if 'build_image' not in grains.get('product_version') | default('', true) %}
       - sls: repos


### PR DESCRIPTION
## What does this PR change?

See title. Fixing https://github.com/SUSE/spacewalk/issues/22103 together with https://github.com/uyuni-project/uyuni-tools/pull/9
