### PR TITLE
Change the default value of install_salt_bundle to true

### DIFF
--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -44,7 +44,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "quantity" {

--- a/modules/build_host/variables.tf
+++ b/modules/build_host/variables.tf
@@ -53,7 +53,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "quantity" {

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -48,7 +48,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "quantity" {

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -73,7 +73,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "quantity" {

--- a/modules/mirror/variables.tf
+++ b/modules/mirror/variables.tf
@@ -24,7 +24,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "swap_file_size" {

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -83,7 +83,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "quantity" {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -199,7 +199,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "traceback_email" {

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -224,7 +224,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "quantity" {

--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -44,7 +44,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "quantity" {

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -48,7 +48,7 @@ variable "additional_packages" {
 
 variable "install_salt_bundle" {
   description = "use true to install the venv-salt-minion package in the hosts"
-  default     = false
+  default     = true
 }
 
 variable "ssh_key_path" {


### PR DESCRIPTION
## What does this PR change?

This PR change the default value of _install_salt_bundle_ variable in the majority of modules.
It keeps untouched the host modules from other backends.

The aim of this refactor is to simplify our main.tf for most of our environments, where we were replacing the value of this variable in almost all the cases.

