### PR TITLE
Revert taskomatic hibernation logging

### DIFF
--- a/salt/server/taskomatic.sls
+++ b/salt/server/taskomatic.sls
@@ -10,24 +10,6 @@ taskomatic_config:
     - repl: JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address=*:8001,server=y,suspend=n "
     - require:
       - sls: server.rhn
-
-hibernate_debug_log:
-  file.line:
-    - name: /srv/tomcat/webapps/rhn/WEB-INF/classes/log4j2.xml
-    - content: '        <Logger name="org.hibernate" level="debug" additivity="false"><AppenderRef ref="hibernateAppender" /></Logger>'
-    - after: "<Loggers>"
-    - mode: ensure
-    - require:
-      - sls: server.rhn
-
-taskomatic_hibernate_debug_log:
-  file.line:
-    - name: /srv/tomcat/webapps/rhn/WEB-INF/classes/log4j2.xml
-    - content: '        <File name="hibernateAppender" fileName="/var/log/rhn/rhn_taskomatic_hibernate.log"><PatternLayout pattern="[%d] %-5p - %m%n" /></File>'
-    - after: "<Appenders>"
-    - mode: ensure
-    - require:
-      - sls: server.rhn
 {% endif %}
 
 taskomatic:

--- a/salt/server/tomcat.sls
+++ b/salt/server/tomcat.sls
@@ -18,15 +18,6 @@ tomcat_config:
     - require:
       - sls: server.rhn
       - file: tomcat_config_create
-
-salt_server_action_service_debug_log:
-  file.line:
-    - name: /srv/tomcat/webapps/rhn/WEB-INF/classes/log4j2.xml
-    - content: '        <Logger name="com.suse.manager.webui.services.SaltServerActionService" level="trace" />'
-    - after: "<Loggers>"
-    - mode: ensure
-    - require:
-      - sls: server.rhn
 {% endif %}
 
 {% if grains.get('login_timeout') %}


### PR DESCRIPTION
## What does this PR change?

Reverts https://github.com/uyuni-project/sumaform/pull/1379

This needs to be reverted due to a growing log file beyond good and evil. This hibernation log file had a size of 105 GB on the BV server in NUE and about 50 GB in PRV.

See https://github.com/SUSE/spacewalk/issues/22375#issuecomment-1713446656

CC @srbarrios.

