### PR TITLE
Use 0 as default value for disk sizes

### DIFF
--- a/backend_modules/azure/host/main.tf
+++ b/backend_modules/azure/host/main.tf
@@ -110,14 +110,14 @@ resource "azurerm_linux_virtual_machine" "instance" {
 
 /** START: Set up an extra data disk */
 resource "azurerm_managed_disk" "addtionaldisks" {
-  count = var.additional_disk_size == null ? 0 : var.additional_disk_size > 0 ? var.quantity : 0
+  count                =  var.additional_disk_size > 0 ? var.quantity : 0
   name                 = "${local.resource_name_prefix}-data-volume${var.quantity > 1 ? "-${count.index + 1}" : ""}"
   location             = local.location
   resource_group_name  = local.resource_group_name
   storage_account_type = "Standard_LRS"
   create_option        = local.disk_snapshot == null?"Empty":"Copy"
   source_resource_id   = local.disk_snapshot == null?null:local.disk_snapshot.id
-  disk_size_gb         = var.additional_disk_size == null ? (local.disk_snapshot == null?0:local.disk_snapshot.disk_size_gb) : var.additional_disk_size
+  disk_size_gb         = var.additional_disk_size > 0 ? var.additional_disk_size : (local.disk_snapshot == null?0:local.disk_snapshot.disk_size_gb)
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "addtionaldisks-attach" {

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -64,17 +64,17 @@ resource "libvirt_volume" "main_disk" {
 resource "libvirt_volume" "data_disk" {
   name  = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}-data-disk"
   // needs to be converted to bytes
-  size  = (var.additional_disk_size == null? 0: var.additional_disk_size) * 1024 * 1024 * 1024
+  size  = var.additional_disk_size * 1024 * 1024 * 1024
   pool  = lookup(var.volume_provider_settings, "pool", var.base_configuration["pool"])
-  count = var.additional_disk_size == null? 0 : var.additional_disk_size > 0 ? var.quantity : 0
+  count = var.additional_disk_size > 0 ? var.quantity : 0
 }
 
 resource "libvirt_volume" "database_disk" {
   name  = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}-database-disk"
   // needs to be converted to bytes
-  size  = (var.second_additional_disk_size == null? 0: var.second_additional_disk_size) * 1024 * 1024 * 1024
+  size  = var.second_additional_disk_size * 1024 * 1024 * 1024
   pool  = lookup(var.volume_provider_settings, "pool", var.base_configuration["pool"])
-  count = var.second_additional_disk_size == null? 0 : var.second_additional_disk_size > 0 ? var.quantity : 0
+  count = var.second_additional_disk_size > 0 ? var.quantity : 0
 }
 
 resource "libvirt_cloudinit_disk" "cloudinit_disk" {

--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -108,12 +108,12 @@ variable "provider_settings" {
 
 variable "additional_disk_size" {
   description = "Size of an additional disk, defined in GiB"
-  default     = null
+  default     = 0
 }
 
 variable "second_additional_disk_size" {
   description = "Size of a second additional disk, defined in GiB"
-  default     = null
+  default     = 0
 }
 
 variable "volume_provider_settings" {

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -47,9 +47,9 @@ locals {
   helm_chart_urls    = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "helm_chart_url", null) if var.host_settings[host_key] != null }
   repository_disk_size    = { for host_key in local.hosts :
-    host_key => lookup(var.host_settings[host_key], "repository_disk_size", null) if var.host_settings[host_key] != null }
+    host_key => lookup(var.host_settings[host_key], "repository_disk_size", 0) if var.host_settings[host_key] != null }
   database_disk_size    = { for host_key in local.hosts :
-    host_key => lookup(var.host_settings[host_key], "database_disk_size", null) if var.host_settings[host_key] != null }
+    host_key => lookup(var.host_settings[host_key], "database_disk_size", 0) if var.host_settings[host_key] != null }
 }
 
 module "server" {

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -288,13 +288,13 @@ variable "provider_settings" {
 }
 
 variable "additional_disk_size" {
-  description = "Size of an aditional disk, defined in GiB"
-  default     = null
+  description = "Size of an additional disk, defined in GiB"
+  default     = 0
 }
 
 variable "second_additional_disk_size" {
   description = "Size of a second additional disk, defined in GiB"
-  default     = null
+  default     = 0
 }
 
 variable "volume_provider_settings" {


### PR DESCRIPTION
## What does this PR change?

Title - keep the same convention when defining disk sizes.
