### PR TITLE
CI: Remove deleted variable `create_first_user`

### DIFF
--- a/.github/workflows/ci-validation/salt-server-containerized-validation
+++ b/.github/workflows/ci-validation/salt-server-containerized-validation
@@ -35,7 +35,6 @@ swap_file_size: 1024
 mirror: mirror.tf.local
 skip_changelog_import: true
 disable_download_tokens: true
-create_first_user: true
 mgr_sync_autologin: true
 monitored: true
 forward_registration: true

--- a/modules/proxy_containerized/main.tf
+++ b/modules/proxy_containerized/main.tf
@@ -32,7 +32,6 @@ module "proxy_containerized" {
   grains = {
     product_version           = var.product_version
     server                    = var.server_configuration["hostname"]
-    first_user_present        = var.server_configuration["create_first_user"]
     server_username           = var.server_configuration["username"]
     server_password           = var.server_configuration["password"]
     auto_configure            = var.auto_configure

--- a/salt/proxy_containerized/init.sls
+++ b/salt/proxy_containerized/init.sls
@@ -64,7 +64,7 @@ install_mgr_tools:
 {% endif %}
 
 # This will only work if the proxy is part of the cucumber_testsuite module, otherwise the server might not be ready
-{% if grains.get('auto_configure') and grains.get('testsuite') and grains.get('first_user_present') %}
+{% if grains.get('auto_configure') and grains.get('testsuite') %}
 generate_configuration_file_from_server:
   cmd.run:
     - name: |


### PR DESCRIPTION
## What does this PR change?

This removes the deleted variable `create_first_user` in https://github.com/uyuni-project/sumaform/pull/1527 from the containerized proxy and the CI.

