### PR TITLE
os_pool_repo is needed anyway on build host

### DIFF
--- a/salt/repos/build_host.sls
+++ b/salt/repos/build_host.sls
@@ -71,6 +71,11 @@ desktop_updates_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
     - refresh: True
 
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/{{ sle_version_path }}/x86_64/product/
+    - refresh: True
+
 {% endif %}
 
 


### PR DESCRIPTION
## What does this PR change?

`os_pool_repo` is needed this time as a dependency of `python-instance-billing-flavor-check`.

Original explanations from Michael:
```
When running the build hosts in the cloud this package is required.
In future the cloud images should contain it pre-installed.
But for now let's take care that it gets installed during setup
```