### PR TITLE
Install mgrtools in proxy containerized for Uyuni

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -112,7 +112,7 @@ packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
 %{ endif }
 %{ endif }
 
-%{ if image == "opensuse154o" || image == "opensuse154-ci-pro" || image == "opensuse154-ci-pr-client" || image == "opensuse155-ci-pro"}
+%{ if image == "opensuse154o" || image == "opensuse154-ci-pro" || image == "opensuse154-ci-pr-client" || image == "opensuse155o" || image == "opensuse155-ci-pro"}
 zypper:
   repos:
     - id: tools_pool_repo

--- a/salt/proxy_containerized/init.sls
+++ b/salt/proxy_containerized/init.sls
@@ -54,6 +54,16 @@ env_var_bashrc_registry_proxy_httpd_image:
         echo "export UYUNI_IMAGES_LOCATION={{ container_repository }}" >> /root/.bashrc
         source /root/.bashrc
 
+{% if 'Micro' not in grains['osfullname'] %}
+install_mgr_tools:
+  pkg.installed:
+    - pkgs:
+      - podman
+      - mgrpxy
+      - mgrctl
+      - ca-certificates-suse
+{% endif %}
+
 # This will only work if the proxy is part of the cucumber_testsuite module, otherwise the server might not be ready
 {% if grains.get('auto_configure') and grains.get('testsuite') and grains.get('first_user_present') %}
 generate_configuration_file_from_server:


### PR DESCRIPTION
## What does this PR change?

Install mgrtools in proxy containerized for Uyuni.
Until we move our Uyuni containerized proxy to use Leap Micro 5.5, this fix change will unblock us by installing mgrtools during the salt state.