### PR TITLE
Upgrade rhel 8 version ( 8.2 not available anymore)

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -231,7 +231,7 @@ data "aws_ami" "rhel9" {
 
 data "aws_ami" "rhel8" {
   most_recent = true
-  name_regex  = "^RHEL-8.2.0_HVM-"
+  name_regex  = "^RHEL-8.8.0_HVM-"
   owners      = ["309956199498"]
 
   filter {


### PR DESCRIPTION
## What does this PR change?

Bump RHEL version. RHEL-8.2 is not available anymore