### PR TITLE
We want predictable IPv6 addresses: disable privacy

### DIFF
--- a/salt/default/network.sls
+++ b/salt/default/network.sls
@@ -17,6 +17,11 @@ ipv6_accept_ra_{{ iface }}:
     - name: net.ipv6.conf.{{ iface }}.accept_ra
     - value: 2
 {% endif %}
+{% if grains['osfullname'] == 'SLE Micro' %}
+avoid_network_manager_messing_up_{{ iface }}:
+  cmd.run:
+    - name: nmcli device modify {{ iface }} ipv6.addr-gen-mode eui64
+{% endif %}
 {% endfor %}
 
 {% else %}


### PR DESCRIPTION
## What does this PR change?

SLE Micro uses Network Manager, and Network manager enables IPv6 privacy by default.

