### PR TITLE
fix enabling of repos

### DIFF
--- a/salt/repos/build_host.sls
+++ b/salt/repos/build_host.sls
@@ -71,11 +71,6 @@ desktop_updates_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Desktop-Applications/{{ sle_version_path }}/x86_64/update/
     - refresh: True
 
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/{{ sle_version_path }}/x86_64/product/
-    - refresh: True
-
 {% endif %}
 
 

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -340,7 +340,7 @@ os_ltss_repo:
 
 {% endif %} {# '15' == grains['osrelease'] #}
 
-{% if '15.1' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' not in grains.get('product_version') | default('', true)) %}
+{% if '15.1' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true)) %}
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/
@@ -358,7 +358,7 @@ os_ltss_repo:
 
 {% endif %} {# '15.1' == grains['osrelease'] #}
 
-{% if '15.2' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' not in grains.get('product_version') | default('', true)) %}
+{% if '15.2' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true)) %}
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
@@ -375,7 +375,7 @@ os_ltss_repo:
 
 {% endif %} {# '15.2' == grains['osrelease'] #}
 
-{% if '15.3' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' not in grains.get('product_version') | default('', true)) %}
+{% if '15.3' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true)) %}
 
 os_pool_repo:
   pkgrepo.managed:
@@ -393,7 +393,7 @@ os_ltss_repo:
 
 {% endif %} {# '15.3' == grains['osrelease'] #}
 
-{% if '15.4' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' not in grains.get('product_version') | default('', true) ) %}
+{% if '15.4' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true) ) %}
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP4/x86_64/product/
@@ -412,7 +412,7 @@ os_update_repo:
 
 {% endif %} {# '15.4' == grains['osrelease'] #}
 
-{% if '15.5' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' not in grains.get('product_version') | default('', true) ) %}
+{% if '15.5' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true) ) %}
 os_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP5/x86_64/product/


### PR DESCRIPTION
## What does this PR change?

Here in repos we need to check different as the negate is happening for all the grains check

`not (grains.get("...") or grains.get("...") or 'payg' in grains.get("...") | default('', true))`

This makes also the fix from @Bischoff obsolete (I had to revert it as it creates now a duplicate ID)
