### PR TITLE
Fix wrong name for reverse master file

### DIFF
--- a/modules/dhcp_dns/main.tf
+++ b/modules/dhcp_dns/main.tf
@@ -117,7 +117,7 @@ ${join("\n", [ for host in var.private_hosts:
                         host["private_name"])
              ])}
 EOT
-    destination = "/var/lib/named/master/db.1.168.192.in-addr.arpa"
+    destination = "/var/lib/named/master/db.${local.reverse_prefix}.in-addr.arpa"
   }
 
   provisioner "file"  {


### PR DESCRIPTION
## What does this PR change?

For example, use `db.50.168.192.in-addr.arpa`  for BV 5.0 instead of `db.1.168.192.in-addr.arpa`.
