### PR TITLE
Add custom grain for CPE

### DIFF
--- a/_grains/cpe_grain.py
+++ b/_grains/cpe_grain.py
@@ -1,0 +1,78 @@
+import re
+
+def get_cpe_grain(grains):
+    ret = {"cpe": ""}
+
+    os_release = _parse_os_release("/etc/os-release")
+
+    cpe = os_release["CPE_NAME"]
+    if cpe:
+        ret["cpe"] = cpe
+    else:
+        derived_cpe = _derive_cpe(grains)
+        if derived_cpe:
+            ret["cpe"] = derived_cpe
+
+    return ret
+
+# Copy-pasted from https://github.com/saltstack/salt/blame/master/salt/grains/core.py
+def _parse_os_release(*os_release_files):
+    """
+    Parse os-release and return a parameter dictionary
+
+    This function will behave identical to
+    platform.freedesktop_os_release() from Python >= 3.10, if
+    called with ("/etc/os-release", "/usr/lib/os-release").
+
+    See http://www.freedesktop.org/software/systemd/man/os-release.html
+    for specification of the file format.
+    """
+    # These fields are mandatory fields with well-known defaults
+    # in practice all Linux distributions override NAME, ID, and PRETTY_NAME.
+    ret = {"NAME": "Linux", "ID": "linux", "PRETTY_NAME": "Linux"}
+
+    errno = None
+    for filename in os_release_files:
+        try:
+            with open(filename, 'r') as ifile:
+                regex = re.compile("^([\\w]+)=(?:'|\")?(.*?)(?:'|\")?$")
+                for line in ifile:
+                    match = regex.match(line.strip())
+                    if match:
+                        # Shell special characters ("$", quotes, backslash,
+                        # backtick) are escaped with backslashes
+                        ret[match.group(1)] = re.sub(
+                            r'\\([$"\'\\`])', r"\1", match.group(2)
+                        )
+            break
+        except OSError as error:
+            errno = error.errno
+    else:
+        raise OSError(
+            errno, "Unable to read files {}".format(", ".join(os_release_files))
+        )
+
+    return ret
+
+
+def _derive_cpe(grains):
+    """
+    Try to derive the CPE of the system based on the collected core grains.
+
+    PS: This function is not guaranteed to derive the correct CPE as there could be a many 
+    variances of the same OS that require different CPEs, for example, release and beta versions.
+
+    Currently the function exclusively derives CPEs for Debian and Ubuntu. 
+    These two operating systems are the primary focus, as they are intended to be supported by 
+    the OVAL-based CVE auditing project, for which this modification is intended.
+
+    TODO: reference the OVAL code
+    """
+    os = grains.get('os')
+    os_release = grains.get('osrelease')
+    if os == 'Debian':
+        return "cpe:/o:debian:debian_linux:" + os_release
+    elif os == "Ubuntu":
+        return "cpe:/o:canonical:ubuntu_linux:" + os_release
+    else:
+        return None

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -214,7 +214,7 @@ resource "null_resource" "host_salt_configuration" {
         gpg_keys                  = var.gpg_keys
         ipv6                      = var.ipv6
     })
-    custom_grains_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
+    custom_grain_modules_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
   }
 
   connection {

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -214,6 +214,7 @@ resource "null_resource" "host_salt_configuration" {
         gpg_keys                  = var.gpg_keys
         ipv6                      = var.ipv6
     })
+    custom_grains_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
   }
 
   connection {
@@ -279,6 +280,11 @@ resource "null_resource" "host_salt_configuration" {
       "sudo mv /tmp/salt /root",
       "sudo bash /root/salt/first_deployment_highstate.sh"
     ]
+  }
+
+  provisioner "file" {
+    source      = "_grains"
+    destination = "/srv/salt"
   }
 }
 

