### PR TITLE
Add unzip package to the controller

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -45,6 +45,7 @@ cucumber_requisites:
       - libxslt-devel
       - mozilla-nss-tools
       - postgresql-devel
+      - unzip
       # packaged ruby gems
       - ruby2.5-rubygem-bundler
       - twopence


### PR DESCRIPTION
For the container tests we need to move the redfish mock server to the controller. For this we need unzip to unpack the Redfish archive.
