### PR TITLE
Remove duplicate repository

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -362,12 +362,6 @@ zypper:
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-    - id: test_packages_pool
-      name: test_packages_pool
-      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/
-      enabled: 1
-      autorefresh: 1
-      gpgcheck: false
 %{ endif }
     - id: ca_suse
       name: ca_suse


### PR DESCRIPTION
## What does this PR change?

Fix repository installed twice:
```
[2024-02-16T18:19:45.729Z] module.slemicro55-sshminion.module.sshminion.module.host.null_resource.provisioning[0] (remote-exec):
     Comment: Failed to configure repo 'test_repo_rpm_pool': Repository 'test_repo_rpm_pool' already exists as 'test_packages_pool'.
```
