### PR TITLE
Wait for traefik to be started in k3s installs

### DIFF
--- a/salt/server_containerized/install_k3s.sls
+++ b/salt/server_containerized/install_k3s.sls
@@ -9,6 +9,15 @@ k3s_install:
       - INSTALL_K3S_EXEC: "--tls-san={{ grains.get('fqdn') }}" 
     - unless: systemctl is-active k3s
 
+wait_for_traefik:
+  cmd.script:
+    - name: salt://server_containerized/wait_for_kube_resource.py
+    - args: kube-system deploy traefik
+    - use_vt: True
+    - template: jinja
+    - require:
+      - cmd: k3s_install
+
 helm_install:
   pkg.installed:
     - refresh: True

--- a/salt/server_containerized/wait_for_kube_resource.py
+++ b/salt/server_containerized/wait_for_kube_resource.py
@@ -1,0 +1,34 @@
+#!{{grains['pythonexecutable']}}
+
+import subprocess
+import sys
+import time
+
+
+if len(sys.argv) != 4:
+    print("Usage: wait_for_kube_resource.py <namespace> <kind> <name>")
+
+_, namespace, kind, name = sys.argv
+
+print("Waiting for {} {} to be ready...".format(name, kind))
+
+ready_check = "grep Running"
+if kind in ["service", "svc"]:
+    ready_check = "wc -l | grep 1"
+elif kind in ["deployment", "deploy"]:
+    ready_check = "grep 1/1"
+elif kind == "issuer":
+    ready_check = "grep True"
+
+cmd = "kubectl get --no-headers -n {} {} {} | {}".format(namespace, kind, name, ready_check)
+
+for i in range(60):
+
+    process = subprocess.run(cmd, shell=True)
+    if process.returncode == 0:
+        break
+
+    print("... not finished yet...")
+    time.sleep(10)
+
+print("Done.")


### PR DESCRIPTION
## What does this PR change?

If mgradm install runs before traefik had time to deploy the ingressroutetcp resources we wouldn't get any of the TCP and UDP ports exposed.