### PR TITLE
Fix cloud init for slemicro 5.5 when container_proxy

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -400,10 +400,9 @@ runcmd:
 %{ endif }
 %{ if container_proxy }
   - [ transactional-update, --continue, --non-interactive, pkg, install, mgrpxy, ca-certificates-suse ]
-%{ else }
+%{ endif }
   - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, salt-minion, avahi ]
   - [ reboot ]
-%{ endif }
 %{ endif }
 
 %{ if image == "ubuntu2004o" }


### PR DESCRIPTION
## What does this PR change?

It was a typo in cloud-init for sle micro 5.5, when container_proxy.
So, we were not installing all that was necessary.
