### PR TITLE
Add 4.3-pr product version

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -28,6 +28,8 @@ Legal values for CI:
 `uyuni-pr` is a special product version used internally to test Pull Requests. Packages are under a subproject in systemsmanagement:Uyuni:Master:TEST and systemsmanagement:Uyuni:Master:PR.
 This is not meant to be used outside the Continous Integration system (CI).
 
+Similarly, `4.3-pr` is used for testing Pull Requests on Manager-4.3.
+
 Because packages are under different subprojects for each CI run and each Pull Request, repositories will be added later as additional repositories.
 
 Note: the version of Salt on minions is determined by this value, as Salt is obtained from SUSE Manager Tools repos.

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -6,6 +6,7 @@ variable "testsuite-branch" {
     "4.2-nightly"    = "Manager-4.2"
     "4.3-released"   = "Manager-4.3"
     "4.3-nightly"    = "Manager-4.3"
+    "4.3-pr"         = "Manager-4.3"
     "4.3-beta"       = "master"
     "head"           = "master"
     "uyuni-master"   = "master"

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -69,7 +69,7 @@ variable "host_settings" {
 
 // server
 variable "product_version" {
-  description = "One of: 4.0-nightly, 4.0-released, 4.1-nightly, 4.1-released, 4.2-nightly, 4.2-released, 4.3-nightly, 4.3-released, 4.3-beta, head, test, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.0-nightly, 4.0-released, 4.1-nightly, 4.1-released, 4.2-nightly, 4.2-released, 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, head, test, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -10,6 +10,7 @@ variable "images" {
     "4.2-build_image"= "sles15sp3o"
     "4.3-released"   = "sles15sp4o"
     "4.3-nightly"    = "sles15sp4o"
+    "4.3-pr"         = "sles15sp4o"
     "4.3-beta"       = "sles15sp4o"
     "4.3-build_image"= "sles15sp4o"
     "head"           = "sles15sp4o"

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.0-released, 4.0-nightly, 4.1-released, 4.1-nightly, 4.2-released, 4.2-nightly, 4.3-released, 4.3-nightly, 4.3-beta, head, test, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.0-released, 4.0-nightly, 4.1-released, 4.1-nightly, 4.2-released, 4.2-nightly, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, head, test, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -10,6 +10,7 @@ variable "images" {
     "4.2-build_image"= "sles15sp3o"
     "4.3-released"   = "sles15sp4o"
     "4.3-nightly"    = "sles15sp4o"
+    "4.3-pr"         = "sles15sp4o"
     "4.3-beta"       = "sles15sp4o"
     "4.3-build_image"= "sles15sp4o"
     "head"           = "sles15sp4o"

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.0-nightly, 4.0-released, 4.1-released, 4.1-nightly, 4.2-released, 4.2-nightly, 4.3-released, 4.3-nightly, 4.3-beta, head, test, uyuni-master, uyuni-released"
+  description = "One of: 4.0-nightly, 4.0-released, 4.1-released, 4.1-nightly, 4.2-released, 4.2-nightly, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, head, test, uyuni-master, uyuni-released"
   type        = string
 }
 

--- a/salt/repos/additional.sls
+++ b/salt/repos/additional.sls
@@ -4,7 +4,7 @@
   pkgrepo.managed:
     - humanname: {{ label }}_repo
   {%- if grains['os_family'] == 'Debian' %}
-  {%- if 'uyuni-pr' in grains.get('product_version', '') %}
+  {%- if 'uyuni-pr' in grains.get('product_version', '') or '4.3-pr' in grains.get('product_version', '') %}
     - name: deb [trusted=yes] {{ url }} /
     - file: /etc/apt/sources.list.d/sumaform_additional_repos.list
   {%- else %}

--- a/salt/repos/proxy43.sls
+++ b/salt/repos/proxy43.sls
@@ -54,7 +54,7 @@ containers_updates_repo:
 
 {% endif %}
 
-{% if '4.3-nightly' in grains['product_version'] %}
+{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] %}
 proxy_devel_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.3/images/repo/SLE-Module-SUSE-Manager-Proxy-4.3-POOL-x86_64-Media1/

--- a/salt/repos/proxyUyuni.sls
+++ b/salt/repos/proxyUyuni.sls
@@ -8,7 +8,7 @@ proxy_pool_repo:
     - priority: 97
 {% endif %}
 
-{% if 'uyuni-master' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') %}
+{% if 'uyuni-master' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') or '4.3-pr' in grains.get('product_version') %}
 proxy_devel_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/

--- a/salt/repos/server43.sls
+++ b/salt/repos/server43.sls
@@ -51,7 +51,7 @@ module_web_scripting_update_repo:
 
 {% endif %}
 
-{% if '4.3-nightly' in grains['product_version'] %}
+{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] %}
 
 server_devel_repo:
   pkgrepo.managed:

--- a/salt/server/postgres.sls
+++ b/salt/server/postgres.sls
@@ -23,7 +23,7 @@ postgresql_hba_configuration:
   file.append:
     - name: /var/lib/pgsql/data/pg_hba.conf
     - text: |
-{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-released', '4.3-beta'] %}
+{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-pr', '4.3-released', '4.3-beta'] %}
         host    all     all       0.0.0.0/0      scram-sha-256
         host    all     all       ::/0           scram-sha-256
 {%- else %}

--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -42,7 +42,7 @@ test_repo_debian_updates:
       {% endif %}
 
 # modify Cobbler to be executed from remote-machines..
-{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-released", "uyuni-pr", "head", "4.3-released", "4.3-nightly"] %}
+{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-released", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr"] %}
 {% set cobbler_use_settings_yaml = grains.get('product_version') | default('', true) in products_using_new_cobbler_version %}
 
 cobbler_configuration:
@@ -88,14 +88,14 @@ testsuite_salt_packages:
   pkg.installed:
     - pkgs:
       - salt-ssh
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'nightly' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'nightly' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') or '4.3-pr' in grains.get('product_version') %}
     - fromrepo: testing_overlay_devel_repo
 {% endif %}
     - require:
       - sls: repos
 {% endif %}
 
-{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.2-nightly", "4.2-released"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr", "4.2-nightly", "4.2-released"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,


### PR DESCRIPTION


## What does this PR change?

We need to run tests on PRs with 4.3. This is essentially a 4.3-nightly with the "Trusted=yes" for debian/ubuntu repos.
