### PR TITLE
Rename Salt state for kiwi package on build host

### DIFF
--- a/salt/build_host/init.sls
+++ b/salt/build_host/init.sls
@@ -8,7 +8,7 @@ certificate_authority_certificate:
     - makedirs: True
 
 {% if '4.2' not in grains.get('product_version') %}
-cucumber_requisites:
+kiwi_imager_server_dependency:
   pkg.installed:
     - pkgs:
       - python3-kiwi


### PR DESCRIPTION
## What does this PR change?

This will rename the Salt step used for the Kiwi package on the build host.