--- a/backend_modules/azure/host/main.tf
+++ b/backend_modules/azure/host/main.tf
@@ -150,7 +150,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
         gpg_keys              = var.gpg_keys
         ipv6                  = var.ipv6
     })
-    custom_grains_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
+    custom_grain_modules_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
   }
   connection {
     host        = local.public_instance ? azurerm_public_ip.suma-pubIP[count.index].ip_address : azurerm_network_interface.suma-main-nic[count.index].private_ip_address

--- a/backend_modules/azure/host/main.tf
+++ b/backend_modules/azure/host/main.tf
@@ -150,6 +150,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
         gpg_keys              = var.gpg_keys
         ipv6                  = var.ipv6
     })
+    custom_grains_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
   }
   connection {
     host        = local.public_instance ? azurerm_public_ip.suma-pubIP[count.index].ip_address : azurerm_network_interface.suma-main-nic[count.index].private_ip_address
@@ -213,6 +214,11 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
       "sudo bash /root/salt/first_deployment_highstate.sh"
     ]
   }
+
+   provisioner "file" {
+     source      = "_grains"
+     destination = "/srv/salt"
+   }
 }
 
 /** END: provisioning */

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -193,7 +193,7 @@ resource "null_resource" "provisioning" {
         gpg_keys                  = var.gpg_keys
         ipv6                      = var.ipv6
     })
-    custom_grains_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
+    custom_grain_modules_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
   }
 
   count = var.provision ? var.quantity : 0

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -193,6 +193,7 @@ resource "null_resource" "provisioning" {
         gpg_keys                  = var.gpg_keys
         ipv6                      = var.ipv6
     })
+    custom_grains_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
   }
 
   count = var.provision ? var.quantity : 0
@@ -258,6 +259,11 @@ resource "null_resource" "provisioning" {
     inline = [
       "bash /root/salt/post_provisioning_cleanup.sh",
     ]
+  }
+
+  provisioner "file" {
+    source      = "_grains"
+    destination = "/srv/salt"
   }
 }
 

--- a/backend_modules/ssh/host/main.tf
+++ b/backend_modules/ssh/host/main.tf
@@ -37,7 +37,7 @@ resource "null_resource" "provisioning" {
         gpg_keys                  = var.gpg_keys
         ipv6                      = var.ipv6
     })
-    custom_grains_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
+    custom_grain_modules_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
   }
 
   count = var.provision ? 1 : 0

--- a/backend_modules/ssh/host/main.tf
+++ b/backend_modules/ssh/host/main.tf
@@ -37,6 +37,7 @@ resource "null_resource" "provisioning" {
         gpg_keys                  = var.gpg_keys
         ipv6                      = var.ipv6
     })
+    custom_grains_hash = sha1(join("", [for f in fileset("_grains", "*"): filesha1("_grains/${f}")]))
   }
 
   count = var.provision ? 1 : 0
@@ -110,6 +111,11 @@ resource "null_resource" "provisioning" {
     inline = [
       "sudo bash /opt/salt/first_deployment_highstate.sh"
     ]
+  }
+
+  provisioner "file" {
+    source      = "_grains"
+    destination = "/srv/salt"
   }
 }
 


### PR DESCRIPTION
## What does this PR change?
Hi! I'm a GSoC contributor for Uyuni working on the OVAL-based CVE auditing project.

The primary goal of this PR is to be able to access minions CPEs from the backend in order to be able to conduct more accurate vulnerability scanning. With the CPE we can accurately identify the minion operating system and with that, we can decide what vulnerabilities affect the minion and what vulnerabilities do not.

Additional custom grain modules can be added to the `_grains` folder and propagated automatically to the host machines in subsequent terraform state applications. 

## Notes
- One problem that bugs me is that the custom grain modules are getting propagated to clients and servers even though we only need it on the server.
- Also, I'm unsure how to use [file_roots](https://docs.saltproject.io/en/latest/ref/configuration/master.html#std-conf_master-file_roots) instead of harcoding the path. 


