### PR TITLE
Correctly handle the main disk size for aws host

### DIFF
--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -7,7 +7,7 @@ locals {
     ssh_user        = lookup(lookup(var.base_configuration["ami_info"], var.image, {}), "ssh_user", "ec2-user")
     public_instance = false
     instance_with_eip = false
-    volume_size     = 50
+    volume_size     = var.main_disk_size
     private_ip      = null
     overwrite_fqdn  = null
     bastion_host    = lookup(var.base_configuration, "bastion_host", null)


### PR DESCRIPTION
## What does this PR change?

Currently, we can't modify the default main disk size ( 50Gib ). 
With this change, we will now use correctly main_disk_size variable to setup the main disk size.