### PR TITLE
Update the containerized server repo to get uyuni-tools from

### DIFF
--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -271,9 +271,9 @@ variable "connect_to_additional_network" {
 }
 
 variable "image" {
-  description = "An image name, e.g. sles12sp4 or opensuse154o"
+  description = "An image name, e.g. sles15sp5 or opensuse155o"
   type        = string
-  default     = "opensuse154o"
+  default     = "opensuse155o"
 }
 
 variable "provision" {

--- a/salt/repos/server_containerized.sls
+++ b/salt/repos/server_containerized.sls
@@ -1,9 +1,8 @@
 {% if 'server_containerized' in grains.get('roles')  %}
 
-systemsmanagement_Uyuni_Master_ServerContainer:
+systemsmanagement_Uyuni_Master_ContainerUtils:
     pkgrepo.managed:
-      # TODO change to the regular URL once available
-    - baseurl: http://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/ServerContainer/openSUSE_Leap_15.4/
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/openSUSE_Leap_15.5/
     - refresh: True
 
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

While at it bump the server container host default image to Leap 15.5.