### PR TITLE
This tweak enable some logs to debug hibernate and SaltServerActionService

### DIFF
--- a/salt/server/taskomatic.sls
+++ b/salt/server/taskomatic.sls
@@ -11,6 +11,23 @@ taskomatic_config:
     - require:
       - sls: server.rhn
 
+hibernate_debug_log:
+  file.line:
+    - name: /srv/tomcat/webapps/rhn/WEB-INF/classes/log4j2.xml
+    - content: '    <Logger name="org.hibernate" level="debug" additivity="false"><AppenderRef ref="hibernateAppender" /></Logger>'
+    - after: "<Loggers>"
+    - mode: ensure
+    - require:
+      - sls: server.rhn
+
+taskomatic_hibernate_debug_log:
+  file.line:
+    - name: /srv/tomcat/webapps/rhn/WEB-INF/classes/log4j2.xml
+    - content: '    <File name="hibernateAppender" fileName="/var/log/rhn/rhn_taskomatic_hibernate.log"><PatternLayout pattern="[%d] %-5p - %m%n" /></File>'
+    - after: "<Appenders>"
+    - mode: ensure
+    - require:
+      - sls: server.rhn
 {% endif %}
 
 taskomatic:

--- a/salt/server/tomcat.sls
+++ b/salt/server/tomcat.sls
@@ -19,6 +19,14 @@ tomcat_config:
       - sls: server.rhn
       - file: tomcat_config_create
 
+salt_server_action_service_debug_log:
+  file.line:
+    - name: /srv/tomcat/webapps/rhn/WEB-INF/classes/log4j2.xml
+    - content: '    <Logger name="com.suse.manager.webui.services.SaltServerActionService" level="trace" />'
+    - after: "<Loggers>"
+    - mode: ensure
+    - require:
+      - sls: server.rhn
 {% endif %}
 
 {% if grains.get('login_timeout') %}


### PR DESCRIPTION
## What does this PR change?

In order to debug this bug https://bugzilla.suse.com/show_bug.cgi?id=1212498
We want to have more fine trace logs in Java side, so we can understand what Taskomatic and SaltServerActionService (from Tomcat) side are doing.
