### PR TITLE
Add os_pool_repo to build host, needed for python3-lxml

### DIFF
--- a/salt/repos/build_host.sls
+++ b/salt/repos/build_host.sls
@@ -71,6 +71,11 @@ desktop_updates_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
     - refresh: True
 
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/{{ sle_version_path }}/x86_64/product/
+    - refresh: True
+
 {% endif %}
 
 


### PR DESCRIPTION
## What does this PR change?

Add `os_pool_repo` to build host, needed for `python3-lxml`, which is now a requirement of `python3-kiwi`
