### PR TITLE
z/VM guests

### DIFF
--- a/backend_modules/aws/README.md
+++ b/backend_modules/aws/README.md
@@ -17,7 +17,7 @@ This architecture is based on [AWS VPC with Public and Private Subnets](https://
 A mirror is necessary for SUSE Manager installations and for SLES clients (see README_ADVANCED.md).
 In Uyuni deployments with free OSs a mirror is not mandatory, but will still to speed up machine provisioning.
 
-AWS backend don't have support for pxe_boot hosts. It's implementation will be considered in future releases.
+AWS backend don't have support for pxe_boot hosts. Its implementation will be considered in future releases.
 
 ## Prerequisites
 

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -1,4 +1,3 @@
-
 locals {
   ami = lookup(lookup(var.base_configuration["ami_info"], var.image, {}), "ami", var.image)
 
@@ -233,7 +232,6 @@ resource "null_resource" "host_salt_configuration" {
   }
 
   provisioner "file" {
-
     content = yamlencode(merge(
       {
         hostname : local.hnames[count.index]
@@ -263,7 +261,7 @@ resource "null_resource" "host_salt_configuration" {
         ipv6                          = var.ipv6
         data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? local.data_disk_device : null
       },
-    var.grains))
+      var.grains))
     destination = "/tmp/grains"
   }
 

--- a/backend_modules/azure/host/main.tf
+++ b/backend_modules/azure/host/main.tf
@@ -171,7 +171,6 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
   }
 
   provisioner "file" {
-
     content = yamlencode(merge(
       {
         hostname : "${azurerm_linux_virtual_machine.instance[count.index].name}"
@@ -200,7 +199,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
         ipv6                          = var.ipv6
         data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "sdb" : null
       },
-    var.grains))
+      var.grains))
     destination = "/tmp/grains"
   }
 

--- a/backend_modules/feilong/README.md
+++ b/backend_modules/feilong/README.md
@@ -1,0 +1,75 @@
+# Feilong-specific configuration
+
+## Overview
+
+Base Module currrently does not create any resources, but is used to define shared variables.
+
+Host Module currently creates for each host:
+
+- a set of cloud-init parameters, that will be stored into a local file in `/tmp` directory; this file will then be uploaded by Feilong at VM deployment time
+- a z/VM guest virtual machine.
+
+
+## Prerequisites
+
+You will need:
+
+- a s/390 mainframe running z/VM inside one of its LPARs
+- a Feilong connector, running on a Linux system inside a z/VM guest in that LPAR
+- to have a pair of openSSH keys created for user `zvmsdk` on that Linux system
+- to grant the Feilong connector SSH access to your local workstation so it can download files
+
+The Feilong connector can either be deployed standalone, following these [instructions](https://cloudlib4zvm.readthedocs.io/en/latest/quickstart.html#installation), or be part of a larger [IBM Cloud Infrastructure Center](https://www.ibm.com/products/cloud-infrastructure-center) (CIC). 
+
+You can grant access to the Feilong connector to your local account by adding the public key of `zvmsdk` user into your `~/.ssh/autorized_keys` file.
+
+An usage example follows:
+
+```hcl-terraform
+...
+provider "feilong" {
+  connector = "feilong.example.org"
+  local_user = "johndoe@test.example.org"
+}
+...
+```
+
+
+## Select Feilong backend to be used
+
+If you want a pure s/390 deployment, create a symbolic link to the `feilong` backend module directory inside the `modules` directory: `ln -sfn ../backend_modules/feilong modules/backend`.
+
+If you rather want to mix it with e.g. the libvirt module, just call directly from your `main.tf` file the `base` and `host` backend modules.
+
+
+## Feilong backend specific variables
+
+Most modules have configuration settings specific to the Feilong backend, those are set via the `provider_settings` map variable. They are all described below.
+
+### Base Module
+
+| Variable name            | Type   | Default value   | Description                                                                                                             |
+|--------------------------|--------|-----------------|-------------------------------------------------------------------------------------------------------------------------|
+| key_file                 | string | `~/.ssh/id_rsa` | path to private SSH key file used for provisioning                                                                      |
+
+### Host Module
+
+| Variable name            | Type   | Default value   | Description                                                                                                             |
+|--------------------------|--------|-----------------|-------------------------------------------------------------------------------------------------------------------------|
+| userid                   | string | `null`          | system name for z/VM (8 characters maximum, all caps)                                                                   |
+| memory                   | string | `2G`            | amount of VM "storage", as an integer followed by an unit: B, K, M, G                                                   |
+| vcpu                     | number | `1`             | number of virtual CPUs assigned to the VM                                                                               |
+| mac                      | string | `null`          | MAC address as 6 hexadecimal digits separed by colons; beware the first 3 bytes might be replaced by Feilong's default  |
+| ssh_user                 | string | `root`          | system user to connect to via SSH for provisioning                                                                      |
+
+An example follows:
+
+```hcl-terraform
+...
+provider_settings = {
+  userid   = "S15SP3"
+  mac      = "02:3a:fc:44:55:66"
+  ssh_user = "sles"
+}
+...
+```

--- a/backend_modules/feilong/base/main.tf
+++ b/backend_modules/feilong/base/main.tf
@@ -1,0 +1,15 @@
+locals {
+  name_prefix  = var.name_prefix
+  domain       = var.domain
+  ssh_key_path = var.ssh_key_path
+  key_file     = lookup(var.provider_settings, "key_file", "~/.ssh/id_rsa")
+}
+
+output "configuration" {
+  value = {
+    name_prefix  = local.name_prefix
+    domain       = local.domain
+    ssh_key_path = local.ssh_key_path
+    key_file     = local.key_file
+  }
+}

--- a/backend_modules/feilong/base/variables.tf
+++ b/backend_modules/feilong/base/variables.tf
@@ -1,0 +1,1 @@
+../../null/base/variables.tf

--- a/backend_modules/feilong/base/versions.tf
+++ b/backend_modules/feilong/base/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    feilong = {
+      source = "bischoff/feilong"
+      version = "0.0.2"
+    }
+  }
+}

