### PR TITLE
Don't add container utils repo in Leap Micro

### DIFF
--- a/salt/repos/server_containerizedUyuni.sls
+++ b/salt/repos/server_containerizedUyuni.sls
@@ -9,7 +9,7 @@
 {% set repo = 'openSUSE_Leap_Micro_5.5' %}
 {% endif %}
 
-{% if 'Leap_Micro' in repo %} 
+{% if 'Leap_Micro' not in repo %} 
 systemsmanagement_Uyuni_Master_ContainerUtils:
     pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/

--- a/salt/repos/server_containerizedUyuni.sls
+++ b/salt/repos/server_containerizedUyuni.sls
@@ -9,12 +9,13 @@
 {% set repo = 'openSUSE_Leap_Micro_5.5' %}
 {% endif %}
 
+{% if 'Leap_Micro' in repo %} 
 systemsmanagement_Uyuni_Master_ContainerUtils:
     pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/
     - refresh: True
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
-
+{% endif %}
 {% endif %}
 
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Don't add container utils repo in Leap Micro, otherwise it collides with combustion. https://github.com/uyuni-project/sumaform/blob/master/backend_modules/libvirt/host/combustion#L19
