### PR TITLE
Reduce default main disk size to 20GiB

### DIFF
--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -108,7 +108,7 @@ variable "provider_settings" {
 
 variable "main_disk_size" {
   description = "Size of main disk, defined in GiB"
-  default     = 200
+  default     = 20
 }
 
 variable "additional_disk_size" {

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -43,7 +43,7 @@ variable "images" {
 
 variable "main_disk_size" {
   description = "Size of main disk, defined in GiB"
-  default     = 200
+  default     = 20
 }
 
 variable "repository_disk_size" {

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -121,7 +121,7 @@ variable "image" {
 
 variable "main_disk_size" {
   description = "Size of main disk, defined in GiB"
-  default     = 200
+  default     = 20
 }
 
 variable "repository_disk_size" {

--- a/modules/proxy_containerized/variables.tf
+++ b/modules/proxy_containerized/variables.tf
@@ -96,7 +96,7 @@ variable "volume_provider_settings" {
 
 variable "main_disk_size" {
   description = "Size of main disk, defined in GiB"
-  default     = 200
+  default     = 20
 }
 
 variable "repository_disk_size" {


### PR DESCRIPTION
## What does this PR change?

Currently, all the instances are by default deploy with the main disk size equal to 200GiB. 
We want to reduce this default size to 20GiB.

I also reduced proxy disk size ( previously 200GiB )
