### PR TITLE
Add kiwi packages to buildhost

### DIFF
--- a/salt/build_host/init.sls
+++ b/salt/build_host/init.sls
@@ -7,6 +7,13 @@ certificate_authority_certificate:
     - source: salt://build_host/certs/ca.cert.pem
     - makedirs: True
 
+{% if '4.2' not in grains.get('product_version') %}
+cucumber_requisites:
+  pkg.installed:
+    - pkgs:
+      - python3-kiwi
+{% endif %}
+
 {% if '11' in grains['osrelease'] %}
 
 update_ca_truststore_registry_build_host:


### PR DESCRIPTION
## What does this PR change?

Since we kill the openSUSE Leap reposync in the test suite, we have to install the kiwi package in order to be able to successfully bootstrap the buildhost. We also see failures regarding this in our 4.3 CI.

See https://github.com/SUSE/spacewalk/issues/22440
