### PR TITLE
Add "install_salt_bundle" flag to ssh backend grains

### DIFF
--- a/backend_modules/ssh/host/main.tf
+++ b/backend_modules/ssh/host/main.tf
@@ -28,6 +28,7 @@ resource "null_resource" "provisioning" {
         hostname                  = "${local.resource_name_prefix}${var.quantity > 1 ? "-${count.index + 1}" : ""}"
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
+        install_salt_bundle       = var.install_salt_bundle
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
         additional_certs          = var.additional_certs
@@ -86,6 +87,7 @@ resource "null_resource" "provisioning" {
         testsuite                 = var.base_configuration["testsuite"]
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
+        install_salt_bundle       = var.install_salt_bundle
         additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
         additional_certs          = var.additional_certs


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with `ssh` backend module, where `install_salt_bundle` grain is not available. Leading to this errors during deployment:

```
salt.exceptions.SaltRenderError: Jinja variable 'dict object' has no attribute 'install_salt_bundle'; line 15
```

/cc @Etheryte 