### PR TITLE
Additional disk for /var/lib/pgsql partition custom size

### DIFF
--- a/.github/workflows/ci-validation/salt-server-validation
+++ b/.github/workflows/ci-validation/salt-server-validation
@@ -53,6 +53,7 @@ iss_master: null
 iss_slave: null
 db_configuration: {'local': true, 'hostname': 'localhost', 'port': '5432'}
 repository_disk_size: 0
+database_disk_size: 0
 EOF
 
 cat > testconfig/minion <<EOF

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 .*.sw*
 
 .idea
+sumaform.iml

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -865,7 +865,7 @@ To disable the swap file, set its size to 0.
 
 ## Additional disk on Server or Proxy
 
-In case the default disk size for those machines is not enough for the amount of products you want to synchronize, you can add an additional disk which will mount the first volume in `/var/spacewalk` with size `repository_disk_size`. This additional disk will be created in the pool specified by `data_pool`.
+In case the default disk size for those machines is not enough for the amount of products you want to synchronize, you can add an additional disk which will mount the first volume in `/var/spacewalk` with size `repository_disk_size` and the second volume in `/var/lib/pgsql` with size `database_disk_size`. This additional disk will be created in the pool specified by `data_pool`.
 
 An example follows:
 
@@ -876,6 +876,7 @@ module "server" {
   product_version = "4.2-nightly"
   name = "server"
   repository_disk_size = 500
+  database_disk_size = 50
   volume_provider_settings = {
     data_pool = "default"
   }

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -39,6 +39,7 @@ locals {
   availability_zone = var.base_configuration["availability_zone"]
   region            = var.base_configuration["region"]
   data_disk_device  = split(".", local.provider_settings["instance_type"])[0] == "t2" ? "xvdf" : "nvme1n1"
+  second_data_disk_device  = split(".", local.provider_settings["instance_type"])[0] == "t2" ? "xvdf" : "nvme2n1"
 
   host_eip = local.provider_settings["public_instance"] && local.provider_settings["instance_with_eip"]? true: false
 }
@@ -261,6 +262,7 @@ resource "null_resource" "host_salt_configuration" {
         reset_ids                     = true
         ipv6                          = var.ipv6
         data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? local.data_disk_device : null
+        second_data_disk_device       = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? local.second_data_disk_device : null
       },
       var.grains))
     destination = "/tmp/grains"

--- a/backend_modules/azure/host/main.tf
+++ b/backend_modules/azure/host/main.tf
@@ -198,6 +198,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" 
         reset_ids                     = true
         ipv6                          = var.ipv6
         data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "sdb" : null
+        second_data_disk_device       = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "sdc" : null
       },
       var.grains))
     destination = "/tmp/grains"

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -69,6 +69,14 @@ resource "libvirt_volume" "data_disk" {
   count = var.additional_disk_size == null? 0 : var.additional_disk_size > 0 ? var.quantity : 0
 }
 
+resource "libvirt_volume" "database_disk" {
+  name  = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}-database-disk"
+  // needs to be converted to bytes
+  size  = (var.second_additional_disk_size == null? 0: var.second_additional_disk_size) * 1024 * 1024 * 1024
+  pool  = lookup(var.volume_provider_settings, "pool", var.base_configuration["pool"])
+  count = var.second_additional_disk_size == null? 0 : var.second_additional_disk_size > 0 ? var.quantity : 0
+}
+
 resource "libvirt_cloudinit_disk" "cloudinit_disk" {
   name           = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}-cloudinit-disk"
   user_data      = data.template_file.user_data.rendered
