### PR TITLE
Install salt bundle, when required, through Combustion

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -44,7 +44,11 @@ PACKAGES="$PACKAGES helm"
 PACKAGES="$PACKAGES bash-completion mgrpxy"
 %{ endif }
 
+%{ if install_salt_bundle }
+PACKAGES="$PACKAGES venv-salt-minion"
+%{ else }
 PACKAGES="$PACKAGES salt-minion"
+%{ endif }
 
 %{ if testsuite }
 PACKAGES="$PACKAGES andromeda-dummy milkyway-dummy virgo-dummy timezone" 

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -81,6 +81,7 @@ data "template_file" "combustion" {
   ])
     use_mirror_images   = var.base_configuration["use_mirror_images"]
     mirror              = var.base_configuration["mirror"]
+    install_salt_bundle = var.install_salt_bundle
     container_server    = contains(var.roles, "server_containerized")
     container_proxy     = contains(var.roles, "proxy_containerized")
     container_runtime   = local.container_runtime


### PR DESCRIPTION
## What does this PR change?

Install salt bundle, when required, through Combustion.
For instance, we need it to bootstrap the Containerized Proxy Host when it's running in a SLE Micro 5.5
