### PR TITLE
PXE kernel: use by default the path for containerized proxy

### DIFF
--- a/modules/dhcp_dns/main.tf
+++ b/modules/dhcp_dns/main.tf
@@ -68,7 +68,7 @@ option domain-name-servers ${local.prefix}.53;
 subnet ${local.prefix}.0 netmask 255.255.255.0
 {
   range ${local.prefix}.128 ${local.prefix}.253;
-  filename "boot/pxelinux.0";
+  filename "pxelinux.0";
   next-server ${local.prefix}.254;
 }
 


### PR DESCRIPTION
## What does this PR change?

The path to the PXE boot kernel depends on the context:

Traditional proxy:
  * cobbler: `pxelinux.0`
  * retail: `boot/pxelinux.0`

Containerized proxy:
  * cobbler: `pxelinux.0`
  * retail: `pxelinux.0`

This PR takes the new and "most common" location as default value.
