### PR TITLE
Containerization fixes found in 5.0 BV

### DIFF
--- a/salt/default/pkgs.sls
+++ b/salt/default/pkgs.sls
@@ -3,11 +3,18 @@ include:
 
 {% if grains['additional_packages'] %}
 install_additional_packages:
+  {% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SLE Micro'  %}
+  cmd.run:
+{% for package in grains['additional_packages'] %}
+    - name: transactional-update -c -n pkg in {{ package }}
+{% endfor %}
+  {% else %}
   pkg.latest:
     - pkgs:
 {% for package in grains['additional_packages'] %}
       - {{ package }}
 {% endfor %}
+  {% endif %}
     {% if 'paygo' not in grains.get('product_version', '') %}
     - require:
       - sls: repos

--- a/salt/server_containerized/large_deployment.sls
+++ b/salt/server_containerized/large_deployment.sls
@@ -9,13 +9,13 @@ large_deployment_increase_tasko_parallel_threads:
   cmd.run:
     - name: mgrctl exec 'echo "taskomatic.com.redhat.rhn.taskomatic.task.MinionActionExecutor.parallel_threads = 3" >> /etc/rhn/rhn.conf'
     - require:
-      - pkg: uyuni-tools
+      - file: /usr/bin/mgrctl
 
 large_deployment_increase_hibernate_max_connections:
   cmd.run:
     - name: mgrctl exec 'echo "hibernate.c3p0.max_size = 50" >> /etc/rhn/rhn.conf'
     - require:
-      - pkg: uyuni-tools
+      - file: /usr/bin/mgrctl
 
 large_deployment_tune_tomcat_stylesheet_host:
   file.managed:
@@ -46,13 +46,13 @@ large_deployment_increase_database_max_connections:
   cmd.run:
     - name: mgrctl exec 'sed -i "s/max_connections = (.*)/max_connections = 450/" /var/lib/pgsql/data/postgresql.conf'
     - require:
-      - pkg: uyuni-tools
+      - file: /usr/bin/mgrctl
 
 large_deployment_increase_database_work_memory:
   cmd.run:
     - name: mgrctl exec 'sed -i "s/work_mem = (.*)/work_mem = 10MB/" /var/lib/pgsql/data/postgresql.conf'
     - require:
-      - pkg: uyuni-tools
+      - file: /usr/bin/mgrctl
 
 large_deployment_postgresql_restart:
   cmd.run:


### PR DESCRIPTION
## What does this PR change?

This fixes

- `large deployments` requirements on the containerized server. This is needed because of the following change: https://github.com/uyuni-project/sumaform/commit/37393f84eeb4a64d86a6b22a925d30ed9665618f#diff-af6a4441405654e0b2b396bf711aa3b290fe1c0bcba22c4489f79ba5f9e21b53: 
```diff
+ {% if grains['osfullname'] != 'SLE Micro' %}
uyuni-tools:
  pkg.installed:
    - pkgs:
      - mgradm
      - mgrctl
+ {% endif %}
 ```
in
https://github.com/uyuni-project/sumaform/blob/2ee9b10275c8b7609be7a985a86342e9f6f93745/salt/server_containerized/install_common.sls#L3-L9
   ![image](https://github.com/uyuni-project/sumaform/assets/12104291/75402cce-5346-4835-b085-61b221c35af7)
  ![image](https://github.com/uyuni-project/sumaform/assets/12104291/210432e5-0f9d-4fca-ac8b-02490fbb2fea)
```bash
suma-bv-50-srv:~ # rpm -q uyuni-tools
package uyuni-tools is not installed
uma-bv-50-srv:~ # which mgradm
/usr/bin/mgradm
suma-bv-50-srv:~ # rpm -qf /usr/bin/mgradm
mgradm-0.1.4-150550.1.1.develHead.x86_64
uma-bv-50-srv:~ # zypper info mgradm
Loading repository data...
Reading installed packages...


Information for package mgradm:
-------------------------------
Repository     : @System
Name           : mgradm
Version        : 0.1.4-150550.1.1.develHead
Arch           : x86_64
Vendor         : obs://build.suse.de/Devel:Galaxy
Support Level  : unknown
Installed Size : 8.7 MiB
Installed      : Yes
Status         : up-to-date
Source package : uyuni-tools-0.1.4-150550.1.1.develHead.src
Upstream URL   : https://github.com/uyuni-project/uyuni-tools
Summary        : Command line tool to install and update Uyuni
Description    :
    mgradm is a convenient tool to install and update Uyuni components as containers running
    either on Podman or a Kubernetes cluster.

suma-bv-50-srv:~ # zypper se mgradm
Loading repository data...
Reading installed packages...

S  | Name                   | Summary                                       | Type
---+------------------------+-----------------------------------------------+--------
i+ | mgradm                 | Command line tool to install and update Uyuni | package
   | mgradm-bash-completion | Bash Completion for mgradm                    | package
   | mgradm-zsh-completion  | Zsh Completion for mgradm                     | package

    Note: For an extended search including not yet activated remote resources please use 'zypper
    search-packages'.
suma-bv-50-srv:~ # zypper se mgrctl
Loading repository data...
Reading installed packages...

S  | Name                   | Summary                                                     | Type
---+------------------------+-------------------------------------------------------------+--------
i+ | mgrctl                 | Command line tool to perform day-to-day operations on Uyuni | package
   | mgrctl-bash-completion | Bash Completion for mgrctl                                  | package
   | mgrctl-zsh-completion  | Zsh Completion for mgrctl                                   | package

    Note: For an extended search including not yet activated remote resources please use 'zypper
    search-packages'.
```
-  Fix SLE Micro issues when defining `additional_packages` as variable in the `main.tf`.
  ![image](https://github.com/uyuni-project/sumaform/assets/12104291/f6e3e4f3-0b9e-4b40-b898-533ac1bb1227)

https://github.com/uyuni-project/sumaform/blob/2ee9b10275c8b7609be7a985a86342e9f6f93745/salt/default/pkgs.sls#L5-L10
does not work for transactional systems. The code above fixes this. However, SLE Micro still needs a reboot after that.


