### PR TITLE
container: install both uyuniadm and uyunictl packages

### DIFF
--- a/salt/server_containerized/install_common.sls
+++ b/salt/server_containerized/install_common.sls
@@ -2,7 +2,9 @@
 
 uyuni_tools:
   pkg.installed:
-    - name: uyuni-tools
+    - pkgs:
+      - uyuniadm
+      - uyunictl
     
 {% if mirror_hostname %}
 


### PR DESCRIPTION
## What does this PR change?

Now that uyuni-tools has been split in two distinct packages, we need to adapt the container server install to get both tools.

Required for PR https://github.com/uyuni-project/uyuni-tools/pull/61