### PR TITLE
Add SLE-Module-Containers repos to Salt testenv nodes

### DIFF
--- a/salt/salt_testenv/init.sls
+++ b/salt/salt_testenv/init.sls
@@ -24,6 +24,16 @@ sle_module_hpc_repo_updates:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-HPC/{{ repo_path }}/x86_64/update/
     - refresh: True
+
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/{{ repo_path }}/x86_64/product/
+    - refresh: True
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/{{ repo_path }}/x86_64/update/
+    - refresh: True
 {% endif %}
 
 {% if grains['osrelease_info'][1] >= 3 %}


### PR DESCRIPTION
## What does this PR change?

This PR just includes the `SLE-Module-Containers` repositories when deploying Salt testenv nodes on SLE15[SP?] images, as we need as source for `docker` package (which is now a dependency for `python3-salt-testsuite`).

This should fix the issue we see for Salt Shaker in our internal CI: https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-products-next-sles15sp5/61/console
