### PR TITLE
Fix an issue where role is also created when not using a paygo server.

### DIFF
--- a/backend_modules/aws/base/iam_instance_profile.tf
+++ b/backend_modules/aws/base/iam_instance_profile.tf
@@ -24,6 +24,7 @@ resource "aws_iam_role" "metering_full_access_role" {
 
 
 resource "aws_iam_role_policy_attachment" "metering_full_access_policy_attachment" {
+  count  = var.is_server_paygo_instance ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/AWSMarketplaceMeteringFullAccess"
   role       = aws_iam_role.metering_full_access_role.name
 }


### PR DESCRIPTION
## What does this PR change?

To deploy paygo server on AWS, you need an IAM role with specific rights. 
This IAM role was also creating when deploying a BYOS server.

Fix the deployment to correctly not create the IAM role when deploying an BYOS server.