--- a/backend_modules/feilong/host/main.tf
+++ b/backend_modules/feilong/host/main.tf
@@ -1,0 +1,110 @@
+locals {
+  name_prefix       = var.base_configuration["name_prefix"]
+  domain            = var.base_configuration["domain"]
+  ssh_key_path      = var.base_configuration["ssh_key_path"]
+  provider_settings = merge({
+    userid   = null
+    memory   = "2G"
+    vcpu     = 1
+    mac      = null
+    ssh_user = "root"
+    key_file = var.base_configuration["key_file"]
+    },
+    var.provider_settings)
+}
+
+resource "feilong_cloudinit_params" "s390_params" {
+  name       = "${local.name_prefix}${var.name}"
+
+  hostname   = "${local.name_prefix}${var.name}.${local.domain}"
+  public_key = trimspace(file(local.ssh_key_path))
+}
+
+resource "feilong_guest" "s390_guest" {
+  depends_on = [ feilong_cloudinit_params.s390_params ]
+
+  name       = "${local.name_prefix}${var.name}"
+
+  memory     = local.provider_settings["memory"]
+  disk       = "20G"
+  vcpus      = local.provider_settings["vcpu"]
+  image      = var.image
+  userid     = local.provider_settings["userid"]
+  mac        = local.provider_settings["mac"]
+
+  cloudinit_params = feilong_cloudinit_params.s390_params.file
+}
+
+resource "null_resource" "provisioning" {
+  depends_on = [ feilong_guest.s390_guest ]
+
+  triggers = {
+  }
+
+  connection {
+    host        = feilong_guest.s390_guest.ip_address
+    private_key = file(local.provider_settings["key_file"])
+    user        = local.provider_settings["ssh_user"]
+  }
+
+  provisioner "file" {
+    source      = "salt"
+    destination = "/tmp"
+  }
+
+  provisioner "file" {
+    content = yamlencode(
+      {
+        hostname                      = "${local.name_prefix}${var.name}"
+        domain                        = local.domain
+        use_avahi                     = false
+        provider                      = "feilong"
+        roles                         = var.roles
+        use_os_released_updates       = var.use_os_released_updates
+        additional_repos              = var.additional_repos
+        additional_repos_only         = var.additional_repos_only
+        additional_certs              = var.additional_certs
+        additional_packages           = var.additional_packages
+        install_salt_bundle           = var.install_salt_bundle
+        swap_file_size                = var.swap_file_size
+        authorized_keys               = concat(
+          local.ssh_key_path != null ? [ trimspace(file(local.ssh_key_path)) ] : [],
+          var.ssh_key_path != null   ? [ trimspace(file(var.ssh_key_path)) ] : [],
+        )
+        gpg_keys                      = var.gpg_keys
+        connect_to_base_network       = true
+        connect_to_additional_network = false
+        ipv6                          = var.ipv6
+
+        // These should be defined in a "sumaform module", but we cannot use sumaform modules,
+        // because "backend" symbolic link probably points to a different backend module :-(
+        timezone                      = "Europe/Berlin"
+        use_ntp                       = true
+    })
+    destination = "/tmp/grains"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo bash /tmp/salt/wait_for_salt.sh",
+    ]
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo rm -rf /root/salt",
+      "sudo mv /tmp/salt /root",
+      "sudo bash /root/salt/first_deployment_highstate.sh"
+    ]
+  }
+}
+
+output "configuration" {
+  depends_on  = [ feilong_guest.s390_guest, null_resource.provisioning ]
+  value = {
+    ids       = [ feilong_guest.s390_guest.userid               ]
+    hostnames = [ feilong_cloudinit_params.s390_params.hostname ]
+    macaddrs  = [ feilong_guest.s390_guest.mac_address          ]
+    ipaddrs  =  [ feilong_guest.s390_guest.ip_address           ]
+  }
+}

