### PR TITLE
Allow SUMA4.3 VM image

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -18,7 +18,7 @@ Legal values for work-in-progress software are:
 
 - `4.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.2)
 - `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
-- `4.3-VM`       (corresponds to the Virtual Image in the Build Service project Devel:Galaxy:Manager:4.3)
+- `4.3-VM-nightly`       (corresponds to the Virtual Image in the Build Service project Devel:Galaxy:Manager:4.3)
 - `4.3-beta`    (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
 - `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, for `server` and `proxy`only works with SLE15SP4 image)
 - `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap image)

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -11,12 +11,14 @@ Legal values for released software are:
 
 - `4.2-released`   (latest released Maintenance Update for SUSE Manager 4.2 and Tools)
 - `4.3-released`   (latest released Maintenance Update for SUSE Manager 4.3 and Tools)
+- `4.3-VM-released` (latest released Maintenance Update for SUSE Manager 4.3Virtual Machine)
 - `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
 
 Legal values for work-in-progress software are:
 
 - `4.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.2)
 - `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
+- `4.3-VM`       (corresponds to the Virtual Image in the Build Service project Devel:Galaxy:Manager:4.3)
 - `4.3-beta`    (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
 - `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, for `server` and `proxy`only works with SLE15SP4 image)
 - `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap image)

--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -148,6 +148,23 @@ virsh console suma32pg
 
 especially in the case the network is not working and you need to debug it, or if the images have difficulties booting.
 
+### Accessing VMs through bastion host
+
+When deployed VMs are behind NAT and not directly accessible from the machine terraform is running on, it is required for libvirt connection provider to specify a jump host. To do this add
+bastion configuration options to the libvirt `provider_settings`:
+
+```hcl-terraform
+
+provider_settings = {
+    bastion_host        = <jump-host-fqdn>
+    bastion_host_key    = <validation-of-jump-host>
+    bastion_port        = <jump-host-port>
+    bastion_user        = <jump-host-user>
+    bastion_password    = <jump-host-password>
+    bastion_private_key = <jump-host-user-authentication>
+}
+```
+
 ## Only upload a subset of available images
 
 By default all known base OS images are uploaded to the libvirt host (currently several versions of SLES and CentOS). It is possible to limit the OS selection in order to avoid wasting space and bandwidth, if the needed OSs are known a priori.

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -46,6 +46,7 @@ locals {
     slemicro53-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_53/SLE-Micro.x86_64-sumaform.qcow2"
     slemicro54-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_54/SLE-Micro.x86_64-sumaform.qcow2"
     slemicro55o              = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_55/SLE-Micro.x86_64-sumaform.qcow2"
+    suma43VM-ign             = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.suse.de"}/ibs/home:/oholecek:/SUMA-VM/images/SUSE-Manager-Server.x86_64-KVM.qcow2"
   }
   pool               = lookup(var.provider_settings, "pool", "default")
   network_name       = lookup(var.provider_settings, "network_name", "default")

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -46,7 +46,7 @@ locals {
     slemicro53-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_53/SLE-Micro.x86_64-sumaform.qcow2"
     slemicro54-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_54/SLE-Micro.x86_64-sumaform.qcow2"
     slemicro55o              = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_55/SLE-Micro.x86_64-sumaform.qcow2"
-    suma43VM-ign             = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.suse.de"}/ibs/home:/oholecek:/SUMA-VM/images/SUSE-Manager-Server.x86_64-KVM.qcow2"
+    suma43VM-ign             = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Manager:/4.3/images/SUSE-Manager-Server.x86_64-KVM.qcow2"
   }
   pool               = lookup(var.provider_settings, "pool", "default")
   network_name       = lookup(var.provider_settings, "network_name", "default")

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -84,5 +84,12 @@ output "configuration" {
     pool         = local.pool
     network_name = local.bridge == null ? local.network_name : null
     bridge       = local.bridge
+    bastion_host        = lookup(var.provider_settings, "bastion_host", null)
+    bastion_host_key    = lookup(var.provider_settings, "bastion_host_key", null)
+    bastion_port        = lookup(var.provider_settings, "bastion_port", null)
+    bastion_user        = lookup(var.provider_settings, "bastion_user", null)
+    bastion_password    = lookup(var.provider_settings, "bastion_password", null)
+    bastion_private_key = lookup(var.provider_settings, "bastion_private_key", null)
+    bastion_certificate = lookup(var.provider_settings, "bastion_certificate", null)
   }
 }

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -227,6 +227,14 @@ resource "null_resource" "provisioning" {
     host     = libvirt_domain.domain[count.index].network_interface[0].addresses[0]
     user     = "root"
     password = "linux"
+    // ssh connection through a bastion host
+    bastion_host        = lookup(var.provider_settings, "bastion_host", var.base_configuration["bastion_host"])
+    bastion_host_key    = lookup(var.provider_settings, "bastion_host_key", var.base_configuration["bastion_host_key"])
+    bastion_port        = lookup(var.provider_settings, "bastion_port", var.base_configuration["bastion_port"])
+    bastion_user        = lookup(var.provider_settings, "bastion_user", var.base_configuration["bastion_user"])
+    bastion_password    = lookup(var.provider_settings, "bastion_password", var.base_configuration["bastion_password"])
+    bastion_private_key = lookup(var.provider_settings, "bastion_private_key", var.base_configuration["bastion_private_key"])
+    bastion_certificate = lookup(var.provider_settings, "bastion_certificate", var.base_configuration["bastion_certificate"])
   }
 
   provisioner "file" {

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -20,7 +20,7 @@ module "cucumber_testsuite" {
   # for more information on product_version values
   # you should use the same version here as in git_repo below
   # if you work on Uyuni you should use e.g. uyuni-master here and uyuni as git_repo below
-  # if you work on SUMA you should use e.g. 4.3-nightly, 4.3-released, 4.3-VM, 4.3-VM-released, or head and spacewalk as git_repo below
+  # if you work on SUMA you should use e.g. 4.3-nightly, 4.3-released, 4.3-VM-nightly, 4.3-VM-released, or head and spacewalk as git_repo below
   product_version = "uyuni-master"
 
   # SUSE SCC credentials

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -20,7 +20,7 @@ module "cucumber_testsuite" {
   # for more information on product_version values
   # you should use the same version here as in git_repo below
   # if you work on Uyuni you should use e.g. uyuni-master here and uyuni as git_repo below
-  # if you work on SUMA you should use e.g. 4.3-nightly, 4.3-released or head and spacewalk as git_repo below
+  # if you work on SUMA you should use e.g. 4.3-nightly, 4.3-released, 4.3-VM, 4.3-VM-released, or head and spacewalk as git_repo below
   product_version = "uyuni-master"
 
   # SUSE SCC credentials

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -6,7 +6,7 @@ variable "testsuite-branch" {
     "4.3-nightly"    = "Manager-4.3"
     "4.3-pr"         = "Manager-4.3"
     "4.3-VM-released"= "Manager-4.3"
-    "4.3-VM"         = "Manager-4.3"
+    "4.3-VM-nightly"         = "Manager-4.3"
     "4.3-beta"       = "master"
     "head"           = "master"
     "uyuni-master"   = "master"

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -5,6 +5,8 @@ variable "testsuite-branch" {
     "4.3-released"   = "Manager-4.3"
     "4.3-nightly"    = "Manager-4.3"
     "4.3-pr"         = "Manager-4.3"
+    "4.3-VM-released"= "Manager-4.3"
+    "4.3-VM"         = "Manager-4.3"
     "4.3-beta"       = "master"
     "head"           = "master"
     "uyuni-master"   = "master"

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -91,16 +91,15 @@ module "server" {
   additional_repos               = lookup(local.additional_repos, "server", {})
   additional_repos_only          = lookup(local.additional_repos_only, "server", false)
   additional_packages            = lookup(local.additional_packages, "server", [])
-  repository_disk_use_cloud_setup= lookup(local.repository_disk_use_cloud_setup, "server", false)
-  repository_disk_size           = lookup(local.repository_disk_size, "server", null)
   login_timeout                  = var.login_timeout
 
-  saltapi_tcpdump               = var.saltapi_tcpdump
-  provider_settings             = lookup(local.provider_settings_by_host, "server", {})
-  server_mounted_mirror         = lookup(local.server_mounted_mirror, "server", {})
-  repository_disk_size          = lookup(local.repository_disk_size, "server", {})
-  database_disk_size            = lookup(local.database_disk_size, "server", {})
-  large_deployment              = lookup(local.large_deployment, "server", false)
+  saltapi_tcpdump                 = var.saltapi_tcpdump
+  provider_settings               = lookup(local.provider_settings_by_host, "server", {})
+  server_mounted_mirror           = lookup(local.server_mounted_mirror, "server", {})
+  repository_disk_size            = lookup(local.repository_disk_size, "server", {})
+  database_disk_size              = lookup(local.database_disk_size, "server", {})
+  large_deployment                = lookup(local.large_deployment, "server", false)
+  repository_disk_use_cloud_setup = lookup(local.repository_disk_use_cloud_setup, "server", false)
 }
 
 module "server_containerized" {

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -56,6 +56,8 @@ locals {
     host_key => lookup(var.host_settings[host_key], "auto_configure", false) if var.host_settings[host_key] != null }
   create_first_user       = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "create_first_user", false) if var.host_settings[host_key] != null }
+  repository_disk_use_cloud_setup = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "repository_disk_use_cloud_setup", null) if var.host_settings[host_key] != null }
 }
 
 module "server" {
@@ -89,6 +91,8 @@ module "server" {
   additional_repos               = lookup(local.additional_repos, "server", {})
   additional_repos_only          = lookup(local.additional_repos_only, "server", false)
   additional_packages            = lookup(local.additional_packages, "server", [])
+  repository_disk_use_cloud_setup= lookup(local.repository_disk_use_cloud_setup, "server", false)
+  repository_disk_size           = lookup(local.repository_disk_size, "server", null)
   login_timeout                  = var.login_timeout
 
   saltapi_tcpdump               = var.saltapi_tcpdump

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -79,7 +79,7 @@ variable "host_settings" {
 
 // server
 variable "product_version" {
-  description = "One of: 4.2-nightly, 4.2-released, 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, 4.3-VM, 4.3-VM-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.2-nightly, 4.2-released, 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, 4.3-VM-nightly, 4.3-VM-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -79,7 +79,7 @@ variable "host_settings" {
 
 // server
 variable "product_version" {
-  description = "One of: 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, 4.3-VM, 4.3-VM-released, head, test, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.2-nightly, 4.2-released, 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, 4.3-VM, 4.3-VM-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -38,7 +38,7 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos7o", "opensuse155o", "rocky8o", "rocky9o", "sles12sp4o", "sles12sp5o", "sles15sp3o", "sles15sp4o", "ubuntu2004o", "ubuntu2204o"]
+  default     = ["centos7o", "opensuse155o", "rocky8o", "rocky9o", "sles12sp4o", "sles12sp5o", "sles15sp3o", "sles15sp4o", "ubuntu2004o", "ubuntu2204o", "suma43VM-ign"]
 }
 
 variable "repository_disk_size" {
@@ -79,7 +79,7 @@ variable "host_settings" {
 
 // server
 variable "product_version" {
-  description = "One of: 4.2-nightly, 4.2-released, 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, 4.3-VM, 4.3-VM-released, head, test, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -8,7 +8,7 @@ variable "images" {
     "4.3-pr"         = "sles15sp4o"
     "4.3-beta"       = "sles15sp4o"
     "4.3-build_image"= "sles15sp4o"
-    "4.3-VM"         = "sles15sp4o"
+    "4.3-VM-nightly"         = "sles15sp4o"
     "4.3-VM-released"= "sles15sp4o"
     "head"           = "sles15sp4o"
     "uyuni-master"   = "opensuse155o"

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -8,6 +8,8 @@ variable "images" {
     "4.3-pr"         = "sles15sp4o"
     "4.3-beta"       = "sles15sp4o"
     "4.3-build_image"= "sles15sp4o"
+    "4.3-VM"         = "sles15sp4o"
+    "4.3-VM-released"= "sles15sp4o"
     "head"           = "sles15sp4o"
     "uyuni-master"   = "opensuse155o"
     "uyuni-released" = "opensuse155o"

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.2-released, 4.2-nightly, 4.2-build_image, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.2-released, 4.2-nightly, 4.2-build_image, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM, 4.3-VM-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.2-released, 4.2-nightly, 4.2-build_image, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM, 4.3-VM-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.2-released, 4.2-nightly, 4.2-build_image, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -9,7 +9,7 @@ variable "images" {
     "4.3-beta"       = "sles15sp4o"
     "4.3-build_image"= "sles15sp4o"
     "4.3-paygo"      = "suma-server-43-paygo"
-    "4.3-VM"         = "suma43VM-ign"
+    "4.3-VM-nightly"         = "suma43VM-ign"
     "4.3-VM-released"= "suma43VM-ign"
     "head"           = "sles15sp4o"
     "uyuni-master"   = "opensuse155o"

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -9,6 +9,8 @@ variable "images" {
     "4.3-beta"       = "sles15sp4o"
     "4.3-build_image"= "sles15sp4o"
     "4.3-paygo"      = "suma-server-43-paygo"
+    "4.3-VM"         = "suma43VM-ign"
+    "4.3-VM-released"= "suma43VM-ign"
     "head"           = "sles15sp4o"
     "uyuni-master"   = "opensuse155o"
     "uyuni-released" = "opensuse155o"

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -79,6 +79,7 @@ module "server" {
     main_disk_size                 = var.main_disk_size
     repository_disk_size           = var.repository_disk_size
     database_disk_size             = var.database_disk_size
+    repository_disk_use_cloud_setup= var.repository_disk_use_cloud_setup
     forward_registration           = var.forward_registration
     server_registration_code       = var.server_registration_code
     accept_all_ssl_protocols       = var.accept_all_ssl_protocols

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.2-released, 4.2-nightly, 4.2-build_image, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-paygo, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.2-released, 4.2-nightly, 4.2-build_image, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-paygo, 4.3-VM, 4.3-VM-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -250,6 +250,11 @@ variable "database_disk_size" {
   default     = 0
 }
 
+variable "repository_disk_use_cloud_setup" {
+  description = "Use cloud tool suma-storage to setup additional disk for repository and database data"
+  default = false
+}
+
 variable "saltapi_tcpdump" {
   description = "If set to true, all network operations of salt-api are logged to /tmp/ with tcpdump."
   default     = false

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.2-released, 4.2-nightly, 4.2-build_image, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-paygo, 4.3-VM, 4.3-VM-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.2-released, 4.2-nightly, 4.2-build_image, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-paygo, 4.3-VM-nightly, 4.3-VM-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -65,6 +65,8 @@ avahi_pkg:
       {% endif %}
       {% endif %}
 {% endif %}
+    - requires:
+      - pkgrepo: os_pool_repo
 
 # WORKAROUND: watch does not really work with Salt 2016.11
 avahi_dead_before_config:

--- a/salt/default/minimal.sls
+++ b/salt/default/minimal.sls
@@ -4,12 +4,12 @@ include:
   {% endif %}
   - default.network
   - default.firewall
-  - default.avahi
   {% if 'build_image' not in grains.get('product_version', '') and 'paygo' not in grains.get('product_version', '') %}
   - repos
   {% else %}
   - repos.testsuite
   {% endif %}
+  - default.avahi
   - default.time
 
 minimal_package_update:

--- a/salt/default/testsuite.sls
+++ b/salt/default/testsuite.sls
@@ -13,6 +13,7 @@ default_cucumber_requisites:
       - andromeda-dummy
       - milkyway-dummy
       - virgo-dummy
+      - iptables
     - require:
       - sls: repos.testsuite
 

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -742,6 +742,8 @@ tools_update_repo:
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% elif '4.3-released' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
+{% elif '4.3-VM-released' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("downloadcontent.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu' + short_release + '-Uyuni-Client-Tools/xUbuntu_' + release %}
 {% else %}
@@ -770,6 +772,11 @@ tools_update_repo_raised_priority:
             Pin: release l=SUSE:Updates:Ubuntu:{{ release }}-CLIENT-TOOLS:x86_64:update
             Pin-Priority: 800
 {% elif '4.3-released' in grains.get('product_version') | default('', true) %}
+    - contents: |
+            Package: *
+            Pin: release l=SUSE:Updates:Ubuntu:{{ release }}-CLIENT-TOOLS:x86_64:update
+            Pin-Priority: 800
+{% elif '4.3-VM-released' in grains.get('product_version') | default('', true) %}
     - contents: |
             Package: *
             Pin: release l=SUSE:Updates:Ubuntu:{{ release }}-CLIENT-TOOLS:x86_64:update

--- a/salt/repos/proxy43.sls
+++ b/salt/repos/proxy43.sls
@@ -54,7 +54,7 @@ containers_updates_repo:
 
 {% endif %}
 
-{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] %}
+{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] or '4.3-VM' in grains['product_version'] %}
 proxy_devel_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.3/images/repo/SLE-Module-SUSE-Manager-Proxy-4.3-POOL-x86_64-Media1/

--- a/salt/repos/proxy43.sls
+++ b/salt/repos/proxy43.sls
@@ -54,7 +54,7 @@ containers_updates_repo:
 
 {% endif %}
 
-{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] or '4.3-VM' in grains['product_version'] %}
+{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] or '4.3-VM-nightly' in grains['product_version'] %}
 proxy_devel_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.3/images/repo/SLE-Module-SUSE-Manager-Proxy-4.3-POOL-x86_64-Media1/

--- a/salt/repos/server43.sls
+++ b/salt/repos/server43.sls
@@ -51,7 +51,7 @@ module_web_scripting_update_repo:
 
 {% endif %}
 
-{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] or '4.3-VM' in grains['product_version'] %}
+{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] or '4.3-VM-nightly' in grains['product_version'] %}
 
 server_devel_repo:
   pkgrepo.managed:

--- a/salt/repos/server43.sls
+++ b/salt/repos/server43.sls
@@ -51,7 +51,7 @@ module_web_scripting_update_repo:
 
 {% endif %}
 
-{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] %}
+{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] or '4.3-VM' in grains['product_version'] %}
 
 server_devel_repo:
   pkgrepo.managed:

--- a/salt/server/additional_disk.sls
+++ b/salt/server/additional_disk.sls
@@ -12,7 +12,11 @@ susemanager-cloud-setup-server:
 
 spacewalk_directory:
   cmd.run:
+{% if grains.get('database_disk_size') > 0 %}
+    - name: suma-storage /dev/{{grains['data_disk_device']}} /dev/{{grains['second_data_disk_device']}}
+{% else %}
     - name: suma-storage /dev/{{grains['data_disk_device']}}
+{% endif %}
     - require:
       - pkg: susemanager-cloud-setup-server
 
@@ -77,6 +81,7 @@ spacewalk_directory:
 {% endif %} # grains.get('repository_disk_size')
 
 {% if grains.get('database_disk_size') > 0 %}
+{% if not grains.get('repository_disk_use_cloud_setup') %}
 
 {% set fstype = grains.get('second_data_disk_fstype') | default('ext4', true) %}
 {% if grains['second_data_disk_device'] == "nvme2n1" %}
@@ -128,4 +133,5 @@ pgsql_directory:
     - require:
         - cmd: pgsql_partition
 
+{% endif %} # grains.get('repository_disk_use_cloud_setup')
 {% endif %} # grains.get('database_disk_size')

--- a/salt/server/additional_disk.sls
+++ b/salt/server/additional_disk.sls
@@ -95,6 +95,16 @@ pgsql_partition:
         - pkg: parted
 
 postgres:
+  mount.mounted:
+    - name: /var/lib/pgsql
+    - device: {{partition_name}}
+    - fstype: ext4
+    - mkmnt: True
+    - persist: True
+    - opts:
+        - defaults
+    - require:
+        - cmd: pgsql_partition
   group.present:
     - system: True
   user.present:
@@ -115,16 +125,6 @@ pgsql_directory:
       - user
       - group
       - mode
-  mount.mounted:
-    - name: /var/lib/pgsql
-    - device: {{partition_name}}
-    - fstype: ext4
-    - mkmnt: True
-    - persist: True
-    - opts:
-        - defaults
-    - require:
-        - cmd: pgsql_partition
 
 {% endif %} # grains.get('repository_disk_use_cloud_setup')
 {% endif %} # grains.get('database_disk_size')

--- a/salt/server/additional_disk.sls
+++ b/salt/server/additional_disk.sls
@@ -5,6 +5,18 @@ parted:
   pkg.installed
 
 {% if grains.get('repository_disk_size') > 0 %}
+{% if grains.get('repository_disk_use_cloud_setup') %}
+
+susemanager-cloud-setup-server:
+  pkg.installed
+
+spacewalk_directory:
+  cmd.run:
+    - name: suma-storage /dev/{{grains['data_disk_device']}}
+    - require:
+      - pkg: susemanager-cloud-setup-server
+
+{% else %}
 
 {% set fstype = grains.get('data_disk_fstype') | default('ext4', true) %}
 {% if grains['data_disk_device'] == "nvme1n1" %}
@@ -61,7 +73,8 @@ spacewalk_directory:
     - require:
       - cmd: spacewalk_partition
 
-{% endif %}
+{% endif %} # grains.get('repository_disk_use_cloud_setup')
+{% endif %} # grains.get('repository_disk_size')
 
 {% if grains.get('database_disk_size') > 0 %}
 
@@ -115,4 +128,4 @@ pgsql_directory:
     - require:
         - cmd: pgsql_partition
 
-{% endif %}
+{% endif %} # grains.get('database_disk_size')

--- a/salt/server/additional_disk.sls
+++ b/salt/server/additional_disk.sls
@@ -38,19 +38,15 @@ spacewalk_partition:
 
 www:
   group.present:
-    - gid: 469
     - system: True
 
 wwwrun:
   group.present:
-    - gid: 466
     - system: True
   user.present:
     - fullname: WWW daemon apache
     - shell: /usr/sbin/nologin
     - home: /var/lib/wwwrun
-    - uid: 466
-    - gid: 466
     - groups:
       - wwwrun
       - www
@@ -100,14 +96,11 @@ pgsql_partition:
 
 postgres:
   group.present:
-    - gid: 464
     - system: True
   user.present:
     - fullname: PostgreSQL Server
     - shell: /bin/bash
     - home: /var/lib/pgsql
-    - uid: 464
-    - gid: 464
     - groups:
       - postgres
 

--- a/salt/server/postgres.sls
+++ b/salt/server/postgres.sls
@@ -23,7 +23,7 @@ postgresql_hba_configuration:
   file.append:
     - name: /var/lib/pgsql/data/pg_hba.conf
     - text: |
-{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-pr', '4.3-released', '4.3-beta'] %}
+{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-pr', '4.3-released', '4.3-beta', '4.3-VM', '4.3-VM-released'] %}
         host    all     all       0.0.0.0/0      scram-sha-256
         host    all     all       ::/0           scram-sha-256
 {%- else %}

--- a/salt/server/postgres.sls
+++ b/salt/server/postgres.sls
@@ -23,7 +23,7 @@ postgresql_hba_configuration:
   file.append:
     - name: /var/lib/pgsql/data/pg_hba.conf
     - text: |
-{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-pr', '4.3-released', '4.3-beta', '4.3-VM', '4.3-VM-released'] %}
+{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-pr', '4.3-released', '4.3-beta', '4.3-VM-nightly', '4.3-VM-released'] %}
         host    all     all       0.0.0.0/0      scram-sha-256
         host    all     all       ::/0           scram-sha-256
 {%- else %}

--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -3,6 +3,9 @@
 include:
   - server
 
+# There products already have salt, prevent version conflicts by not updating/downgrading them
+{% set products_with_preinstalled_salt = [ "build_image", "paygo", "4.3-VM", "4.3-VM-released" ] %}
+
 minima:
   archive.extracted:
     - name: /usr/bin
@@ -37,9 +40,9 @@ test_repo_debian_updates:
     - creates: /srv/www/htdocs/pub/TestRepoDebUpdates/Release
     - require:
       - pkg: testsuite_packages
-      {% if 'build_image' not in grains.get('product_version', '') and 'paygo' not in grains.get('product_version', '') %}
+{% if grains.get('product_version', '') not in products_with_preinstalled_salt %}
       - pkg: testsuite_salt_packages
-      {% endif %}
+{% endif %}
 
 # modify Cobbler to be executed from remote-machines..
 {% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-released", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr", "4.3-VM", "4.3-VM-released" ] %}
@@ -84,7 +87,7 @@ testsuite_packages:
       - sls: repos
     {% endif %}
 
-{% if 'build_image' not in grains.get('product_version', '') and 'paygo' not in grains.get('product_version', '') %}
+{% if grains.get('product_version', '') not in products_with_preinstalled_salt %}
 testsuite_salt_packages:
   pkg.installed:
     - pkgs:

--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -4,7 +4,7 @@ include:
   - server
 
 # There products already have salt, prevent version conflicts by not updating/downgrading them
-{% set products_with_preinstalled_salt = [ "build_image", "paygo", "4.3-VM", "4.3-VM-released" ] %}
+{% set products_with_preinstalled_salt = [ "build_image", "paygo", "4.3-VM-nightly", "4.3-VM-released" ] %}
 
 minima:
   archive.extracted:
@@ -45,7 +45,7 @@ test_repo_debian_updates:
 {% endif %}
 
 # modify Cobbler to be executed from remote-machines..
-{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-released", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr", "4.3-VM", "4.3-VM-released" ] %}
+{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-released", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr", "4.3-VM-nightly", "4.3-VM-released" ] %}
 {% set cobbler_use_settings_yaml = grains.get('product_version') | default('', true) in products_using_new_cobbler_version %}
 {% if 'build_image' not in grains.get('product_version', '') and 'paygo' not in grains.get('product_version', '') %}
 cobbler_configuration:
@@ -99,7 +99,7 @@ testsuite_salt_packages:
       - sls: repos
 {% endif %}
 
-{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr", "4.2-nightly", "4.2-released", "4.3-VM", "4.3-VM-released"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr", "4.2-nightly", "4.2-released", "4.3-VM-nightly", "4.3-VM-released"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,

--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -42,7 +42,7 @@ test_repo_debian_updates:
       {% endif %}
 
 # modify Cobbler to be executed from remote-machines..
-{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-released", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr"] %}
+{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-released", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr", "4.3-VM", "4.3-VM-released" ] %}
 {% set cobbler_use_settings_yaml = grains.get('product_version') | default('', true) in products_using_new_cobbler_version %}
 {% if 'build_image' not in grains.get('product_version', '') and 'paygo' not in grains.get('product_version', '') %}
 cobbler_configuration:
@@ -96,7 +96,7 @@ testsuite_salt_packages:
       - sls: repos
 {% endif %}
 
-{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr", "4.2-nightly", "4.2-released"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr", "4.2-nightly", "4.2-released", "4.3-VM", "4.3-VM-released"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,


### PR DESCRIPTION
## What does this PR change?

Preparing SLE15SP4 EOL, new SUMA4.3 releases will be image based. This PR adds support for `4.3-VM` and `4.3-VM-released` version.

Another changes:
- add support to use jump hosts for libvirt provider
- ensure base repos are present before installing avahi
- 4.3-VM uses tools from cloud environment to setup data disks. This PR allows sumaform to use it.
