### PR TITLE
Add public names output value to null backend

### DIFF
--- a/backend_modules/null/host/main.tf
+++ b/backend_modules/null/host/main.tf
@@ -24,8 +24,9 @@ resource "null_resource" "domain" {
 
 output "configuration" {
   value = {
-    ids       = ["1"]
-    hostnames = ["domain"]
-    macaddrs  = []
+    ids          = ["1"]
+    hostnames    = ["domain"]
+    macaddrs     = []
+    public_names = []
   }
 }


### PR DESCRIPTION
## What does this PR change?

In github action, we are using null backend for testing our main.tf. This backend doesn't support public names needed for AWS. 
In this PR, I'm adding a default publis_names variable ouput for null backend

## Github action error

```
╷
│ Error: Unsupported attribute
│ 
│   on main.tf line 717, in output "aws_mirrors_public_name":
│  717:   value = module.mirror.configuration.public_names
│     ├────────────────
│     │ module.mirror.configuration is object with 3 attributes
│ 
│ This object does not have an attribute named "public_names".
╵
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```
