### PR TITLE
Remove 4.0 and 4.1

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -9,14 +9,12 @@ Some modules have a `product_version` variable that determines the software prod
 
 Legal values for released software are:
 
-- `4.1-released`   (latest released Maintenance Update for SUSE Manager 4.1 and Tools)
 - `4.2-released`   (latest released Maintenance Update for SUSE Manager 4.2 and Tools)
 - `4.3-released`   (latest released Maintenance Update for SUSE Manager 4.3 and Tools)
 - `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
 
 Legal values for work-in-progress software are:
 
-- `4.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.1)
 - `4.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.2)
 - `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
 - `4.3-beta`    (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
@@ -479,7 +477,7 @@ module "server" {
   base_configuration = module.base.configuration
 
   name = "server"
-  product_version = "4.1-nightly"
+  product_version = "4.3-nightly"
 }
 
 module "proxy" {
@@ -487,7 +485,7 @@ module "proxy" {
   base_configuration = module.base.configuration
 
   name = "proxy"
-  product_version = "4.1-nightly"
+  product_version = "4.3-nightly"
   server_configuration = module.server.configuration
 }
 

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -12,7 +12,7 @@ provider "libvirt" {
 module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
-  product_version = "4.0-nightly"
+  product_version = "4.3-nightly"
 
   cc_username = ...
   cc_password = ...
@@ -205,7 +205,7 @@ As an example:
 module "cucumber_testsuite" {
   source = "./modules/cucumber_testsuite"
 
-  product_version = "4.0-nightly"
+  product_version = "4.3-nightly"
   ...
   git_repo = "https://url.to.git/repo/to/clone"
   branch = "cool-feature"

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -1,7 +1,5 @@
 variable "testsuite-branch" {
   default = {
-    "4.1-released"   = "Manager-4.1"
-    "4.1-nightly"    = "Manager-4.1"
     "4.2-released"   = "Manager-4.2"
     "4.2-nightly"    = "Manager-4.2"
     "4.3-released"   = "Manager-4.3"

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -69,7 +69,7 @@ variable "host_settings" {
 
 // server
 variable "product_version" {
-  description = "One of: 4.0-nightly, 4.0-released, 4.1-nightly, 4.1-released, 4.2-nightly, 4.2-released, 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, head, test, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.2-nightly, 4.2-released, 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -1,10 +1,5 @@
 variable "images" {
   default = {
-    "4.0-released"   = "sles15sp1o"
-    "4.0-nightly"    = "sles15sp1o"
-    "4.1-released"   = "sles15sp2o"
-    "4.1-nightly"    = "sles15sp2o"
-    "4.1-build_image"= "sles15sp2o"
     "4.2-released"   = "sles15sp3o"
     "4.2-nightly"    = "sles15sp3o"
     "4.2-build_image"= "sles15sp3o"

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.0-released, 4.0-nightly, 4.1-released, 4.1-nightly, 4.2-released, 4.2-nightly, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, head, test, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.2-released, 4.2-nightly, 4.2-build_image, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -1,10 +1,5 @@
 variable "images" {
   default = {
-    "4.0-released"   = "sles15sp1o"
-    "4.0-nightly"    = "sles15sp1o"
-    "4.1-released"   = "sles15sp2o"
-    "4.1-nightly"    = "sles15sp2o"
-    "4.1-build_image"= "sles15sp2o"
     "4.2-released"   = "sles15sp3o"
     "4.2-nightly"    = "sles15sp3o"
     "4.2-build_image"= "sles15sp3o"

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.0-nightly, 4.0-released, 4.1-released, 4.1-nightly, 4.2-released, 4.2-nightly, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, head, test, uyuni-master, uyuni-released"
+  description = "One of: 4.2-released, 4.2-nightly, 4.2-build_image, 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-paygo, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
 }
 

--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -147,10 +147,6 @@ scc:
     - SLE-Module-Containers15-SP4-Pool
     - SLE-Module-Containers15-SP4-Updates
     # SUSE Manager Server
-    - SLE-Product-SUSE-Manager-Server-4.1-Pool
-    - SLE-Product-SUSE-Manager-Server-4.1-Updates
-    - SLE-Module-SUSE-Manager-Server-4.1-Pool
-    - SLE-Module-SUSE-Manager-Server-4.1-Updates
     - SLE-Product-SUSE-Manager-Server-4.2-Pool
     - SLE-Product-SUSE-Manager-Server-4.2-Updates
     - SLE-Module-SUSE-Manager-Server-4.2-Pool
@@ -160,10 +156,6 @@ scc:
     - SLE-Module-SUSE-Manager-Server-4.3-Pool
     - SLE-Module-SUSE-Manager-Server-4.3-Updates
     # SUSE Manager Proxy
-    - SLE-Product-SUSE-Manager-Proxy-4.1-Pool
-    - SLE-Product-SUSE-Manager-Proxy-4.1-Updates
-    - SLE-Module-SUSE-Manager-Proxy-4.1-Pool
-    - SLE-Module-SUSE-Manager-Proxy-4.1-Updates
     - SLE-Product-SUSE-Manager-Proxy-4.2-Pool
     - SLE-Product-SUSE-Manager-Proxy-4.2-Updates
     - SLE-Module-SUSE-Manager-Proxy-4.2-Pool
@@ -173,10 +165,6 @@ scc:
     - SLE-Module-SUSE-Manager-Proxy-4.3-Pool
     - SLE-Module-SUSE-Manager-Proxy-4.3-Updates
     # Retail Branch Server
-    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Pool
-    - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.1-Updates
-    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Pool
-    - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.1-Updates
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.2-Pool
     - SLE-Product-SUSE-Manager-Retail-Branch-Server-4.2-Updates
     - SLE-Module-SUSE-Manager-Retail-Branch-Server-4.2-Pool
@@ -316,14 +304,6 @@ http:
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Proxy-4.2-POOL-x86_64-Media1
     archs: [x86_64]
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/ToSLE/SLE_15_SP3/
-    archs: [x86_64]
-
-  # SUSE Manager 4.1 devel
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1/SLE_15_SP2
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/ToSLE/SLE_15_SP2/
-    archs: [x86_64]
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1/images/repo/SLE-Module-SUSE-Manager-Testing-Overlay-4.1-POOL-x86_64-Media1/
     archs: [x86_64]
 
   # SUSE Manager 4.2 devel

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -732,15 +732,13 @@ tools_update_repo:
   pkgrepo.managed:
     - humanname: tools_update_repo
     - file: /etc/apt/sources.list.d/tools_update_repo.list
-# We only have one shared Client Tools repository, so we are using 4.3 for 4.2 and 4.1
+# We only have one shared Client Tools repository, so we are using 4.3 for 4.2
 {% if 'nightly' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.3:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
 {% elif 'head' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/Head:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
 {% elif 'beta' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS-BETA/x86_64/update/' %}
-{% elif '4.1-released' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% elif '4.2-released' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% elif '4.3-released' in grains.get('product_version') | default('', true) %}
@@ -766,11 +764,6 @@ tools_update_repo_raised_priority:
     - contents: |
             Package: *
             Pin: release l=Devel:Galaxy:Manager:4.3:Ubuntu{{ release }}-SUSE-Manager-Tools
-            Pin-Priority: 800
-{% elif '4.1-released' in grains.get('product_version') | default('', true) %}
-    - contents: |
-            Package: *
-            Pin: release l=SUSE:Updates:Ubuntu:{{ release }}-CLIENT-TOOLS:x86_64:update
             Pin-Priority: 800
 {% elif '4.2-released' in grains.get('product_version') | default('', true) %}
     - contents: |

--- a/salt/scc/proxy.sls
+++ b/salt/scc/proxy.sls
@@ -1,20 +1,5 @@
 {% if 'proxy' in grains.get('roles') and grains.get('proxy_registration_code') %}
 
-{% if '4.1' in grains['product_version'] %}
-register_suse_manager_proxy_with_scc:
-   cmd.run:
-     - name: SUSEConnect --url https://scc.suse.com -r {{ grains.get("proxy_registration_code") }} -p SUSE-Manager-Proxy/4.1/x86_64
-add_sle_module_basesystem:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-basesystem/15.2/x86_64
-add_sle_module_server_application:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-server-applications/15.2/x86_64
-add_sle_module_suse_manager_proxy:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-suse-manager-proxy/4.1/x86_64
-{% endif %}
-
 {% if '4.2' in grains['product_version'] %}
 register_suse_manager_proxy_with_scc:
    cmd.run:

--- a/salt/scc/server.sls
+++ b/salt/scc/server.sls
@@ -1,27 +1,5 @@
 {% if 'server' in grains.get('roles') and grains.get('server_registration_code') %}
 
-{% if '4.1' in grains['product_version'] %}
-register_suse_manager_server_with_scc:
-   cmd.run:
-     - name: SUSEConnect --url https://scc.suse.com -r {{ grains.get("server_registration_code") }} -p SUSE-Manager-Server/4.1/x86_64
-add_sle_module_basesystem:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-basesystem/15.2/x86_64
-add_sle_module_python2:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-python2/15.2/x86_64
-add_sle_module_server_application:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-server-applications/15.2/x86_64
-add_sle_module_web_scripting:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-web-scripting/15.2/x86_64
-add_sle_module_suse_manager_server:
-   cmd.run:
-     - name: SUSEConnect -p sle-module-suse-manager-server/4.1/x86_64
-{% endif %}
-
-
 {% if '4.2' in grains['product_version'] %}
 register_suse_manager_server_with_scc:
    cmd.run:


### PR DESCRIPTION
## What does this PR change?

Remove oldies: SUSE Manager 4.0 and 4.1.

(note about the minima part: this code is used only when creating a new mirror from sumaform ; the cleanup is already done in our permanent mirrors).
