### PR TITLE
change slemicro55 image name

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -45,7 +45,7 @@ locals {
     slemicro52-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_52/SUSE-MicroOS.x86_64-sumaform.qcow2"
     slemicro53-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_53/SLE-Micro.x86_64-sumaform.qcow2"
     slemicro54-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_54/SLE-Micro.x86_64-sumaform.qcow2"
-    slemicro55o              = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_55/SLE-Micro.x86_64-sumaform.qcow2"
+    slemicro55              = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_55/SLE-Micro.x86_64-sumaform.qcow2"
   }
   pool               = lookup(var.provider_settings, "pool", "default")
   network_name       = lookup(var.provider_settings, "network_name", "default")

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -340,7 +340,7 @@ runcmd:
   - "systemctl start 'qemu-ga@virtio\\x2dports-org.qemu.guest_agent.0'"
 %{ endif }
 
-%{ if image == "slemicro55o" }
+%{ if image == "slemicro55" }
 zypper:
   repos:
 %{ if container_server }

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -243,7 +243,7 @@ module "slemicro-minion" {
   quantity = contains(local.hosts, "slemicro-minion") ? 1 : 0
   base_configuration = module.base.configuration
   product_version    = var.product_version
-  image              = lookup(local.images, "slemicro-minion", "slemicro55o")
+  image              = lookup(local.images, "slemicro-minion", "slemicro55")
   name               = lookup(local.names, "slemicro-minion", "min-slemicro5")
 
   server_configuration = local.minimal_configuration

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -2,7 +2,7 @@
 
 variable "images" {
   default = {
-    "head"           = "slemicro55o"
+    "head"           = "slemicro55"
     "uyuni-master"   = "opensuse155o"
     "uyuni-released" = "opensuse155o"
     "uyuni-pr"       = "opensuse155o"


### PR DESCRIPTION
## What does this PR change?

Libvirt images should only have the sufix "o" for official images. Since this new sle-micro 5.5 image is not an official one but instead made in Sumaform project we should not use the suffix.

An image with this name is reserved for when the official image is our with the cloud-init available.