### PR TITLE
Remove nested VM entries

### DIFF
--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -303,14 +303,3 @@ host_settings = {
   }
 }
 ```
-
-Furthermore you have to specify 2 other variable inside your `main.tf` that defines the hostname and the MAC addresses
-of the image you use, if needed:
-
-```hcl
-nested_vm_host = "hostname1"
-nested_vm_mac  = "aa:bb:cc:dd:ee:ff"
-```
-
-It should contain the same hostname as the one defined in the `hvm_disk_image` section you see above. This is a
-workaround to not have to refactor parts of the current sumaform code.

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -33,8 +33,6 @@ module "controller" {
     cc_username  = var.base_configuration["cc_username"]
     cc_password  = var.base_configuration["cc_password"]
     git_username = var.git_username
-    nested_vm_host = var.nested_vm_host
-    nested_vm_mac = var.nested_vm_mac
     git_password = var.git_password
     git_repo     = var.git_repo
     branch       = var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -781,16 +781,3 @@ variable "server_instance_id" {
   description = "Server instance ID"
   default     = null
 }
-
-
-variable "nested_vm_host" {
-  description = "Hostname for a nested VM if it is used, see README_TESTING.md"
-  type        = string
-  default     = "min-nested"
-}
-
-variable "nested_vm_mac" {
-  description = "MAC address for a nested VM if it is used, see README_TESTING.md"
-  type        = string
-  default     = ""
-}

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -400,8 +400,6 @@ module "controller" {
 
   branch                   = var.branch
   git_username             = var.git_username
-  nested_vm_host          = var.nested_vm_host
-  nested_vm_mac           = var.nested_vm_mac
   git_password             = var.git_password
   git_repo                 = var.git_repo
   git_profiles_repo        = var.git_profiles_repo

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -150,18 +150,6 @@ variable "login_timeout" {
   default     = null
 }
 
-variable "nested_vm_host" {
-  description = "Hostname for a nested VM if it is used, see README_TESTING.md"
-  type        = string
-  default     = "min-nested"
-}
-
-variable "nested_vm_mac" {
-  description = "MAC address for a nested VM if it is used, see README_TESTING.md"
-  type        = string
-  default     = ""
-}
-
 variable "container_server" {
   description = "true to run the server in containers"
   default = false

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -14,10 +14,6 @@ export SERVER="{{ grains.get('server') }}"
 export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 {% if grains.get('monitoring_server') | default(false, true) %}export MONITORING_SERVER="{{ grains.get('monitoring_server') }}"{% else %}# no monitoring server defined {% endif %}
 
-# Nested VM specific host
-{% if grains.get('nested_vm_host') %}export MIN_NESTED="{{ grains.get('nested_vm_host') }}.{{ grains.get('domain') }}"{% else %}# no nested VM hostname defined {%- endif %}
-{% if grains.get('nested_vm_mac') %}export MAC_MIN_NESTED="{{ grains.get('nested_vm_mac') }}"{% else %}# no nested VM MAC address defined {%- endif %}
-
 # Migration to Salt bundle test specific host
 {% if grains.get('salt_migration_minion') | default(false, true) %}export SALT_MIGRATION_MINION="{{ grains.get('salt_migration_minion') }}" {% else %}# no Salt migration minion defined {% endif %}
 


### PR DESCRIPTION
Related to https://github.com/SUSE/spacewalk/issues/22410

We'll test the migration from OS Salt to Salt bundle only on a dedicated BV host.
The entries for a minion running in a nested VM are thus no longer needed.