### PR TITLE
Fix install_salt_bundle in Containerized proxy

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -42,6 +42,9 @@ PACKAGES="$PACKAGES helm"
 
 %{ if container_proxy }
 PACKAGES="$PACKAGES bash-completion mgrpxy"
+%{ endif }
+%{ if install_salt_bundle }
+PACKAGES="$PACKAGES venv-salt-minion"
 %{ else }
 PACKAGES="$PACKAGES salt-minion"
 %{ endif }

--- a/modules/proxy_containerized/main.tf
+++ b/modules/proxy_containerized/main.tf
@@ -20,6 +20,7 @@ module "proxy_containerized" {
   image                         = var.image == "default" || var.product_version == "head" ? var.images[var.product_version] : var.image
   name                          = var.name
   use_os_released_updates       = true
+  install_salt_bundle           = var.install_salt_bundle
   ssh_key_path                  = var.ssh_key_path
   additional_repos              = var.additional_repos
   additional_repos_only         = var.additional_repos_only

--- a/modules/proxy_containerized/variables.tf
+++ b/modules/proxy_containerized/variables.tf
@@ -53,7 +53,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "quantity" {


### PR DESCRIPTION
## What does this PR change?

We had a bootstrap issue because we were install salt-minion instead of venv-salt-minion in our containerized_proxy module
