### PR TITLE
use ServerContainer repo also in k3s

### DIFF
--- a/salt/repos/server_containerized.sls
+++ b/salt/repos/server_containerized.sls
@@ -1,4 +1,4 @@
-{% if 'server_containerized' in grains.get('roles') and grains.get('container_runtime') | default('podman', true) == 'podman' %}
+{% if 'server_containerized' in grains.get('roles')  %}
 
 systemsmanagement_Uyuni_Master_ServerContainer:
     pkgrepo.managed:


### PR DESCRIPTION
## What does this PR change?

use ServerContainer repo also in k3s (required by `uyuni-tools` )