### PR TITLE
Make IPv6 changes to SLE micro permanent

### DIFF
--- a/salt/default/network.sls
+++ b/salt/default/network.sls
@@ -22,7 +22,9 @@ ipv6_accept_ra_{{ iface }}:
 {% if (grains['osfullname'] == 'SLE Micro') and (grains['osrelease'] != '5.1') and (grains['osrelease'] != '5.2') %}
 avoid_network_manager_messing_up:
   cmd.run:
-    - name: nmcli device modify eth0 ipv6.addr-gen-mode eui64
+    - name: |
+        nmcli connection modify "Wired connection 1" ipv6.addr-gen-mode eui64
+        nmcli device modify eth0 ipv6.addr-gen-mode eui64
 {% endif %}
 
 {% else %}


### PR DESCRIPTION
## What does this PR change?

Let IPv6 changes to SLE micro survive a reboot.

In Network Manager world, `nmcli device` is apparently transient, while `nmcli connection` seems to be permanent.
