### PR TITLE
Revert default master server to Leap 15.5 image

### DIFF
--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -3,7 +3,7 @@
 variable "images" {
   default = {
     "head"           = "slemicro55o"
-    "uyuni-master"   = "leapmicro55o"
+    "uyuni-master"   = "opensuse155o"
     "uyuni-released" = "opensuse155o"
     "uyuni-pr"       = "opensuse155o"
   }


### PR DESCRIPTION
## What does this PR change?

Since there are still issues with installing k3s on Leap Micro, switch back to leap in the mean time to unblock everyone.
