### PR TITLE
Install salt-bundle in sle micro 5.5 on cloud-init stage

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -395,7 +395,11 @@ runcmd:
 %{ if container_proxy }
   - [ transactional-update, --continue, --non-interactive, pkg, install, mgrpxy, ca-certificates-suse ]
 %{ endif }
+%{ if install_salt_bundle }
+  - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, venv-salt-minion, avahi ]
+%{ else }
   - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, salt-minion, avahi ]
+%{ endif }
   - [ reboot ]
 %{ endif }
 


### PR DESCRIPTION
## What does this PR change?

If we have the grain **install_salt_bundle** we expect to have installed the salt bundle during the clound-init phase of the sle micro 5.5 deployment.