### PR TITLE
Add Salt migration minion entries

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -146,8 +146,8 @@ module "controller" {
     opensuse155arm_sshminion = length(var.opensuse155arm_sshminion_configuration["hostnames"]) > 0 ? var.opensuse155arm_sshminion_configuration["hostnames"][0] : null
     sle15sp3s390_minion    = length(var.sle15sp3s390_minion_configuration["hostnames"]) > 0 ? var.sle15sp3s390_minion_configuration["hostnames"][0] : null
     sle15sp3s390_sshminion = length(var.sle15sp3s390_sshminion_configuration["hostnames"]) > 0 ? var.sle15sp3s390_sshminion_configuration["hostnames"][0] : null
+    salt_migration_minion = length(var.salt_migration_minion_configuration["hostnames"]) > 0 ? var.salt_migration_minion_configuration["hostnames"][0] : null
   }
-
 
   image   = "opensuse154o"
   provider_settings = var.provider_settings

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -677,6 +677,13 @@ variable "sle15sp3s390_sshminion_configuration" {
   }
 }
 
+variable "salt_migration_minion_configuration" {
+  description = "use module.<SALT_MIGRATION_MINION>.configuration"
+  default = {
+    hostnames = []
+  }
+}
+
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
   default     = {}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -14,10 +14,12 @@ export SERVER="{{ grains.get('server') }}"
 export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 {% if grains.get('monitoring_server') | default(false, true) %}export MONITORING_SERVER="{{ grains.get('monitoring_server') }}"{% else %}# no monitoring server defined {% endif %}
 
-# Salt bundle test specific hosts
-# At the moment we only need/support one nested VM in the test suite
+# Nested VM specific host
 {% if grains.get('nested_vm_host') %}export MIN_NESTED="{{ grains.get('nested_vm_host') }}.{{ grains.get('domain') }}"{% else %}# no nested VM hostname defined {%- endif %}
 {% if grains.get('nested_vm_mac') %}export MAC_MIN_NESTED="{{ grains.get('nested_vm_mac') }}"{% else %}# no nested VM MAC address defined {%- endif %}
+
+# Migration to Salt bundle test specific host
+{% if grains.get('salt_migration_minion') | default(false, true) %}export SALT_MIGRATION_MINION="{{ grains.get('salt_migration_minion') }}" {% else %}# no Salt migration minion defined {% endif %}
 
 # base goodies
 {% if grains.get('additional_network') | default(false, true) %}export PRIVATENET="{{ grains.get('additional_network') }}" {% else %}# no private network defined {% endif %}


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/22410

This PR adds the entries needed in order to test the migration from a Salt minion (OS Salt)  to the Salt bundle on a dedicated host, removing the need for a nested VM.

Note: `salt_migration_minion` is just a placeholder name 
