### PR TITLE
Jinja booleans should be lower case

### DIFF
--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -13,7 +13,7 @@ include:
   - default.testsuite
   {% endif %}
 
-{% if grains.get('use_os_released_updates') | default(False, true) %}
+{% if grains.get('use_os_released_updates') | default(false, true) %}
 {% if not grains['osfullname'] == 'SLE Micro' %}
 update_packages:
   pkg.uptodate:


### PR DESCRIPTION
## What does this PR change?

Conform to best practices.

According to https://tedboy.github.io/jinja2/templ13.html
```
The special constants true, false, and none are indeed lowercase. Because that caused confusion
in the past, (True used to expand to an undefined variable that was considered false), all three can
now also be written in title case (True, False, and None). However, for consistency, (all Jinja
identifiers are lowercase) you should use the lowercase versions.
```
