### PR TITLE
DHCP and DNS host

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -424,7 +424,7 @@ connect_to_additional_network = true
 When there are two connections, the first network interface `eth0` gets connected to base network, and the second interface `eth1` gets connected to the additional network.
 When there is only one connection, the card is always `eth0`, no matter to which network it is connected.
 
-Some modules have preset defaults: SUSE Manager/Uyuni servers and the testsuite controller connect only to the base network, while SUSE Manager/Uyuni proxies and clients or minions connect to both networks.
+Some modules have preset defaults: SUSE Manager/Uyuni servers and the testsuite controller connect only to the base network, while SUSE Manager/Uyuni proxies connect to both networks.
 
 DHCP and DNS services for the additional network may be ensured by the proxy. Alternatively, you can install a DHCP and DNS server into the additional network by declaring:
 

--- a/backend_modules/libvirt/host/network_config.yaml
+++ b/backend_modules/libvirt/host/network_config.yaml
@@ -6,7 +6,7 @@ network:
   ethernets:
     ens3:
       dhcp4: true
-%{ else  }
+%{ else }
 network:
   version: 1
   config:
@@ -17,5 +17,10 @@ network:
     name: eth0
 %{ endif }
     subnets:
+%{ if dhcp_dns }
+      - type: static
+        address: ${dhcp_dns_address}
+%{ else }
       - type: dhcp
+%{ endif }
 %{ endif }

--- a/modules/base/main.tf
+++ b/modules/base/main.tf
@@ -34,5 +34,10 @@ output "configuration" {
     use_shared_resources     = var.use_shared_resources
     testsuite                = var.testsuite
     use_eip_bastion          = var.use_eip_bastion
+    # WORKAROUND
+    # For some reason, the key "additional_network" from AWS module gets lost
+    # Force it into existence
+    additional_network       = null
+    # END OF WORKAROUND
   }, module.base_backend.configuration)
 }

