### PR TITLE
Install mgrctl when we deploy a containerized proxy

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -393,7 +393,7 @@ runcmd:
   - [ transactional-update, --continue, --non-interactive, pkg, install, mgrctl, mgradm, netavark, aardvark-dns, ca-certificates-suse ]
 %{ endif }
 %{ if container_proxy }
-  - [ transactional-update, --continue, --non-interactive, pkg, install, mgrpxy, ca-certificates-suse ]
+  - [ transactional-update, --continue, --non-interactive, pkg, install, mgrctl, mgrpxy, ca-certificates-suse ]
 %{ endif }
 %{ if install_salt_bundle }
   - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, venv-salt-minion, avahi ]


### PR DESCRIPTION
## What does this PR change?

Install mgrctl when we deploy a containerized proxy.
We need it in the testsuite in order to onboard a proxy, as we will be using mgrctl cp server:<path_proxy_config>