### PR TITLE
Fix: Empty `require:` due to if statement

### DIFF
--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -6,8 +6,8 @@ include:
 minima_download:
   cmd.run:
     - name: mgrctl exec 'curl --output-dir /root -OL https://github.com/uyuni-project/minima/releases/download/v0.4/minima-linux-amd64.tar.gz'
-    - require:
 {% if grains['osfullname'] != 'SLE Micro' %}
+    - require:
       - pkg: uyuni-tools
 {% endif %}
 


### PR DESCRIPTION
## What does this PR change?

Fix the empty `require:` statement.
