### PR TITLE
Add symlink to rhn configuration to make it compatible with testsuite

### DIFF
--- a/salt/server_containerized/init.sls
+++ b/salt/server_containerized/init.sls
@@ -6,3 +6,10 @@ include:
   - server_containerized.initial_content
   - server_containerized.testsuite
   - server_containerized.large_deployment
+
+rhn_symlink:
+  file.symlink:
+    - name: /etc/rhn
+    - target: /var/lib/containers/storage/volumes/etc-rhn/_data/
+    - makedirs : True
+    - force: True


### PR DESCRIPTION
## What does this PR change?

Add a symlink to point to rhn configuration to make it compatible with our hostname check in uyuni
https://github.com/uyuni-project/uyuni/blob/2187c60a36cf054abc53f64aa17a6e7e16433e58/testsuite/features/support/twopence_init.rb#L48C1-L48C91