### PR TITLE
Add new controller variable to enable / disable the catch timeout mes…

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -61,6 +61,7 @@ module "controller" {
     is_using_scc_repositories = var.is_using_scc_repositories
     server_instance_id        = var.server_instance_id
     container_runtime         = lookup(var.server_configuration, "runtime", null)
+    catch_timeout_message     = var.catch_timeout_message
 
     sle12sp5_paygo_minion    = length(var.sle12sp5_paygo_minion_configuration["hostnames"]) > 0 ? var.sle12sp5_paygo_minion_configuration["hostnames"][0] : null
     sle15sp5_paygo_minion    = length(var.sle15sp5_paygo_minion_configuration["hostnames"]) > 0 ? var.sle15sp5_paygo_minion_configuration["hostnames"][0] : null

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -763,7 +763,7 @@ variable "no_mirror" {
 }
 
 variable "catch_timeout_message" {
-  description = "Specify to controller, enable the mechanism to catch timeout message we have during BV"
+  description = "Enable the mechanism to catch the timeout message shown by a server overloaded"
   default     = false
 }
 

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -762,6 +762,11 @@ variable "no_mirror" {
   default     = false
 }
 
+variable "catch_timeout_message" {
+  description = "Specify to controller, enable the mechanism to catch timeout message we have during BV"
+  default     = false
+}
+
 variable "is_using_paygo_server" {
   description = "Specify to controller that server image is a paygo image"
   default     = false

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -117,6 +117,7 @@ export PROVIDER="{{ grains.get('provider') }}"
 {% if 'build_image' not in grains.get('product_version') | default('', true) %}export IS_USING_BUILD_IMAGE="{{ grains.get('is_using_build_image') }}" {% endif %}
 export IS_USING_PAYGO_SERVER="{{ grains.get('is_using_paygo_server') }}"
 export IS_USING_SCC_REPOSITORIES="{{ grains.get('is_using_scc_repositories') }}"
+export CATCH_TIMEOUT_MESSAGE="{{ grains.get('catch_timeout_message') }}"
 export SERVER_INSTANCE_ID="{{ grains.get('server_instance_id') }}"
 
 #### Generate certificates for Google Chrome


### PR DESCRIPTION
## What does this PR 

During build validation, we have server instability when bootstrapping the clients in parallel but also when running the smoke tests in parallel. 
To manage this situation and avoid having to run those stages manually, we added a mechanism in the testsuite to catch those timeouts and reload the page when possible.
This mechanism is now optional and is disable by default

This PR add the possibility to enable the catch timeout mechanism during CI deployment.

It creates a new variable used in the controller bashrc to enable the catch timeout mechanism.