### PR TITLE
containers: use localhost for the reportdb

### DIFF
--- a/salt/server_containerized/uyuniadm.yaml
+++ b/salt/server_containerized/uyuniadm.yaml
@@ -1,5 +1,7 @@
 db:
   password: spacewalk
+reportdb:
+  host: localhost
 cert:
   password: spacewalk
 scc:


### PR DESCRIPTION
## What does this PR change?

Use localhost reportdb hostname to avoid hairpins.