### PR TITLE
Add sles15sp4 byos instance support to controller

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -93,6 +93,7 @@ module "controller" {
     sle15sp4_client      = length(var.sle15sp4_client_configuration["hostnames"]) > 0 ? var.sle15sp4_client_configuration["hostnames"][0] : null
     sle15sp4_minion      = length(var.sle15sp4_minion_configuration["hostnames"]) > 0 ? var.sle15sp4_minion_configuration["hostnames"][0] : null
     sle15sp4_sshminion   = length(var.sle15sp4_sshminion_configuration["hostnames"]) > 0 ? var.sle15sp4_sshminion_configuration["hostnames"][0] : null
+    sle15sp4_byos_minion = length(var.sle15sp4_byos_minion_configuration["hostnames"]) > 0 ? var.sle15sp4_byos_minion_configuration["hostnames"][0] : null
     sle15sp5_client      = length(var.sle15sp5_client_configuration["hostnames"]) > 0 ? var.sle15sp5_client_configuration["hostnames"][0] : null
     sle15sp5_minion      = length(var.sle15sp5_minion_configuration["hostnames"]) > 0 ? var.sle15sp5_minion_configuration["hostnames"][0] : null
     sle15sp5_sshminion   = length(var.sle15sp5_sshminion_configuration["hostnames"]) > 0 ? var.sle15sp5_sshminion_configuration["hostnames"][0] : null

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -119,6 +119,15 @@ variable "sle12sp5_paygo_minion_configuration" {
   }
 }
 
+variable "sle15sp4_byos_minion_configuration" {
+  description = "use module.<SLE15SP4_BYOS_MINION>.configuration, see main.tf.libvirt-testsuite.example"
+  default = {
+    hostnames = []
+  }
+}
+
+variable "sle15_paygo_minion_configuration" {
+  description = "use module.<SLE15_PAYGO_MINION>.configuration, see main.tf.libvirt-testsuite.example"
 variable "sle15sp5_paygo_minion_configuration" {
   description = "use module.<SLE15SP5_PAYGO_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -126,8 +126,6 @@ variable "sle15sp4_byos_minion_configuration" {
   }
 }
 
-variable "sle15_paygo_minion_configuration" {
-  description = "use module.<SLE15_PAYGO_MINION>.configuration, see main.tf.libvirt-testsuite.example"
 variable "sle15sp5_paygo_minion_configuration" {
   description = "use module.<SLE15SP5_PAYGO_MINION>.configuration, see main.tf.libvirt-testsuite.example"
   default = {

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -50,6 +50,7 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 {% if grains.get('sle15sp3_client') | default(false, true) %}export SLE15SP3_CLIENT="{{ grains.get('sle15sp3_client') }}" {% else %}# no SLE15SP3 client defined {% endif %}
 {% if grains.get('sle15sp4_client') | default(false, true) %}export SLE15SP4_CLIENT="{{ grains.get('sle15sp4_client') }}" {% else %}# no SLE15SP4 client defined {% endif %}
 {% if grains.get('sle15sp4_minion') | default(false, true) %}export SLE15SP4_MINION="{{ grains.get('sle15sp4_minion') }}" {% else %}# no SLE15SP4 minion defined {% endif %}
+{% if grains.get('sle15sp4_byos_minion') | default(false, true) %}export SLE15SP4_BYOS_MINION="{{ grains.get('sle15sp4_byos_minion') }}" {% else %}# no SLE15SP4 BYOS minion defined {% endif %}
 {% if grains.get('sle15sp4_sshminion') | default(false, true) %}export SLE15SP4_SSHMINION="{{ grains.get('sle15sp4_sshminion') }}" {% else %}# no SLE15SP4 ssh minion defined {% endif %}
 {% if grains.get('sle15sp5_client') | default(false, true) %}export SLE15SP5_CLIENT="{{ grains.get('sle15sp5_client') }}" {% else %}# no SLE15SP5 client defined {% endif %}
 {% if grains.get('sle15sp5_minion') | default(false, true) %}export SLE15SP5_MINION="{{ grains.get('sle15sp5_minion') }}" {% else %}# no SLE15SP5 minion defined {% endif %}


### PR DESCRIPTION
## What does this PR change?

For paygo testing, I need to bootstrap a byos without SCC. This instance should fail to bootstrap.
That's why I have two sles15sp4 instance
- sles15sp4-byos-minion => fail bootstrap without SCC
- sles15sp4-minion => run default minion pipeline once I add SCC credential

