### PR TITLE
Add `product_version` to cont. server validation

### DIFF
--- a/.github/workflows/ci-validation/salt-server-containerized-validation
+++ b/.github/workflows/ci-validation/salt-server-containerized-validation
@@ -18,6 +18,7 @@ osrelease: '15.5'
 osrelease_info: [15, 5]
 
 hostname: sumaform-test-server
+product_version: head
 install_salt_bundle: true
 gpg_keys: ['testkey.pub']
 domain: tf.local


### PR DESCRIPTION
## What does this PR change?

Add the `product_version` grain to the containerized server tests. We also have this defined in the normal server tests.

 Necessary for e.g. https://github.com/uyuni-project/sumaform/pull/1475
