### PR TITLE
Add Leap Micro with combustion and make it default for PR testing

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -27,6 +27,13 @@ zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repos
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/update/leap/15.5/sle/ sle_update_repo
 %{ endif }
 
+for i in ${additional_repos};do
+  name=$(echo $i | cut -d= -f1)
+  url=$(echo $i | cut -d= -f2)
+  zypper ar $url $name
+done
+
+
 # Install packages
 PACKAGES="qemu-guest-agent avahi ca-certificates"
 %{ if container_server }

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -86,6 +86,7 @@ data "template_file" "combustion" {
     container_proxy     = contains(var.roles, "proxy_containerized")
     container_runtime   = local.container_runtime
     testsuite           = lookup(var.base_configuration, "testsuite", false)
+    additional_repos    = join(" ", [for key, value in var.additional_repos : "${key}=${value}"])
   }
 }
 

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -5,7 +5,7 @@ variable "images" {
     "head"           = "slemicro55o"
     "uyuni-master"   = "opensuse155o"
     "uyuni-released" = "opensuse155o"
-    "uyuni-pr"       = "opensuse155o"
+    "uyuni-pr"       = "leapmicro55o"
   }
 }
 

--- a/salt/default/minimal.sls
+++ b/salt/default/minimal.sls
@@ -13,7 +13,7 @@ include:
   - default.time
 
 minimal_package_update:
-{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SLE Micro'  %}
+{% if grains['os_family'] == 'Suse' and grains['osfullname'] in['SLE Micro', 'openSUSE Leap Micro']  %}
   cmd.run:
 {% if grains['install_salt_bundle'] %}
     - name: transactional-update -c package up zypper libzypp venv-salt-minion

--- a/salt/repos/additional.sls
+++ b/salt/repos/additional.sls
@@ -1,3 +1,5 @@
+# Skip Micro OSes, given the additional repos are set up by combustion/ignition/cloud-init
+{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
 {% if grains['additional_repos'] %}
 {% for label, url in grains['additional_repos'].items() %}
 {{ label }}_repo:
@@ -57,7 +59,7 @@ update-ca-certificates:
 {% endif %}
 {% endfor %}
 {% endif %}
-
+{% endif %}
 # WORKAROUND: see github:saltstack/salt#10852
 {{ sls }}_nop:
   test.nop: []

--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -110,40 +110,11 @@ repo_key_import:
       - cmd: galaxy_key_copy
 {% endif %}
 
-testing_overlay_devel_repo:
-  cmd.run:
-{% if grains.get('product_version') | default('', true) in ['uyuni-master', 'uyuni-pr', 'uyuni-released'] %}
-    - name: 'mgrctl exec "zypper -n ar -f -p 96 http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/ testing_overlay_devel_repo"'
-{% else %}
-    - name: 'mgrctl exec "zypper -n ar -f -p 96 http://{{ grains.get("mirror") | default("download.suse.de", true) }}//ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Testing-Overlay-4.3-POOL-x86_64-Media1/ testing_overlay_devel_repo"'
-{% endif %}
-    - unless: mgrctl exec "zypper lr" | grep testing_overlay_devel_repo
-    - require:
-{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
-      - cmd: repo_key_import
-
-# Allowing downgrade of salt-ssh as it has sometimes a slightly older version than what is in the image
-{% if 'build_image' not in grains.get('product_version') | default('', true) %}
-saltssh_package:
-   cmd.run:
-    - name: mgrctl exec "zypper -n in --allow-downgrade salt-ssh"
-    - require:
-{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
-      - cmd: testing_overlay_devel_repo
-{% endif %}
-
 testsuite_packages:
   cmd.run:
     - name: mgrctl exec "zypper -n in iputils expect wget OpenIPMI"
 {% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
     - require:
-{% if 'build_image' not in grains.get('product_version') | default('', true) %}
-      - cmd: saltssh_package
-{% endif %}
       - pkg: uyuni-tools
 {% endif %}
 


### PR DESCRIPTION
## What does this PR change?

Add Leap Micro to sumaform and use it by default for PR testing.

Because of Leap Micro being transactional, we need to install any additional package with combustion
