### PR TITLE
Limit changelog entries per package

### DIFF
--- a/salt/server/rhn.sls
+++ b/salt/server/rhn.sls
@@ -12,16 +12,14 @@ package_import_skip_changelog_reposync:
 
 {% endif %}
 
-{% if 'uyuni' in grains['product_version'] %}
-
 limit_changelog_entries:
-  file.append:
+  file.replace:
     - name: /etc/rhn/rhn.conf
-    - text: java.max_changelog_entries = 3
+    - pattern: java.max_changelog_entries.*
+    - repl: java.max_changelog_entries = 3
+    - append_if_not_found: true
     - require:
       - sls: server
-
-{% endif %}
 
 {% if grains.get('disable_download_tokens') %}
 disable_download_tokens:

--- a/salt/server/rhn.sls
+++ b/salt/server/rhn.sls
@@ -12,6 +12,17 @@ package_import_skip_changelog_reposync:
 
 {% endif %}
 
+{% if 'uyuni' in grains['product_version'] %}
+
+limit_changelog_entries:
+  file.append:
+    - name: /etc/rhn/rhn.conf
+    - text: java.max_changelog_entries = 3
+    - require:
+      - sls: server
+
+{% endif %}
+
 {% if grains.get('disable_download_tokens') %}
 disable_download_tokens:
   file.append:

--- a/salt/server_containerized/rhn.sls
+++ b/salt/server_containerized/rhn.sls
@@ -12,16 +12,14 @@ package_import_skip_changelog_reposync:
 
 {% endif %}
 
-{% if 'uyuni' in grains['product_version'] %}
-
 limit_changelog_entries:
-  file.append:
+  file.replace:
     - name: /etc/rhn/rhn.conf
-    - text: java.max_changelog_entries = 3
+    - pattern: java.max_changelog_entries.*
+    - repl: java.max_changelog_entries = 3
+    - append_if_not_found: true
     - require:
       - sls: server
-
-{% endif %}
 
 {% if grains.get('disable_download_tokens') %}
 disable_download_tokens:

--- a/salt/server_containerized/rhn.sls
+++ b/salt/server_containerized/rhn.sls
@@ -12,6 +12,17 @@ package_import_skip_changelog_reposync:
 
 {% endif %}
 
+{% if 'uyuni' in grains['product_version'] %}
+
+limit_changelog_entries:
+  file.append:
+    - name: /etc/rhn/rhn.conf
+    - text: java.max_changelog_entries = 3
+    - require:
+      - sls: server
+
+{% endif %}
+
 {% if grains.get('disable_download_tokens') %}
 disable_download_tokens:
   file.append:


### PR DESCRIPTION
## What does this PR change?

With Uyuni we have much more packages that get synced compared to SLES. This limits the amount of changelogs to download and keep.

See
- https://www.uyuni-project.org/uyuni-docs/en/uyuni/administration/tuning-changelogs.html
- https://docs.saltproject.io/en/latest/ref/states/all/salt.states.file.html#salt.states.file.replace

