### PR TITLE
DHCP and DNS host

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -396,9 +396,9 @@ module "minion" {
 
 If you will be adding Windows minions, you should disable Avahi in sumaform, as for historical reasons mDNS and resolution of .local and .lan is broken and will not work. Do not trust any source saying it works on Windows 10 (there are lots of "ifs" and "buts"), or can be fixed with Bonjour Printing Services (not for .local).
 
-## Additional network and SUSE Manager for Retail
+## Additional network
 
-You may get an additional, isolated, network, with neither DHCP nor DNS by specifying for example:
+You may get an additional, isolated, network by specifying for example:
 
 ```hcl
 module "base" {
@@ -412,7 +412,7 @@ module "base" {
 
 This will create a network named `private`, with your prefix in front of the name (e.g. `prefix-private`).
 
-You may use that additional network to test SUSE Manager for Retail with the test suite or manually.
+You may use that additional network to test Cobbler or SUSE Manager for Retail with the test suite or manually.
 
 For each VM, you can decide whether it connects to the base network and/or to the additional network by specifying:
 
@@ -424,7 +424,38 @@ connect_to_additional_network = true
 When there are two connections, the first network interface `eth0` gets connected to base network, and the second interface `eth1` gets connected to the additional network.
 When there is only one connection, the card is always `eth0`, no matter to which network it is connected.
 
-Some modules have preset defaults: SUSE Manager/Uyuni Servers and the testsuite controller connect only to the base network, while SUSE Manager/Uyuni Proxies and clients or minions connect to both networks.
+Some modules have preset defaults: SUSE Manager/Uyuni servers and the testsuite controller connect only to the base network, while SUSE Manager/Uyuni proxies and clients or minions connect to both networks.
+
+DHCP and DNS services for the additional network may be ensured by the proxy. Alternatively, you can install a DHCP and DNS server into the additional network by declaring:
+
+```hcl
+module "cucumber_testsuite" {
+  ...
+  host_settings = {
+    ...
+    dhcp-dns = {
+      name = "dhcp-dns"
+      image = "opensuse155o"
+    }
+    ...
+  }
+}
+```
+
+from the test suite module, or:
+
+```hcl
+module "dhcp-dns" {
+  source = "./modules/dhcp_dns"
+
+  name = "dhcp-dns"
+  image = "opensuse155o"
+  terminals = [ module.sles12sp5-terminal.configuration module.sles15sp4-terminal.configuration ]
+  first_terminal_ip = 5
+}
+```
+
+in a more direct manner.
 
 ## Custom SSH keys
 

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -424,7 +424,7 @@ connect_to_additional_network = true
 When there are two connections, the first network interface `eth0` gets connected to base network, and the second interface `eth1` gets connected to the additional network.
 When there is only one connection, the card is always `eth0`, no matter to which network it is connected.
 
-Some modules have preset defaults: SUSE Manager/Uyuni servers and the testsuite controller connect only to the base network, while SUSE Manager/Uyuni proxies and clients or minions connect to both networks.
+Some modules have preset defaults: SUSE Manager/Uyuni servers and the testsuite controller connect only to the base network, while SUSE Manager/Uyuni proxies connect to both networks.
 
 DHCP and DNS services for the additional network may be ensured by the proxy. Alternatively, you can install a DHCP and DNS server into the additional network by declaring:
 

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -43,6 +43,7 @@ locals {
     contains(var.roles, "pxe_boot") ? { xslt = templatefile("${path.module}/pxe_boot.xsl", { manufacturer = local.manufacturer, product = local.product }) } : {})
   cloud_init = length(regexall("o$", var.image)) > 0
   ignition = length(regexall("-ign$", var.image)) > 0
+  add_net = var.base_configuration["additional_network"] != null ? slice(split(".", var.base_configuration["additional_network"]), 0, 3) : [ "192", "168", "0" ]
 }
 
 data "template_file" "user_data" {
@@ -62,7 +63,9 @@ data "template_file" "user_data" {
 data "template_file" "network_config" {
   template = file("${path.module}/network_config.yaml")
   vars = {
-    image = var.image
+    image              = var.image
+    dhcp_dns           = contains(var.roles, "dhcp_dns")
+    dhcp_dns_address   = join(".", concat(local.add_net, [ "53" ]))
   }
 }
 

--- a/backend_modules/libvirt/host/network_config.yaml
+++ b/backend_modules/libvirt/host/network_config.yaml
@@ -6,7 +6,7 @@ network:
   ethernets:
     ens3:
       dhcp4: true
-%{ else  }
+%{ else }
 network:
   version: 1
   config:
@@ -17,5 +17,10 @@ network:
     name: eth0
 %{ endif }
     subnets:
+%{ if dhcp_dns }
+      - type: static
+        address: ${dhcp_dns_address}
+%{ else }
       - type: dhcp
+%{ endif }
 %{ endif }

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -34,5 +34,7 @@ output "configuration" {
     use_shared_resources     = var.use_shared_resources
     testsuite                = var.testsuite
     use_eip_bastion          = var.use_eip_bastion
+    # let "additional_network" be defined even if not using libvirt:
+    additional_network       = null
   }, module.base_backend.configuration)
 }

--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -14,7 +14,7 @@ module "client" {
   ssh_key_path                  = var.ssh_key_path
   ipv6                          = var.ipv6
   connect_to_base_network       = true
-  connect_to_additional_network = true
+  connect_to_additional_network = false
   roles                         = ["client"]
   disable_firewall              = var.disable_firewall
   grains = {

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -219,6 +219,17 @@ locals {
   minimal_configuration = { hostname = contains(local.hosts, "proxy") ? local.proxy_full_name : local.server_full_name }
 }
 
+module "dhcp-dns" {
+  source             = "../dhcp_dns"
+
+  quantity           = contains(local.hosts, "dhcp-dns") ? 1 : 0
+  base_configuration = module.base.configuration
+  image              = lookup(local.images, "dhcp-dns", "opensuse155o")
+  name               = lookup(local.names, "dhcp-dns", "dhcp-dns")
+  terminals          = [ module.pxeboot-minion.configuration ]
+  first_terminal_ip  = 4
+}
+
 module "suse-client" {
   source             = "../client"
 

--- a/modules/dhcp_dns/main.tf
+++ b/modules/dhcp_dns/main.tf
@@ -1,0 +1,147 @@
+module "dhcp_dns" {
+  source = "../host"
+
+  base_configuration            = var.base_configuration
+  name                          = var.name
+  quantity                      = var.base_configuration["additional_network"] != null ? var.quantity : 0
+
+  connect_to_base_network       = false
+  connect_to_additional_network = true
+  roles                         = ["dhcp_dns"]
+  provision                     = false
+
+  image                         = var.image
+}
+
+# The DHCP and DNS server has no direct connection to the outside, so we must download the packages on its behalf
+locals {
+  add_net              = var.base_configuration["additional_network"] != null ? slice(split(".", var.base_configuration["additional_network"]), 0, 3) : [ "192", "168", "0" ]
+  prefix               = join(".", local.add_net)
+  reverse_prefix       = join(".", reverse(local.add_net))
+  resource_name_prefix = "${var.base_configuration["name_prefix"]}${var.name}"
+  zypper               = "/usr/bin/zypper --non-interactive --gpg-auto-import-keys"
+  # Currently only for openSUSE 15.5:
+  repo                 = "https://download.opensuse.org/distribution/leap/15.5/repo/oss"
+}
+
+resource "null_resource" "standalone_provisioning" {
+  connection {
+    host     = "${local.prefix}.53"
+    user     = "root"
+    password = "linux"
+    timeout  = "3m"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+      mkdir -p /tmp/dhcp-dns/var/cache/zypp/packages/repo
+      if [ -x /usr/bin/zypper ]; then
+        ${local.zypper} --root /tmp/dhcp-dns addrepo ${local.repo} offline_repo ||:
+        ${local.zypper} --root /tmp/dhcp-dns install --download-only dhcp-server bind
+      fi
+    EOT
+  }
+
+  provisioner "file" {
+    source      = "/tmp/dhcp-dns/var/cache/zypp/packages/repo"
+    destination = "/root"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo ${var.name} > /etc/hostname",
+      "hostname ${var.name}",
+      "echo 'nameserver 127.0.0.1' > /etc/resolv.conf",
+      "echo 'search example.org' >> /etc/resolv.conf",
+      "${local.zypper} addrepo dir:/root/repo offline_repo ||:",
+      "${local.zypper} install --allow-downgrade dhcp-server bind",
+      "sed -i 's!DHCPD_INTERFACE=\"\"!DHCPD_INTERFACE=\"eth0\"!' /etc/sysconfig/dhcpd",
+      "sed -i 's!# include \"/etc/named.conf.include\";!include \"/etc/named.conf.include\";!' /etc/named.conf",
+    ]
+  }
+
+  provisioner "file" {
+    content = <<EOT
+option domain-name "example.org";
+option domain-name-servers ${local.prefix}.53;
+
+subnet ${local.prefix}.0 netmask 255.255.255.0
+{
+  range ${local.prefix}.128 ${local.prefix}.253;
+  filename "boot/pxelinux.0";
+  next-server ${local.prefix}.254;
+}
+
+${join("\n", [ for index, terminal in var.terminals:
+                 format("host %s\n{\n  hardware ethernet %s;\n  fixed-address %s.%d;\n}\n",
+                        split(".", terminal["hostname"])[0],
+                        terminal["macaddr"],
+                        local.prefix,
+                        index + var.first_terminal_ip)
+             ])}
+EOT
+    destination = "/etc/dhcpd.conf"
+  }
+
+  provisioner "file" {
+    content = <<EOT
+zone "${local.reverse_prefix}.in-addr.arpa" {
+  type master;
+  file "/var/lib/named/master/db.${local.reverse_prefix}.in-addr.arpa";
+
+  notify no;
+};
+
+zone "example.org" {
+  type master;
+  file "/var/lib/named/master/db.example.org";
+
+  notify no;
+};
+EOT
+    destination = "/var/lib/named/named.conf.include"
+  }
+
+  provisioner "file"  {
+    content = <<EOT
+$ORIGIN ${local.reverse_prefix}.in-addr.arpa.
+
+@        IN SOA ${local.resource_name_prefix}.example.org. admin@example.org. (2045010101 8600 900 86000 500)
+@        IN NS  ${local.resource_name_prefix}.example.org.
+${local.resource_name_prefix}.example.org. IN A   ${local.prefix}.53
+
+53       IN PTR ${local.resource_name_prefix}.example.org.
+${join("\n", [ for index, terminal in var.terminals:
+                 format("%-8d IN PTR %s.example.org.\n",
+                        index + var.first_terminal_ip,
+                        split(".", terminal["hostname"])[0])
+             ])}
+EOT
+    destination = "/var/lib/named/master/db.1.168.192.in-addr.arpa"
+  }
+
+  provisioner "file"  {
+    content = <<EOT
+$ORIGIN example.org.
+
+@        IN SOA ${local.resource_name_prefix} admin@example.org. (2045010101 8600 900 86000 500)
+@        IN NS  ${local.resource_name_prefix}
+${local.resource_name_prefix} IN A   ${local.prefix}.53
+
+${join("\n", [ for index, terminal in var.terminals:
+                 format("%8s IN A   %s.%d\n",
+                        split(".", terminal["hostname"])[0],
+                        local.prefix,
+                        index + var.first_terminal_ip)
+             ])}
+EOT
+    destination = "/var/lib/named/master/db.example.org"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "systemctl enable --now dhcpd",
+      "systemctl enable --now named",
+    ]
+  }
+}

--- a/modules/dhcp_dns/variables.tf
+++ b/modules/dhcp_dns/variables.tf
@@ -1,0 +1,34 @@
+variable "base_configuration" {
+  description = "use module.base.configuration, see the main.tf example file"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "quantity" {
+  description = "number of hosts like this one"
+  default     = 1
+}
+
+variable "terminals" {
+  description = "configuration of the various PXE terminals"
+  type        = list(object({
+                  id = string
+                  hostname = string
+                  macaddr = string
+                  image = string}))
+}
+
+variable "first_terminal_ip" {
+  description = "last digit of first terminal IP's address"
+  type        = number
+  default     = 1
+}
+
+variable "image" {
+  description = "an image name, e.g. sles12sp4 or opensuse155o"
+  type        = string
+  default     = "opensuse155o"
+}

--- a/modules/dhcp_dns/versions.tf
+++ b/modules/dhcp_dns/versions.tf
@@ -1,0 +1,1 @@
+../backend/host/versions.tf

--- a/modules/minion/main.tf
+++ b/modules/minion/main.tf
@@ -14,7 +14,7 @@ module "minion" {
   ssh_key_path                  = var.ssh_key_path
   ipv6                          = var.ipv6
   connect_to_base_network       = true
-  connect_to_additional_network = true
+  connect_to_additional_network = false
   roles                         = var.roles
   disable_firewall              = var.disable_firewall
 


### PR DESCRIPTION
## What does this PR change?

This PR makes it possible to deploy a DHCP and DNS server inside the private network. This is useful for the containerized proxy because it stops playing that role in Retail context.

The proxy host still has to do the routing and NAT masquerading (for example via the branch network formula).

This PR also stops inserting the traditional client and the normal minion into the private network.

Some adaptation in the test suite will be needed, especially in containerized proxy context, but not only.

@rjmateus could you tell me what you think of the change to   `modules/base/main.tf`? It could be the sign of a problem with the decoupling of modules and backend modules.