--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -14,7 +14,7 @@ module "client" {
   ssh_key_path                  = var.ssh_key_path
   ipv6                          = var.ipv6
   connect_to_base_network       = true
-  connect_to_additional_network = true
+  connect_to_additional_network = false
   roles                         = ["client"]
   disable_firewall              = var.disable_firewall
   grains = {

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -46,7 +46,7 @@ module "controller" {
     redhat_minion     = length(var.redhat_configuration["hostnames"]) > 0 ? var.redhat_configuration["hostnames"][0] : null
     debian_minion     = length(var.debian_configuration["hostnames"]) > 0 ? var.debian_configuration["hostnames"][0] : null
     ssh_minion        = length(var.sshminion_configuration["hostnames"]) > 0 ? var.sshminion_configuration["hostnames"][0] : null
-    pxeboot_mac       = var.pxeboot_configuration["macaddr"]
+    pxeboot_mac       = var.pxeboot_configuration["private_mac"]
     kvm_host          = length(var.kvmhost_configuration["hostnames"]) > 0 ? var.kvmhost_configuration["hostnames"][0] : null
     monitoring_server = length(var.monitoringserver_configuration["hostnames"]) > 0 ? var.monitoringserver_configuration["hostnames"][0] : null
 
@@ -134,13 +134,13 @@ module "controller" {
     debian12_minion      = length(var.debian12_minion_configuration["hostnames"]) > 0 ? var.debian12_minion_configuration["hostnames"][0] : null
     debian12_sshminion   = length(var.debian12_sshminion_configuration["hostnames"]) > 0 ? var.debian12_sshminion_configuration["hostnames"][0] : null
     sle11sp4_buildhost    = length(var.sle11sp4_buildhost_configuration["hostnames"]) > 0 ? var.sle11sp4_buildhost_configuration["hostnames"][0] : null
-    sle11sp3_terminal_mac = var.sle11sp3_terminal_configuration["macaddr"]
+    sle11sp3_terminal_mac = var.sle11sp3_terminal_configuration["private_mac"]
     sle12sp5_buildhost    = length(var.sle12sp5_buildhost_configuration["hostnames"]) > 0 ? var.sle12sp5_buildhost_configuration["hostnames"][0] : null
-    sle12sp5_terminal_mac = var.sle12sp5_terminal_configuration["macaddr"]
+    sle12sp5_terminal_mac = var.sle12sp5_terminal_configuration["private_mac"]
     sle15sp3_buildhost    = length(var.sle15sp3_buildhost_configuration["hostnames"]) > 0 ? var.sle15sp3_buildhost_configuration["hostnames"][0] : null
-    sle15sp3_terminal_mac = var.sle15sp3_terminal_configuration["macaddr"]
+    sle15sp3_terminal_mac = var.sle15sp3_terminal_configuration["private_mac"]
     sle15sp4_buildhost    = length(var.sle15sp4_buildhost_configuration["hostnames"]) > 0 ? var.sle15sp4_buildhost_configuration["hostnames"][0] : null
-    sle15sp4_terminal_mac = var.sle15sp4_terminal_configuration["macaddr"]
+    sle15sp4_terminal_mac = var.sle15sp4_terminal_configuration["private_mac"]
     opensuse154arm_minion    = length(var.opensuse154arm_minion_configuration["hostnames"]) > 0 ? var.opensuse154arm_minion_configuration["hostnames"][0] : null
     opensuse154arm_sshminion = length(var.opensuse154arm_sshminion_configuration["hostnames"]) > 0 ? var.opensuse154arm_sshminion_configuration["hostnames"][0] : null
     opensuse155arm_minion    = length(var.opensuse155arm_minion_configuration["hostnames"]) > 0 ? var.opensuse155arm_minion_configuration["hostnames"][0] : null

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -93,7 +93,9 @@ variable "debian_configuration" {
 variable "pxeboot_configuration" {
   description = "use module.<PXEBOOT_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    macaddr = null
+    private_mac = null
+    private_ip = null
+    private_name = null
     image = null
   }
 }
@@ -599,7 +601,9 @@ variable "sle15sp4_buildhost_configuration" {
 variable "sle15sp4_terminal_configuration" {
   description = "use module.<SLE15SP4_TERMINAL>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    macaddr = null
+    private_mac = null
+    private_ip = null
+    private_name = null
     image = null
   }
 }
@@ -614,7 +618,9 @@ variable "sle15sp3_buildhost_configuration" {
 variable "sle15sp3_terminal_configuration" {
   description = "use module.<SLE15SP3_TERMINAL>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    macaddr = null
+    private_mac = null
+    private_ip = null
+    private_name = null
     image = null
   }
 }
@@ -629,7 +635,9 @@ variable "sle12sp5_buildhost_configuration" {
 variable "sle12sp5_terminal_configuration" {
   description = "use module.<SLE12SP5_TERMINAL>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    macaddr = null
+    private_mac = null
+    private_ip = null
+    private_name = null
     image = null
   }
 }
@@ -644,7 +652,9 @@ variable "sle11sp4_buildhost_configuration" {
 variable "sle11sp3_terminal_configuration" {
   description = "use module.<SLE11SP3_TERMINAL>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
-    macaddr = null
+    private_mac = null
+    private_ip = null
+    private_name = null
     image = null
   }
 }

--- a/modules/dhcp_dns/main.tf
+++ b/modules/dhcp_dns/main.tf
@@ -1,0 +1,147 @@
+module "dhcp_dns" {
+  source = "../host"
+
+  base_configuration            = var.base_configuration
+  name                          = var.name
+  quantity                      = var.base_configuration["additional_network"] != null ? var.quantity : 0
+
+  connect_to_base_network       = false
+  connect_to_additional_network = true
+  roles                         = ["dhcp_dns"]
+  provision                     = false
+
+  image                         = var.image
+}
+
+# The DHCP and DNS server has no direct connection to the outside, so we must download the packages on its behalf
+locals {
+  add_net              = var.base_configuration["additional_network"] != null ? slice(split(".", var.base_configuration["additional_network"]), 0, 3) : []
+  prefix               = join(".", local.add_net)
+  reverse_prefix       = join(".", reverse(local.add_net))
+  zypper               = "/usr/bin/zypper --non-interactive --gpg-auto-import-keys"
+  # Currently only for openSUSE 15.5:
+  repo                 = "http://${var.base_configuration["mirror"] != null ? var.base_configuration["mirror"] : "download.opensuse.org"}/distribution/leap/15.5/repo/oss"
+}
+
+resource "null_resource" "standalone_provisioning" {
+
+  count = var.base_configuration["additional_network"] != null ? var.quantity : 0
+
+  connection {
+    host     = "${local.prefix}.53"
+    user     = "root"
+    password = "linux"
+    timeout  = "3m"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOT
+mkdir -p /tmp/dhcp-dns/var/cache/zypp/packages/repo
+${local.zypper} --root /tmp/dhcp-dns addrepo ${local.repo} offline_repo ||:
+${local.zypper} --root /tmp/dhcp-dns install --download-only dhcp-server bind
+EOT
+  }
+
+  provisioner "file" {
+    source      = "/tmp/dhcp-dns/var/cache/zypp/packages/offline_repo"
+    destination = "/root"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "echo ${var.name} > /etc/hostname",
+      "hostname ${var.name}",
+      "echo 'nameserver 127.0.0.1' > /etc/resolv.conf",
+      "echo 'search example.org' >> /etc/resolv.conf",
+      "${local.zypper} addrepo dir:/root/offline_repo offline_repo ||:",
+      "${local.zypper} install --allow-downgrade dhcp-server bind",
+      "sed -i 's!DHCPD_INTERFACE=\"\"!DHCPD_INTERFACE=\"eth0\"!' /etc/sysconfig/dhcpd",
+      "sed -i 's!# include \"/etc/named.conf.include\";!include \"/etc/named.conf.include\";!' /etc/named.conf",
+    ]
+  }
+
+  provisioner "file" {
+    content = <<EOT
+option domain-name "example.org";
+option domain-name-servers ${local.prefix}.53;
+
+subnet ${local.prefix}.0 netmask 255.255.255.0
+{
+  range ${local.prefix}.128 ${local.prefix}.253;
+  filename "boot/pxelinux.0";
+  next-server ${local.prefix}.254;
+}
+
+${join("\n", [ for host in var.private_hosts:
+                 format("host %s\n{\n  hardware ethernet %s;\n  fixed-address %s.%d;\n}\n",
+                        host["private_name"],
+                        host["private_mac"],
+                        local.prefix,
+                        host["private_ip"])
+             ])}
+EOT
+    destination = "/etc/dhcpd.conf"
+  }
+
+  provisioner "file" {
+    content = <<EOT
+zone "${local.reverse_prefix}.in-addr.arpa" {
+  type master;
+  file "/var/lib/named/master/db.${local.reverse_prefix}.in-addr.arpa";
+
+  notify no;
+};
+
+zone "example.org" {
+  type master;
+  file "/var/lib/named/master/db.example.org";
+
+  notify no;
+};
+EOT
+    destination = "/var/lib/named/named.conf.include"
+  }
+
+  provisioner "file"  {
+    content = <<EOT
+$ORIGIN ${local.reverse_prefix}.in-addr.arpa.
+
+@        IN SOA dhcp-dns.example.org. admin.example.org. (2045010101 8600 900 86000 500)
+@        IN NS  dhcp-dns.example.org.
+dhcp-dns.example.org. IN A   ${local.prefix}.53
+
+53       IN PTR dhcp-dns.example.org.
+${join("\n", [ for host in var.private_hosts:
+                 format("%-8d IN PTR %s.example.org.\n",
+                        host["private_ip"],
+                        host["private_name"])
+             ])}
+EOT
+    destination = "/var/lib/named/master/db.1.168.192.in-addr.arpa"
+  }
+
+  provisioner "file"  {
+    content = <<EOT
+$ORIGIN example.org.
+
+@        IN SOA dhcp-dns admin.example.org. (2045010101 8600 900 86000 500)
+@        IN NS  dhcp-dns
+dhcp-dns IN A   ${local.prefix}.53
+
+${join("\n", [ for host in var.private_hosts:
+                 format("%-8s IN A   %s.%d\n",
+                        host["private_name"],
+                        local.prefix,
+                        host["private_ip"])
+             ])}
+EOT
+    destination = "/var/lib/named/master/db.example.org"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "systemctl enable --now dhcpd",
+      "systemctl enable --now named",
+    ]
+  }
+}

--- a/modules/dhcp_dns/variables.tf
+++ b/modules/dhcp_dns/variables.tf
@@ -1,0 +1,28 @@
+variable "base_configuration" {
+  description = "use module.base.configuration, see the main.tf example file"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "quantity" {
+  description = "number of hosts like this one"
+  default     = 1
+}
+
+variable "private_hosts" {
+  description = "configuration of the various hosts in the private network"
+  type        = list(object({
+                  private_mac = string
+                  private_ip = number
+                  private_name = string
+                }))
+}
+
+variable "image" {
+  description = "an image name, e.g. sles12sp5 or opensuse155o"
+  type        = string
+  default     = "opensuse155o"
+}

--- a/modules/dhcp_dns/versions.tf
+++ b/modules/dhcp_dns/versions.tf
@@ -1,0 +1,1 @@
+../backend/host/versions.tf

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -31,5 +31,5 @@ module "host" {
 }
 
 output "configuration" {
-  value = module.host.configuration
+  value = merge( { private_macs = [] }, module.host.configuration)
 }

--- a/modules/minion/main.tf
+++ b/modules/minion/main.tf
@@ -14,7 +14,7 @@ module "minion" {
   ssh_key_path                  = var.ssh_key_path
   ipv6                          = var.ipv6
   connect_to_base_network       = true
-  connect_to_additional_network = true
+  connect_to_additional_network = false
   roles                         = var.roles
   disable_firewall              = var.disable_firewall
 

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -67,6 +67,9 @@ output "configuration" {
   value = {
     id              = length(module.proxy.configuration["ids"]) > 0 ? module.proxy.configuration["ids"][0] : null
     hostname        = length(module.proxy.configuration["hostnames"]) > 0 ? module.proxy.configuration["hostnames"][0] : null
+    private_mac     = length(module.proxy.configuration["private_macs"]) > 0 ? module.proxy.configuration["private_macs"][0]: null
+    private_ip      = 254
+    private_name    = "proxy"
     product_version = var.product_version
     username        = var.server_configuration["username"]
     password        = var.server_configuration["password"]

--- a/modules/pxe_boot/main.tf
+++ b/modules/pxe_boot/main.tf
@@ -16,9 +16,11 @@ module "pxe_boot" {
 
 output "configuration" {
   value = {
-    id       = length(module.pxe_boot.configuration["ids"]) > 0 ? module.pxe_boot.configuration["ids"][0] : null
-    hostname = length(module.pxe_boot.configuration["hostnames"]) > 0 ? module.pxe_boot.configuration["hostnames"][0] : null
-    macaddr = length(module.pxe_boot.configuration["macaddrs"]) > 0 ? module.pxe_boot.configuration["macaddrs"][0] : null
-    image    = var.image
+    id           = length(module.pxe_boot.configuration["ids"]) > 0 ? module.pxe_boot.configuration["ids"][0] : null
+    hostname     = length(module.pxe_boot.configuration["hostnames"]) > 0 ? module.pxe_boot.configuration["hostnames"][0] : null
+    private_mac  = length(module.pxe_boot.configuration["macaddrs"]) > 0 ? module.pxe_boot.configuration["macaddrs"][0] : null
+    private_ip   = var.private_ip
+    private_name = var.private_name
+    image        = var.image
   }
 }

--- a/modules/pxe_boot/variables.tf
+++ b/modules/pxe_boot/variables.tf
@@ -12,12 +12,22 @@ variable "quantity" {
   default     = 1
 }
 
+variable "private_ip" {
+  description = "last digit of IP address in private network"
+  type        = number
+}
+
+variable "private_name" {
+  description = "hostname inside the private network"
+  type        = string
+}
+
 variable "image" {
-  description = "An image name, e.g. sles12sp4 or opensuse155o"
+  description = "an image name, e.g. sles12sp4 or opensuse155o"
   type        = string
 }
 
 variable "provider_settings" {
-  description = "Settings specific to the provider"
+  description = "settings specific to the provider"
   default     = {}
 }

--- a/modules/sshminion/main.tf
+++ b/modules/sshminion/main.tf
@@ -14,7 +14,7 @@ module "sshminion" {
   ssh_key_path                  = var.ssh_key_path
   ipv6                          = var.ipv6
   connect_to_base_network       = true
-  connect_to_additional_network = true
+  connect_to_additional_network = false
   roles                         = ["sshminion"]
   disable_firewall              = var.disable_firewall
   grains = {


### PR DESCRIPTION
## What does this PR change?

This PR makes it possible to deploy a DHCP and DNS server inside the private network. This is useful for the containerized proxy because it stops playing that role in Retail context.

This PR also stops inserting the traditional client and the normal minion into the private network. They were only used for ping tests.

This PR also works around a bug transmitting the configuration from AWS :cry: .

Some adaptation in the test suite will be needed, especially in containerized proxy context, but not only.

## Results

```bash
dhcp-dns:~ # ip a s eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 52:54:00:de:7d:2d brd ff:ff:ff:ff:ff:ff
    altname enp0s3
    altname ens3
    inet 192.168.1.53/24 brd 192.168.1.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::5054:ff:fede:7d2d/64 scope link 
       valid_lft forever preferred_lft forever
```

```bash
dhcp-dns:~ # cat /etc/resolv.conf
nameserver 127.0.0.1
search example.org
```

```bash
dhcp-dns:~ # cat /etc/dhcpd.conf
option domain-name "example.org";
option domain-name-servers 192.168.1.53;

subnet 192.168.1.0 netmask 255.255.255.0
{
  range 192.168.1.128 192.168.1.253;
  filename "boot/pxelinux.0";
  next-server 192.168.1.254;
}

host proxy
{
  hardware ethernet 52:54:00:F6:84:44;
  fixed-address 192.168.1.254;
}

host pxeboot
{
  hardware ethernet 52:54:00:12:CE:0B;
  fixed-address 192.168.1.4;
}
```

```bash
dhcp-dns:~ # cat /etc/named.conf.include
zone "1.168.192.in-addr.arpa" {
  type master;
  file "/var/lib/named/master/db.1.168.192.in-addr.arpa";

  notify no;
};

zone "example.org" {
  type master;
  file "/var/lib/named/master/db.example.org";

  notify no;
};
```

```bash
dhcp-dns:~ # cat /var/lib/named/master/db.1.168.192.in-addr.arpa
$ORIGIN 1.168.192.in-addr.arpa.

@        IN SOA dhcp-dns.example.org. admin@example.org. (2045010101 8600 900 86000 500)
@        IN NS  dhcp-dns.example.org.
dhcp-dns.example.org. IN A   192.168.1.53

53       IN PTR dhcp-dns.example.org.
254      IN PTR proxy.example.org.

4        IN PTR pxeboot.example.org.
```

```bash
dhcp-dns:~ # cat /var/lib/named/master/db.example.org
$ORIGIN example.org.

@        IN SOA dhcp_dns admin@example.org. (2045010101 8600 900 86000 500)
@        IN NS  dhcp_dns
dhcp-dns IN A   192.168.1.53

proxy    IN A   192.168.1.254

pxeboot  IN A   192.168.1.4
```
