### PR TITLE
Fix early avahi installation on controller

### DIFF
--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -4,7 +4,7 @@ include:
 {% if grains['use_avahi'] and grains.get('osmajorrelease', None) != None %}
 
 # TODO: remove the following state when fix to bsc#1163683 is applied to all the SLES <= SLES15SP4
-{% if grains['osfullname'] == 'SLES' and grains['osrelease'] != '15.5' %}
+{% if (grains['osfullname'] == 'SLES' and grains['osrelease'] != '15.5') or (grains['osfullname'] == 'Leap') %}
 custom_avahi_repo:
   pkgrepo.managed:
     - humanname: custom_avahi_repo
@@ -26,6 +26,8 @@ custom_avahi_repo:
     - baseurl: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools:/avahi:/0.7/SLE_15_SP3/
     {% elif grains['osrelease'] == '15.4' %}
     - baseurl: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools:/avahi:/0.8/15.4/
+    {% elif grains['osrelease'] == '15.5' and grains['osfullname'] == 'Leap' %}
+    - baseurl: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools:/avahi:/0.8/15.5/
     {% endif %}
     - enabled: True
     - refresh: True


### PR DESCRIPTION
## What does this PR change?
Previously, since the controller always runs on Leap, the custom repo was not added in the early stage of the controller's setup. Because of this, the installation of avahi-lang would always fail if avahi is enabled in main.tf. This usually wasn't noticed, because a later step will also attempt to install this package, which would then succeed. However, there might be a need for avahi being available during the early stages.
