### PR TITLE
salt_testenv: start docker daemon after classic Salt testsuite installation

### DIFF
--- a/salt/salt_testenv/init.sls
+++ b/salt/salt_testenv/init.sls
@@ -63,6 +63,11 @@ install_salt_testsuite:
       - pkgrepo: salt_testsuite_dependencies_repo
       - pkgrepo: salt_testing_repo
 
+start_docker_service:
+  service.running:
+    - name: docker
+    - requires:
+      - pkg: install_salt_testsuite
 {% endif %}
 
 {% if grains['os'] == 'Debian' %}


### PR DESCRIPTION
## What does this PR change?

In order to allow some Docker related tests to run, we want "docker" service is enable when testing classic Salt package.
