### PR TITLE
For the moment we don't support Leap build hosts

### DIFF
--- a/salt/build_host/init.sls
+++ b/salt/build_host/init.sls
@@ -7,13 +7,6 @@ certificate_authority_certificate:
     - source: salt://build_host/certs/ca.cert.pem
     - makedirs: True
 
-{% if '4.2' not in grains.get('product_version') %}
-kiwi_imager_server_dependency:
-  pkg.installed:
-    - pkgs:
-      - python3-kiwi
-{% endif %}
-
 {% if '11' in grains['osrelease'] %}
 
 update_ca_truststore_registry_build_host:

--- a/salt/repos/build_host.sls
+++ b/salt/repos/build_host.sls
@@ -71,11 +71,6 @@ desktop_updates_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
     - refresh: True
 
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/{{ sle_version_path }}/x86_64/product/
-    - refresh: True
-
 {% endif %}
 
 


### PR DESCRIPTION
## What does this PR change?

This PR reverts preceding PR, and removes the cause why it was needed.

Here's the full story:
 * at some point we tried to use Leap for the build host too
 * but since we killed the reposync for Leap, Dominik needed to preinstall the dependencies for Kiwi at sumaform time
 * this in turn needed I enabled a repository to have a missing dependency of those dependencies

Since we are not yet able to build OS images on Leap, we better remove all of that for now.
