### PR TITLE
Adding two additional variables to enable additional java debugging

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -885,6 +885,8 @@ module "server" {
 The `server` module has options to automatically capture more diagnostic information, off by default:
 
 - `java_debugging`: enable Java debugging and profiling support in Tomcat and Taskomatic
+- `java_hibernate_debugging`: enable additional logs for Hibernate in Tomcat and Taskomatic
+- `java_salt_debugging`: enable additional logs for Hibernate in Tomcat
 - `postgres_log_min_duration`: log PostgreSQL statements taking longer than the duration (expressed as a string, eg. `250ms` or `3s`), or log all statements by specifying `0`
 
 ## Using external database

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -63,6 +63,8 @@ module "server" {
     unsafe_postgres                = var.unsafe_postgres
     postgres_log_min_duration      = var.postgres_log_min_duration
     java_debugging                 = var.java_debugging
+    java_hibernate_debugging       = var.java_hibernate_debugging
+    java_salt_debugging            = var.java_salt_debugging
     skip_changelog_import          = var.skip_changelog_import
     create_first_user              = var.create_first_user
     mgr_sync_autologin             = var.mgr_sync_autologin

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -102,6 +102,16 @@ variable "java_debugging" {
   default     = true
 }
 
+variable "java_hibernate_debugging" {
+  description = "enable additional logs for Hibernate in Tomcat and Taskomatic"
+  default     = false
+}
+
+variable "java_salt_debugging" {
+  description = "enable additional logs for Hibernate in Tomcat"
+  default     = false
+}
+
 variable "skip_changelog_import" {
   description = "import RPMs without changelog data, this speeds up spacewalk-repo-sync"
   default     = true

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -46,6 +46,8 @@ module "server_containerized" {
     server_username                = var.server_username
     server_password                = var.server_password
     java_debugging                 = var.java_debugging
+    java_hibernate_debugging       = var.java_hibernate_debugging
+    java_salt_debugging            = var.java_salt_debugging
     from_email                     = var.from_email
     traceback_email                = var.traceback_email
     skip_changelog_import          = var.skip_changelog_import

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -117,6 +117,16 @@ variable "java_debugging" {
   default     = true
 }
 
+variable "java_hibernate_debugging" {
+  description = "enable additional logs for Hibernate in Tomcat and Taskomatic"
+  default     = false
+}
+
+variable "java_salt_debugging" {
+  description = "enable additional logs for Hibernate in Tomcat"
+  default     = false
+}
+
 variable "skip_changelog_import" {
   description = "import RPMs without changelog data, this speeds up spacewalk-repo-sync"
   default     = true

--- a/salt/server/taskomatic.sls
+++ b/salt/server/taskomatic.sls
@@ -1,8 +1,9 @@
-{% if grains.get('java_debugging') %}
-
+{% if grains.get('java_debugging') or grains.get('java_hibernate_debugging') %}
 include:
   - server.rhn
+{% endif %}
 
+{% if grains.get('java_debugging') %}
 taskomatic_config:
   file.replace:
     - name: /etc/rhn/taskomatic.conf
@@ -10,7 +11,9 @@ taskomatic_config:
     - repl: JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address=*:8001,server=y,suspend=n "
     - require:
       - sls: server.rhn
+{% endif %}
 
+{% if grains.get('java_hibernate_debugging') and '4.2' not in grains['product_version'] %}
 hibernate_debug_log:
   file.line:
     - name: /srv/tomcat/webapps/rhn/WEB-INF/classes/log4j2.xml

--- a/salt/server/tomcat.sls
+++ b/salt/server/tomcat.sls
@@ -1,8 +1,9 @@
-{% if grains.get('java_debugging') %}
-
+{% if grains.get('java_debugging') or grains.get('java_salt_debugging') %}
 include:
   - server.rhn
+{% endif %}
 
+{% if grains.get('java_debugging') %}
 tomcat_config_create:
   file.touch:
     - name: /etc/tomcat/conf.d/remote_debug.conf
@@ -18,7 +19,9 @@ tomcat_config:
     - require:
       - sls: server.rhn
       - file: tomcat_config_create
+{% endif %}
 
+{% if grains.get('java_salt_debugging') and '4.2' not in grains['product_version'] %}
 salt_server_action_service_debug_log:
   file.line:
     - name: /srv/tomcat/webapps/rhn/WEB-INF/classes/log4j2.xml


### PR DESCRIPTION
## What does this PR change?

This PR creates two new variables to enable additional java logs.
Before this PR all the java debug logs were handled by the same variable, but this variable "java_debugging" is set by default as "true".
This was generating too many overhead for regular cases, so now, we have two more variables to switch debug logs for Hibernate and SaltService.
