### PR TITLE
BV: Fix containerized server issues

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -387,7 +387,7 @@ runcmd:
   - [ zypper, mr, -a, -g ]
 %{ if testsuite }
   # Packages needed for the testsuite
-  - [ transactional-update, --continue, --non-interactive, pkg, install, andromeda-dummy, milkyway-dummy, virgo-dummy, wget, timezone, aaa_base-extras, ca-certificates ]
+  - [ transactional-update, --continue, --non-interactive, pkg, install, wget, timezone, aaa_base-extras, ca-certificates ]
 %{ endif }
 %{ if container_server }
   - [ transactional-update, --continue, --non-interactive, pkg, install, mgrctl, mgradm, netavark, aardvark-dns, ca-certificates-suse ]

--- a/salt/server_containerized/large_deployment.sls
+++ b/salt/server_containerized/large_deployment.sls
@@ -8,14 +8,18 @@ include:
 large_deployment_increase_tasko_parallel_threads:
   cmd.run:
     - name: mgrctl exec 'echo "taskomatic.com.redhat.rhn.taskomatic.task.MinionActionExecutor.parallel_threads = 3" >> /etc/rhn/rhn.conf'
+{% if grains['osfullname'] != 'SLE Micro' %}
     - require:
-      - file: /usr/bin/mgrctl
+      - pkg: uyuni-tools
+{% endif %}
 
 large_deployment_increase_hibernate_max_connections:
   cmd.run:
     - name: mgrctl exec 'echo "hibernate.c3p0.max_size = 50" >> /etc/rhn/rhn.conf'
+{% if grains['osfullname'] != 'SLE Micro' %}
     - require:
-      - file: /usr/bin/mgrctl
+      - pkg: uyuni-tools
+{% endif %}
 
 large_deployment_tune_tomcat_stylesheet_host:
   file.managed:
@@ -45,14 +49,18 @@ large_deployment_tomcat_restart:
 large_deployment_increase_database_max_connections:
   cmd.run:
     - name: mgrctl exec 'sed -i "s/max_connections = (.*)/max_connections = 450/" /var/lib/pgsql/data/postgresql.conf'
+{% if grains['osfullname'] != 'SLE Micro' %}
     - require:
-      - file: /usr/bin/mgrctl
+      - pkg: uyuni-tools
+{% endif %}
 
 large_deployment_increase_database_work_memory:
   cmd.run:
     - name: mgrctl exec 'sed -i "s/work_mem = (.*)/work_mem = 10MB/" /var/lib/pgsql/data/postgresql.conf'
+{% if grains['osfullname'] != 'SLE Micro' %}
     - require:
-      - file: /usr/bin/mgrctl
+      - pkg: uyuni-tools
+{% endif %}
 
 large_deployment_postgresql_restart:
   cmd.run:

--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -110,43 +110,13 @@ repo_key_import:
       - cmd: galaxy_key_copy
 {% endif %}
 
-testing_overlay_devel_repo:
-  cmd.run:
-{%- if grains.get('product_version') | default('', true) in ['uyuni-master', 'uyuni-pr', 'uyuni-released'] %}
-    - name: 'mgrctl exec "zypper -n ar -f -p 96 http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/ testing_overlay_devel_repo"'
-{%- else %}
-    - name: 'mgrctl exec "zypper -n ar -f -p 96 http://{{ grains.get("mirror") | default("download.suse.de", true) }}//ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Testing-Overlay-4.3-POOL-x86_64-Media1/ testing_overlay_devel_repo"'
-{%- endif %}
-    - unless: mgrctl exec "zypper lr" | grep testing_overlay_devel_repo
-    - require:
-{% if grains['osfullname'] != 'SLE Micro' %}
-      - pkg: uyuni-tools
-{% endif %}
-      - cmd: repo_key_import
-
-# Allowing downgrade of salt-ssh as it has sometimes a slightly older version than what is in the image
-{% if 'build_image' not in grains.get('product_version') | default('', true) %}
-saltssh_package:
-   cmd.run:
-    - name: mgrctl exec "zypper -n in --allow-downgrade salt-ssh"
-    - require:
-{% if grains['osfullname'] != 'SLE Micro' %}
-      - pkg: uyuni-tools
-{% endif %}
-      - cmd: testing_overlay_devel_repo
-{% endif %}
-
 testsuite_packages:
   cmd.run:
     - name: mgrctl exec "zypper -n in iputils expect wget OpenIPMI"
