### PR TITLE
Allow setting up an environment without SCC credentials

### DIFF
--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -1,11 +1,13 @@
 variable "cc_username" {
   description = "username for the Customer Center"
   type        = string
+  default     = null
 }
 
 variable "cc_password" {
   description = "password for the Customer Center"
   type        = string
+  default     = null
 }
 
 variable "timezone" {

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -2,11 +2,13 @@
 variable "cc_username" {
   description = "username for the Customer Center"
   type        = string
+  default     = null
 }
 
 variable "cc_password" {
   description = "password for the Customer Center"
   type        = string
+  default     = null
 }
 
 variable "use_avahi" {

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -97,7 +97,7 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 
 # various test suite settings
 export GITPROFILES="{{ grains.get('git_profiles_repo') }}"
-export SCC_CREDENTIALS="{{ grains.get('cc_username') }}|{{ grains.get('cc_password') }}"
+{% if grains.get('cc_username') | default(false, true) %}export SCC_CREDENTIALS="{{ grains.get('cc_username') }}|{{ grains.get('cc_password') }}" {% else %}# no SCC Credentials defined {% endif %}
 export AUTH_REGISTRY_CREDENTIALS="{{ grains.get('auth_registry_username') }}|{{ grains.get('auth_registry_password') }}"
 {% if grains.get('auth_registry') | default(false, true) %}export AUTH_REGISTRY="{{ grains.get('auth_registry') }}" {% else %}# no authenticated registry defined {% endif %}
 {% if grains.get('no_auth_registry') | default(false, true) %}export NO_AUTH_REGISTRY="{{ grains.get('no_auth_registry') }}" {% else %}# no container registry defined {% endif %}

--- a/salt/server/setup_env.sh
+++ b/salt/server/setup_env.sh
@@ -17,8 +17,10 @@ MANAGER_DB_HOST="{{ grains.get('db_configuration')['hostname'] }}"
 MANAGER_DB_PORT="{{ grains.get('db_configuration')['port'] }}"
 MANAGER_DB_PROTOCOL="TCP"
 MANAGER_ENABLE_TFTP="Y"
+{%- if grains.get('cc_username') %}
 SCC_USER="{{ grains.get("cc_username") }}"
 SCC_PASS="{{ grains.get("cc_password") }}"
+{% endif %}
 {%- if not grains.get('db_configuration')['local'] %}
 EXTERNALDB_ADMIN_USER="{{ grains.get('db_configuration')['superuser'] }}"
 EXTERNALDB_ADMIN_PASS="{{ grains.get('db_configuration')['superuser_password'] }}"

--- a/salt/server_containerized/uyuniadm.yaml
+++ b/salt/server_containerized/uyuniadm.yaml
@@ -4,9 +4,11 @@ reportdb:
   host: localhost
 cert:
   password: spacewalk
+{%- if grains.get('cc_username') %}
 scc:
   user: {{ grains.get("cc_username") }}
   password: {{ grains.get("cc_password") }}
+{% endif %}
 email: {{ grains.get("traceback_email") | default('galaxy-noise@suse.de', true) }}
 emailFrom: {{ grains.get("from_email") | default('galaxy-noise@suse.de', true) }}
 {%- if grains.get('container_repository') %}


### PR DESCRIPTION
## What does this PR change?

This PR removes the requirement for the SCC Credentials, allowing to set up an environment without them.

Fixes https://github.com/SUSE/spacewalk/issues/22501