### PR TITLE
Revert "Add a reboot after setting repos in containerized server for …

### DIFF
--- a/salt/repos/server_containerized.sls
+++ b/salt/repos/server_containerized.sls
@@ -6,12 +6,6 @@ systemsmanagement_Uyuni_Master_ContainerUtils:
     - refresh: True
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/openSUSE_Leap_15.5/repodata/repomd.xml.key
 
-reboot:
-  module.run:
-    - name: system.reboot
-    - at_time: +2
-    - order: last
-
 {% endif %}
 
 


### PR DESCRIPTION
## What does this PR change?

Rebooting in the middle of a Salt state is a bad idea:
* it can be executed at any time
* Salt cannot continue the state execution after the reboot