@@ -101,7 +109,8 @@ resource "libvirt_domain" "domain" {
   dynamic "disk" {
     for_each = concat(
       length(libvirt_volume.main_disk) == var.quantity ? [{"volume_id" : libvirt_volume.main_disk[count.index].id}] : [],
-      length(libvirt_volume.data_disk) == var.quantity ? [{"volume_id" : libvirt_volume.data_disk[count.index].id}] : []
+      length(libvirt_volume.data_disk) == var.quantity ? [{"volume_id" : libvirt_volume.data_disk[count.index].id}] : [],
+      length(libvirt_volume.database_disk) == var.quantity ? [{"volume_id" : libvirt_volume.database_disk[count.index].id}] : []
     )
     content {
       volume_id = disk.value.volume_id
@@ -237,6 +246,7 @@ resource "null_resource" "provisioning" {
         reset_ids                     = true
         ipv6                          = var.ipv6
         data_disk_device              = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdb" : null
+        second_data_disk_device       = contains(var.roles, "server") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdc" : null
         provider                      = "libvirt"
       },
       var.grains))

--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -111,6 +111,11 @@ variable "additional_disk_size" {
   default     = null
 }
 
+variable "second_additional_disk_size" {
+  description = "Size of a second additional disk, defined in GiB"
+  default     = null
+}
+
 variable "volume_provider_settings" {
   description = "Map of volume-provider-specific settings, see the backend-specific README file"
   default     = {}

--- a/backend_modules/ssh/host/main.tf
+++ b/backend_modules/ssh/host/main.tf
@@ -101,6 +101,7 @@ resource "null_resource" "provisioning" {
         reset_ids                     = true
         ipv6                          = var.ipv6
         data_disk_device              = contains(var.roles, "suse_manager_server") || contains(var.roles, "suse_manager_proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdb" : null
+        second_data_disk_device       = contains(var.roles, "suse_manager_server") || contains(var.roles, "suse_manager_proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdc" : null
       },
       var.grains))
     destination = "/tmp/grains"

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -46,6 +46,10 @@ locals {
     host_key => lookup(var.host_settings[host_key], "container_repository", null) if var.host_settings[host_key] != null }
   helm_chart_urls    = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "helm_chart_url", null) if var.host_settings[host_key] != null }
