### PR TITLE
salt_testenv: install "python3-salt-test" package on nodes with Salt classic package

### DIFF
--- a/salt/salt_testenv/init.sls
+++ b/salt/salt_testenv/init.sls
@@ -48,7 +48,7 @@ salt_testing_repo:
 
 install_salt_testsuite:
   pkg.installed:
-    - name: python3-salt-testsuite
+    - pkgs: ["python3-salt-testsuite", "python3-salt-test"]
     - require:
       - pkgrepo: salt_testsuite_dependencies_repo
       - pkgrepo: salt_testing_repo


### PR DESCRIPTION
## What does this PR change?

This PR just fixes the `salt_testenv` and makes Salt testsuite executor to be installed on hosts where the classic Salt package is being installed: at the moment for SLE15SP1+.