--- a/backend_modules/feilong/host/variables.tf
+++ b/backend_modules/feilong/host/variables.tf
@@ -1,0 +1,1 @@
+../../null/host/variables.tf

--- a/backend_modules/feilong/host/versions.tf
+++ b/backend_modules/feilong/host/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "1.0.10"
+  required_providers {
+    feilong = {
+      source = "bischoff/feilong"
+      version = "0.0.2"
+    }
+  }
+}

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -239,7 +239,7 @@ resource "null_resource" "provisioning" {
         data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdb" : null
         provider                      = "libvirt"
       },
-    var.grains))
+      var.grains))
     destination = "/tmp/grains"
   }
 

--- a/backend_modules/ssh/host/main.tf
+++ b/backend_modules/ssh/host/main.tf
@@ -102,7 +102,7 @@ resource "null_resource" "provisioning" {
         ipv6                          = var.ipv6
         data_disk_device              = contains(var.roles, "suse_manager_server") || contains(var.roles, "suse_manager_proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdb" : null
       },
-    var.grains))
+      var.grains))
     destination = "/tmp/grains"
   }
 

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -143,6 +143,8 @@ module "controller" {
     opensuse154arm_sshminion = length(var.opensuse154arm_sshminion_configuration["hostnames"]) > 0 ? var.opensuse154arm_sshminion_configuration["hostnames"][0] : null
     opensuse155arm_minion    = length(var.opensuse155arm_minion_configuration["hostnames"]) > 0 ? var.opensuse155arm_minion_configuration["hostnames"][0] : null
     opensuse155arm_sshminion = length(var.opensuse155arm_sshminion_configuration["hostnames"]) > 0 ? var.opensuse155arm_sshminion_configuration["hostnames"][0] : null
+    sle15sp3s390_minion    = length(var.sle15sp3s390_minion_configuration["hostnames"]) > 0 ? var.sle15sp3s390_minion_configuration["hostnames"][0] : null
+    sle15sp3s390_sshminion = length(var.sle15sp3s390_sshminion_configuration["hostnames"]) > 0 ? var.sle15sp3s390_sshminion_configuration["hostnames"][0] : null
   }
 
 

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -656,6 +656,20 @@ variable "opensuse155arm_sshminion_configuration" {
   }
 }
 
+variable "sle15sp3s390_minion_configuration" {
+  description = "use module.<SLE15SP3S390_MINION>.configuration"
+  default = {
+    hostnames = []
+  }
+}
+
+variable "sle15sp3s390_sshminion_configuration" {
+  description = "use module.<SLE15SP3S390_SSHMINION>.configuration"
+  default = {
+    hostnames = []
+  }
+}
+
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
   default     = {}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -23,7 +23,7 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 {% if grains.get('additional_network') | default(false, true) %}export PRIVATENET="{{ grains.get('additional_network') }}" {% else %}# no private network defined {% endif %}
 {% if grains.get('mirror') | default(false, true) %}export MIRROR="yes" {% else %}# no mirror used {% endif %}
 