+  repository_disk_size    = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "repository_disk_size", null) if var.host_settings[host_key] != null }
+  database_disk_size    = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "database_disk_size", null) if var.host_settings[host_key] != null }
 }
 
 module "server" {
@@ -84,6 +88,8 @@ module "server" {
   saltapi_tcpdump   = var.saltapi_tcpdump
   provider_settings = lookup(local.provider_settings_by_host, "server", {})
   server_mounted_mirror         = lookup(local.server_mounted_mirror, "server", {})
+  repository_disk_size          = lookup(local.repository_disk_size, "server", {})
+  database_disk_size            = lookup(local.database_disk_size, "server", {})
 }
 
 module "server_containerized" {

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -41,6 +41,16 @@ variable "images" {
   default     = ["centos7o", "opensuse154o", "opensuse155o", "rocky8o", "rocky9o", "sles12sp4o", "sles12sp5o", "sles15sp3o", "sles15sp4o", "ubuntu2004o", "ubuntu2204o"]
 }
 
+variable "repository_disk_size" {
+  description = "Size of an additional disk for /var/spacewalk partition, defined in GiB"
+  default     = 0
+}
+
+variable "database_disk_size" {
+  description = "Size of an additional disk for /var/lib/pgsql partition, defined in GiB"
+  default     = 0
+}
+
 variable "mirror" {
   description = "hostname of the mirror host or leave the default for no mirror"
   default     = null

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -22,6 +22,7 @@ module "host" {
   provision                     = var.provision
   provider_settings             = var.provider_settings
   additional_disk_size          = var.additional_disk_size
+  second_additional_disk_size   = var.second_additional_disk_size
   volume_provider_settings      = var.volume_provider_settings
 
   grains = merge({ disable_firewall = var.disable_firewall },

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -82,6 +82,7 @@ module "server" {
     traceback_email                = var.traceback_email
     saltapi_tcpdump                = var.saltapi_tcpdump
     repository_disk_size           = var.repository_disk_size
+    database_disk_size             = var.database_disk_size
     forward_registration           = var.forward_registration
     server_registration_code       = var.server_registration_code
     accept_all_ssl_protocols       = var.accept_all_ssl_protocols
@@ -92,10 +93,11 @@ module "server" {
   }
 
 
-  image                    = var.image == "default" || var.product_version == "head" ? var.images[var.product_version] : var.image
-  provider_settings        = var.provider_settings
-  additional_disk_size     = var.repository_disk_size
-  volume_provider_settings = var.volume_provider_settings
+  image                           = var.image == "default" || var.product_version == "head" ? var.images[var.product_version] : var.image
+  provider_settings               = var.provider_settings
+  additional_disk_size            = var.repository_disk_size
+  second_additional_disk_size     = var.database_disk_size
+  volume_provider_settings        = var.volume_provider_settings
 }
 
 output "configuration" {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -240,6 +240,11 @@ variable "repository_disk_size" {
   default     = 0
 }
 
+variable "database_disk_size" {
+  description = "Size of an additional disk for /var/lib/pgsql partition, defined in GiB"
+  default     = 0
+}
+
 variable "saltapi_tcpdump" {
   description = "If set to true, all network operations of salt-api are logged to /tmp/ with tcpdump."
   default     = false

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -32,6 +32,7 @@ module "server_containerized" {
   provision                     = var.provision
   provider_settings             = var.provider_settings
   additional_disk_size          = var.additional_disk_size
+  second_additional_disk_size   = var.second_additional_disk_size
   volume_provider_settings      = var.volume_provider_settings
 
   grains = {

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -292,6 +292,11 @@ variable "additional_disk_size" {
   default     = null
 }
 
+variable "second_additional_disk_size" {
+  description = "Size of a second additional disk, defined in GiB"
+  default     = null
+}
+
 variable "volume_provider_settings" {
   description = "Map of volume-provider-specific settings, see the backend-specific README file"
   default     = {}

--- a/salt/server/additional_disk.sls
+++ b/salt/server/additional_disk.sls
@@ -1,10 +1,10 @@
 include:
   - default
 
-{% if grains.get('repository_disk_size') > 0 %}
-
 parted:
   pkg.installed
+
+{% if grains.get('repository_disk_size') > 0 %}
 
 {% set fstype = grains.get('data_disk_fstype') | default('ext4', true) %}
 {% if grains['data_disk_device'] == "nvme1n1" %}
@@ -20,10 +20,36 @@ spacewalk_partition:
     - require:
       - pkg: parted
 
+www:
+  group.present:
+    - gid: 469
+    - system: True
+
+wwwrun:
+  group.present:
+    - gid: 466
+    - system: True
+  user.present:
+    - fullname: WWW daemon apache
+    - shell: /usr/sbin/nologin
+    - home: /var/lib/wwwrun
+    - uid: 466
+    - gid: 466
+    - groups:
+      - wwwrun
+      - www
+
 spacewalk_directory:
   file.directory:
     - name: /var/spacewalk
     - makedirs: True
+    - user: wwwrun
+    - group: www
+    - dir_mode: 775
+    - recurse:
+      - user
+      - group
+      - mode
   mount.mounted:
     - name: /var/spacewalk
     - device: {{partition_name}}
@@ -34,5 +60,59 @@ spacewalk_directory:
       - defaults
     - require:
       - cmd: spacewalk_partition
+
+{% endif %}
+
+{% if grains.get('database_disk_size') > 0 %}
+
+{% set fstype = grains.get('second_data_disk_fstype') | default('ext4', true) %}
+{% if grains['second_data_disk_device'] == "nvme2n1" %}
+{% set partition_name = '/dev/' + grains['second_data_disk_device'] + 'p1' %}
+{% else %}
+{% set partition_name = '/dev/' + grains['second_data_disk_device'] + '1' %}
+{% endif %}
+
+
+pgsql_partition:
+  cmd.run:
+    - name: /usr/sbin/parted -s /dev/{{grains['second_data_disk_device']}} mklabel gpt && /usr/sbin/parted -s /dev/{{grains['second_data_disk_device']}} mkpart primary 0% 100% && sleep 1 && /sbin/mkfs.{{fstype}} {{partition_name}}
+    - unless: ls {{partition_name}}
+    - require:
+        - pkg: parted
+
+postgres:
+  group.present:
+    - gid: 464
+    - system: True
+  user.present:
+    - fullname: PostgreSQL Server
+    - shell: /bin/bash
+    - home: /var/lib/pgsql
+    - uid: 464
+    - gid: 464
+    - groups:
+      - postgres
+
+pgsql_directory:
+  file.directory:
+    - name: /var/lib/pgsql
+    - makedirs: True
+    - user: postgres
+    - group: postgres
+    - dir_mode: 750
+    - recurse:
+      - user
+      - group
+      - mode
+  mount.mounted:
+    - name: /var/lib/pgsql
+    - device: {{partition_name}}
+    - fstype: ext4
+    - mkmnt: True
+    - persist: True
+    - opts:
+        - defaults
+    - require:
+        - cmd: pgsql_partition
 
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

This is a PR to parametrize the partition size for /var/lib/pqsql, aiming to solve not enough disk space issues in our CI tests.

To use it, you need to set this variable (on GB) in your main.tf:

```
    server = {
      ...
      database_disk_size = 50
    }
```
