### PR TITLE
Remove create_first_user variable for server_containerized

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -125,7 +125,6 @@ module "server_containerized" {
   disable_firewall               = false
   allow_postgres_connections     = false
   skip_changelog_import          = false
-  create_first_user              = lookup(local.create_first_user, "server_containerized", false)
   mgr_sync_autologin             = false
   create_sample_channel          = false
   create_sample_activation_key   = false

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -57,7 +57,7 @@ module "server_containerized" {
     repository_disk_size           = var.repository_disk_size
     database_disk_size             = var.database_disk_size
     skip_changelog_import          = var.skip_changelog_import
-    create_first_user              = var.create_first_user
+    create_first_user              = true
     mgr_sync_autologin             = var.mgr_sync_autologin
     create_sample_channel          = var.create_sample_channel
     create_sample_activation_key   = var.create_sample_activation_key
@@ -77,6 +77,6 @@ output "configuration" {
     username           = var.server_username
     password           = var.server_password
     runtime            = var.runtime
-    first_user_present = var.create_first_user
+    first_user_present = true
   }
 }

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -137,11 +137,6 @@ variable "skip_changelog_import" {
   default     = true
 }
 
-variable "create_first_user" {
-  description = "whether to automatically create the first user"
-  default     = true
-}
-
 variable "mgr_sync_autologin" {
   description = "whether to set mgr-sync credentials in the .mgr-sync file"
   default     = true

--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -31,7 +31,6 @@ debug:
   java: true
 {%- endif %}
 
-{% if grains.get('create_first_user') %}
 {% set server_username = grains.get('server_username') | default('admin', true) %}
 {% set server_password = grains.get('server_password') | default('admin', true) %}
 organization: SUSE
@@ -41,4 +40,3 @@ admin:
   firstName: Administrator
   lastName: Administrator
   email: galaxy-noise@suse.de
-{% endif %}


### PR DESCRIPTION
## What does this PR change?

Since the first user creation is now mandatory in mgradm install, don't offer the choice anymore.

Related to https://github.com/uyuni-project/uyuni-tools/pull/192
