### PR TITLE
QE: Align the org and first user to the values set in the Cucumber feature

### DIFF
--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -33,10 +33,10 @@ debug:
 
 {% set server_username = grains.get('server_username') | default('admin', true) %}
 {% set server_password = grains.get('server_password') | default('admin', true) %}
-organization: SUSE
+organization: SUSE Test
 admin:
   password: {{ server_password }}
   login: {{ server_username }}
-  firstName: Administrator
-  lastName: Administrator
+  firstName: Admin
+  lastName: Admin
   email: galaxy-noise@suse.de


### PR DESCRIPTION
## What does this PR change?

We found an issue in some tests, as we expected different values when we create the first org and the first user.

```
  Scenario: Create admin user and first organization
    Given I access the host the first time
    When I go to the home page
    And I enter "SUSE Test" as "orgName"
    And I enter "admin" as "login"
    And I enter "admin" as "desiredpassword"
    And I enter "admin" as "desiredpasswordConfirm"
    And I select "Mr." from "prefix"
    And I enter "Admin" as "firstNames"
    And I enter "Admin" as "lastName"
    And I enter "galaxy-noise@suse.de" as "email"
    And I click on "Create Organization"
    Then I am logged in
```


![image](https://github.com/uyuni-project/sumaform/assets/2827771/e19aaca8-86de-47c1-80b9-94d01b7f7ba3)
<img width="730" alt="image" src="https://github.com/uyuni-project/sumaform/assets/2827771/e7baab96-eea2-469b-b8c9-84d33f3de62a">
