### PR TITLE
Support cloud-init on slemicro55o for not containerized servers

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -45,7 +45,6 @@ locals {
     slemicro52-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_52/SUSE-MicroOS.x86_64-sumaform.qcow2"
     slemicro53-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_53/SLE-Micro.x86_64-sumaform.qcow2"
     slemicro54-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_54/SLE-Micro.x86_64-sumaform.qcow2"
-    slemicro55-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_55/SLE-Micro.x86_64-sumaform.qcow2"
     slemicro55o              = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_55/SLE-Micro.x86_64-sumaform.qcow2"
   }
   pool               = lookup(var.provider_settings, "pool", "default")

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -341,15 +341,16 @@ runcmd:
 %{ endif }
 
 %{ if image == "slemicro55o" }
-%{ if container_server }
 zypper:
   repos:
+%{ if container_server }
     - id: container_tools_repo
       name: container_tools_repo
       baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Head/SLE_15_SP5/
       enabled: 1
       autorefresh: 1
       gpgcheck: false
+%{ endif }
     - id: ca_suse
       name: ca_suse
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP5/
@@ -390,7 +391,10 @@ runcmd:
   # Packages needed for the testsuite
   - [ transactional-update, --continue, --non-interactive, pkg, install, andromeda-dummy, milkyway-dummy, virgo-dummy, wget, timezone, aaa_base-extras, ca-certificates ]
 %{ endif }
-  - [ transactional-update, --continue, --non-interactive, pkg, install, mgrctl, mgradm, netavark, aardvark-dns, ca-certificates-suse, qemu-guest-agent, salt-minion, avahi ]
+%{ if container_server }
+  - [ transactional-update, --continue, --non-interactive, pkg, install, mgrctl, mgradm, netavark, aardvark-dns, ca-certificates-suse ]
+%{ endif }
+  - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, salt-minion, avahi ]
   - [ reboot ]
 %{ endif }
 %{ endif }

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -243,7 +243,7 @@ module "slemicro-minion" {
   quantity = contains(local.hosts, "slemicro-minion") ? 1 : 0
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "slemicro-minion", "slemicro55-ign")
+  image              = lookup(local.images, "slemicro-minion", "slemicro55o")
   name               = lookup(local.names, "slemicro-minion", "min-slemicro5")
 
   server_configuration = local.minimal_configuration


### PR DESCRIPTION
## What does this PR change?

This PR refactor the cloud-init support for slemicro5.5, to be able to deploy it as a regular minion, instead of a containerized server.
It also removed an entry in the list of images, as we were duplicating the URL, and when deploying a sle micro 5.5 minion with `slemicro55-ign`, it seems there was some error in the image and we did not have the repositories in place.