### PR TITLE
Update RHEL ami

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -210,7 +210,7 @@ data "aws_ami" "ubuntu2004" {
 
 data "aws_ami" "rhel9" {
   most_recent = true
-  name_regex  = "^RHEL-9.0.0_HVM-"
+  name_regex  = "^RHEL-9.2.0_HVM-"
   owners      = ["309956199498"]
 
   filter {

--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -19,6 +19,27 @@ data "aws_ami" "opensuse154o" {
   }
 }
 
+data "aws_ami" "opensuse155o" {
+  most_recent = true
+  name_regex  = "^openSUSE-Leap-15-5-v"
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
 data "aws_ami" "sles15sp1o" {
   most_recent = true
   name_regex  = "^suse-sles-15-sp1-byos-v"

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -67,6 +67,7 @@ locals {
     key_file = local.key_file
     ami_info = {
       opensuse154o = { ami = data.aws_ami.opensuse154o.image_id },
+      opensuse155o = { ami = data.aws_ami.opensuse155o.image_id },
       sles15sp1o   = { ami = data.aws_ami.sles15sp1o.image_id },
       sles15sp2o   = { ami = data.aws_ami.sles15sp2o.image_id },
       sles15sp3o   = { ami = data.aws_ami.sles15sp3o.image_id },

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -26,6 +26,22 @@ runcmd:
 
 %{ endif }
 
+%{ if image == "opensuse155o" }
+# WORKAROUND: install latest libzypp to prevent signature verification errors
+runcmd:
+  - zypper addrepo -G -e http://download.opensuse.org/update/leap/15.5/oss/ os_update
+  - zypper addrepo -G -e http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/ client_tools_tmp
+  - zypper ref
+  - zypper up --allow-vendor-change --no-confirm libzypp
+%{ if install_salt_bundle }
+  - zypper in --allow-vendor-change --no-confirm venv-salt-minion
+%{ else }
+  - zypper up --allow-vendor-change --no-confirm salt-minion
+%{ endif }
+  - zypper removerepo --all
+
+%{ endif }
+
 %{ if image == "sles15"}
 zypper:
   repos:


### PR DESCRIPTION
## What does this PR change?

RHEL 8.2 AMI was removed. Switch to latest 8.8 version.
RHEL 9.0 also replaced by 9.2 version