### PR TITLE
install python-instance-billing-flavor-check on buildhost

### DIFF
--- a/salt/build_host/init.sls
+++ b/salt/build_host/init.sls
@@ -30,8 +30,17 @@ update_ca_truststore_registry_build_host:
     - onchanges:
       - file: certificate_authority_certificate
 
+{% elif '15' in grains['osrelease'] %}
+
 {# Do not run update-ca-certificates on SLE 15 because there is    #}
 {# already a systemd unit that watches for changes and runs it:    #}
 {#   /usr/lib/systemd/system/ca-certificates.path                  #}
 
+{% if "opensuse" not in grains['oscodename']|lower %}
+
+cloud_flavor_check:
+  pkg.installed:
+    - name: python-instance-billing-flavor-check
+
+{% endif %}
 {% endif %}

--- a/salt/repos/build_host.sls
+++ b/salt/repos/build_host.sls
@@ -29,6 +29,16 @@ containers_updates_repo:
 {% set sle_version_path = '15-SP5' %}
 {% endif %}
 
+cloud_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Public-Cloud/{{ sle_version_path }}/x86_64/product/
+    - refresh: True
+
+cloud_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Public-Cloud/{{ sle_version_path }}/x86_64/update/
+    - refresh: True
+
 containers_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/{{ sle_version_path }}/x86_64/product/


### PR DESCRIPTION
## What does this PR change?

When running the build hosts in the cloud this package is required.
In future the cloud images should contain it pre-installed.
But for now let's take care that it gets installed during setup
