### PR TITLE
Add SLE-HPC-Module to Salt Testenv 

### DIFF
--- a/salt/salt_testenv/init.sls
+++ b/salt/salt_testenv/init.sls
@@ -13,6 +13,17 @@ development_tools_repo_updates:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ repo_path }}/x86_64/update/
     - refresh: True
+
+# needed for libhttp_parser_2_7_1, dependency of libgit2
+sle_module_hpc_repo_pool:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-HPC/{{ repo_path }}/x86_64/product/
+    - refresh: True
+
+sle_module_hpc_repo_updates:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-HPC/{{ repo_path }}/x86_64/update/
+    - refresh: True
 {% endif %}
 
 {% if grains['osrelease_info'][1] >= 3 %}


### PR DESCRIPTION
## What does this PR change?
We need libhttp_parser_2_7_1, which is a dependency of libgit2. It's available in our SUMA Server channel, but that's only for a single SLE SP. Since it's also in the HPC Module, we can use that repo.
