### PR TITLE
Don't use mirror for ServerContainer branch repo

### DIFF
--- a/salt/repos/server_containerized.sls
+++ b/salt/repos/server_containerized.sls
@@ -3,7 +3,7 @@
 systemsmanagement_Uyuni_Master_ServerContainer:
     pkgrepo.managed:
       # TODO change to the regular URL once available
-    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ServerContainer/openSUSE_Leap_15.4/
+    - baseurl: http://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/ServerContainer/openSUSE_Leap_15.4/
     - refresh: True
 
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

No need to mirror a temporary repo: it would only force us to mirror it.