-# QAM clients
+# BV clients
 {% if grains.get('sle12_paygo_minion') | default(false, true) %}export SLE12_PAYGO_MINION="{{ grains.get('sle12_paygo_minion') }}" {% else %}# no SLE12_PAYGO minion defined {% endif %}
 {% if grains.get('sle15_paygo_minion') | default(false, true) %}export SLE15_PAYGO_MINION="{{ grains.get('sle15_paygo_minion') }}" {% else %}# no SLE15_PAYGO minion defined {% endif %}
 {% if grains.get('sleforsap15_paygo_minion') | default(false, true) %}export SLEFORSAP15_PAYGO_MINION="{{ grains.get('sleforsap15_paygo_minion') }}" {% else %}# no SLEFORSAP15_PAYGO minion defined {% endif %}
@@ -101,6 +101,8 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 {% if grains.get('opensuse154arm_sshminion') | default(false, true) %}export OPENSUSE154ARM_SSHMINION="{{ grains.get('opensuse154arm_sshminion') }}" {% else %}# no OPENSUSE154ARM ssh minion defined {% endif %}
 {% if grains.get('opensuse155arm_minion') | default(false, true) %}export OPENSUSE155ARM_MINION="{{ grains.get('opensuse155arm_minion') }}" {% else %}# no OPENSUSE155ARM minion defined {% endif %}
 {% if grains.get('opensuse155arm_sshminion') | default(false, true) %}export OPENSUSE155ARM_SSHMINION="{{ grains.get('opensuse155arm_sshminion') }}" {% else %}# no OPENSUSE155ARM ssh minion defined {% endif %}
+{% if grains.get('sle15sp3s390_minion') | default(false, true) %}export SLE15SP3S390_MINION="{{ grains.get('sle15sp3s390_minion') }}" {% else %}# no SLE15SP3S390 minion defined {% endif %}
+{% if grains.get('sle15sp3s390_sshminion') | default(false, true) %}export SLE15SP3S390_SSHMINION="{{ grains.get('sle15sp3s390_sshminion') }}" {% else %}# no SLE15SP3S390 ssh minion defined {% endif %}
 
 # various test suite settings
 export GITPROFILES="{{ grains.get('git_profiles_repo') }}"

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -251,18 +251,18 @@ tools_additional_repo:
 tools_pool_repo:
   pkgrepo.managed:
     {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15-BETA/x86_64/product/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15-BETA/{{ grains.get("cpuarch") }}/product/
     {% else %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15/{{ grains.get("cpuarch") }}/product/
     {% endif %}
     - refresh: True
 
 tools_update_repo:
   pkgrepo.managed:
     {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15-BETA/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15-BETA/{{ grains.get("cpuarch") }}/update/
     {% else %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15/{{ grains.get("cpuarch") }}/update/
     {% endif %}
     - refresh: True
 {% else %}
@@ -379,17 +379,17 @@ os_ltss_repo:
 
 os_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP3/x86_64/product/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP3/{{ grains.get("cpuarch") }}/product/
     - refresh: True
 
 os_update_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP3/{{ grains.get("cpuarch") }}/update/
     - refresh: True
 
 os_ltss_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/{{ grains.get("cpuarch") }}/update/
 
 {% endif %} {# '15.3' == grains['osrelease'] #}
 


### PR DESCRIPTION
## What does this PR change?

This PR adds a sumaform backend module for the Feilong connector (z/VM support).

Example usage:
```
module "base_s390" {
  source = "./sumaform/backend_modules/feilong/base"

  name_prefix        = "eric-"
  domain             = "example.org"
  
  testsuite          = true
}

module "sles15sp3s390-minion" {
  source             = "./sumaform/backend_modules/feilong/host"
  base_configuration = module.base_s390.configuration

  name               = "min-s390"
  image              = "s15s3-jeos-1part-ext4"

  provider_settings = {
    userid             = "S15SP3"
    mac                = "11:22:33:44:55:66"
    ssh_user           = "sles"
  }

  use_os_released_updates = false
  ssh_key_path            = "./salt/controller/id_rsa.pub"
}
```