-    - require:
-{% if 'build_image' not in grains.get('product_version') | default('', true) %}
-      - cmd: saltssh_package
-{% endif %}
 {% if grains['osfullname'] != 'SLE Micro' %}
+    - require:
       - pkg: uyuni-tools
 {% endif %}
-      - cmd: testing_overlay_devel_repo
 
 {% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}


### PR DESCRIPTION
## What does this PR change?

- [1.](https://github.com/uyuni-project/sumaform/pull/1513/commits/2616bd9e539722629184c5d4424ee693a060e92b) Since we use cloud-init to install the `uyuni-tools`, we can assume that they are already installed for SLE Micro and only require them for others distros. Partially reverts https://github.com/uyuni-project/sumaform/pull/1509. Cedric did the same with https://github.com/uyuni-project/sumaform/commit/37393f84eeb4a64d86a6b22a925d30ed9665618f
  ![image](https://github.com/uyuni-project/sumaform/assets/12104291/e1bbaf68-2cd4-4a3e-a39a-27034a28ee37)
-[2.](https://github.com/uyuni-project/sumaform/pull/1513/commits/5d6eb33a99f62e7c74b690c034e557c4309319a6) we try to install the `*-dummy` test packages via cloud-init, but do not add the repository for them
```bash
transactional-update 4.1.6 started
Options: --continue --non-interactive pkg install andromeda-dummy milkyway-dummy virgo-dummy wget timezone aaa_base-extras ca-certificates
(...)
2024-02-26 12:47:21 Options: callext 3 zypper -R {} install -y --auto-agree-with-product-licenses andromeda-dummy milkyway-dummy virgo-dummy wget timezone aaa_base-extras ca-certificates
2024-02-26 12:47:22 Executing `zypper -R /tmp/transactional-update-xKAasp install -y --auto-agree-with-product-licenses andromeda-dummy milkyway-dummy virgo-dummy wget timezone aaa_base-extr
as ca-certificates`:
(...)
No update candidate for 'wget-1.20.3-150000.3.15.1.x86_64'. The highest available version is already installed.
'andromeda-dummy' not found in package names. Trying capabilities.
No provider of 'andromeda-dummy' found.
'milkyway-dummy' not found in package names. Trying capabilities.
No provider of 'milkyway-dummy' found.
'virgo-dummy' not found in package names. Trying capabilities.
No provider of 'virgo-dummy' found.
2024-02-26 12:47:23 Application returned with exit status 104.
ERROR: zypper install on /.snapshots/3/snapshot failed with exit code 104!
Use '--interactive' for manual problem resolution.
Removing snapshot #3...
```
https://github.com/uyuni-project/sumaform/blob/70cc929fa249f3ca9bc65498b8c64ee96c3bddef/backend_modules/libvirt/host/user_data.yaml#L343-L400
With adding the repo, do not see the error and the packages will get installed correctly:

```bash
  aaa_base-extras andromeda-dummy milkyway-dummy virgo-dummy

The following 3 packages have no support information from their vendor:
  andromeda-dummy milkyway-dummy virgo-dummy

4 new packages to install.
Overall download size: 87.1 KiB. Already cached: 0 B. After the operation, additional 89.8 KiB will be used.
Continue? [y/n/v/...? shows all options] (y): y

Checking for file conflicts: [...done]
Warning: 4 packages had to be excluded from file conflicts check because they are not yet downloaded.

    Note: Checking for file conflicts requires not installed packages to be downloaded in advance in
    order to access their file lists. See option '--download-in-advance / --dry-run --download-only'
    in the zypper manual page for details.

Retrieving: aaa_base-extras-84.87+git20180409.04c9dae-150300.10.3.1.x86_64 (os_pool_repo) (1/4),  45.2 KiB
Retrieving: aaa_base-extras-84.87+git20180409.04c9dae-150300.10.3.1.x86_64.rpm [...done (45.2 KiB/s)]
(1/4) Installing: aaa_base-extras-84.87+git20180409.04c9dae-150300.10.3.1.x86_64 [..
Updating /etc/sysconfig/backup ...
Running in chroot, ignoring command 'daemon-reload'
Created symlink /etc/systemd/system/timers.target.wants/backup-rpmdb.timer -> /usr/lib/systemd/system/backup-rpmdb.timer.
Created symlink /etc/systemd/system/timers.target.wants/backup-sysconfig.timer -> /usr/lib/systemd/system/backup-sysconfig.timer.
Created symlink /etc/systemd/system/timers.target.wants/check-battery.timer -> /usr/lib/systemd/system/check-battery.timer.
done]
Retrieving: andromeda-dummy-1.0-1.1.noarch (test_pool_repo) (2/4),  13.8 KiB
Retrieving: andromeda-dummy-1.0-1.1.noarch.rpm [..done (12.3 KiB/s)]
(2/4) Installing: andromeda-dummy-1.0-1.1.noarch [..done]
Retrieving: milkyway-dummy-1.0-1.1.x86_64 (test_pool_repo) (3/4),  14.4 KiB
Retrieving: milkyway-dummy-1.0-1.1.x86_64.rpm [.done]
(3/4) Installing: milkyway-dummy-1.0-1.1.x86_64 [..done]
Retrieving: virgo-dummy-1.0-1.1.noarch (test_pool_repo) (4/4),  13.8 KiB
Retrieving: virgo-dummy-1.0-1.1.noarch.rpm [.done]
(4/4) Installing: virgo-dummy-1.0-1.1.noarch [..done]
2024-02-27 13:19:01 Application returned with exit status 0.
2024-02-27 13:19:02 Transaction completed.
Trying to rebuild kdump initrd
2024-02-27 13:19:02 tukit 4.1.6 started
2024-02-27 13:19:02 Options: close 3
2024-02-27 13:19:03 New default snapshot is #3 (/.snapshots/3/snapshot).
2024-02-27 13:19:03 Transaction completed
```
- [3.](https://github.com/uyuni-project/sumaform/pull/1513/commits/9f272b51f478c9bee6719916b3bf1e515619011c) the testing overlay in the test suite Salt state for the containerized server is not needed for container images and can be removed completely. See https://suse.slack.com/archives/C02CLBJ5RGF/p1709041956809459?thread_ts=1709038829.412329&cid=C02CLBJ5RGF
 
Furthermore, we apparently already have some of the test packages available in our [SLE Micro 5.5 image](https://build.opensuse.org/package/show/systemsmanagement:sumaform:images:microos/SLE-MicroOS55). But this is not addressed in this PR.
```bash
transactional-update 4.1.6 started
Options: --continue --non-interactive pkg install andromeda-dummy milkyway-dummy virgo-dummy wget timezone aaa_base-extras ca-certificates
(...)
2024-02-26 12:47:21 tukit 4.1.6 started
2024-02-26 12:47:21 Options: callext 3 zypper -R {} install -y --auto-agree-with-product-licenses andromeda-dummy milkyway-dummy virgo-dummy wget timezone aaa_base-extras ca-certificates
2024-02-26 12:47:22 Executing `zypper -R /tmp/transactional-update-xKAasp install -y --auto-agree-with-product-licenses andromeda-dummy milkyway-dummy virgo-dummy wget timezone aaa_base-extr
as ca-certificates`:
Loading repository data...
Reading installed packages...
'ca-certificates' is already installed.
No update candidate for 'ca-certificates-2+git20210309.21162a6-2.1.noarch'. The highest available version is already installed.
'timezone' is already installed.
No update candidate for 'timezone-2023c-150000.75.23.1.x86_64'. The highest available version is already installed.
'wget' is already installed.
No update candidate for 'wget-1.20.3-150000.3.15.1.x86_64'. The highest available version is already installed.
(...)
2024-02-26 12:47:23 Application returned with exit status 104.
ERROR: zypper install on /.snapshots/3/snapshot failed with exit code 104!
Use '--interactive' for manual problem resolution.
Removing snapshot #3...
```
  ![image](https://github.com/uyuni-project/sumaform/assets/12104291/e43103ed-50c2-4ca0-b116-78078f1351d9)
