### PR TITLE
Add a jump host for the DHCP and DNS server

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -450,6 +450,7 @@ module "dhcp-dns" {
 
   name = "dhcp-dns"
   image = "opensuse155o"
+  hypervisor = { host = "hypervisor.example.org", user = "root", private_key = file("~/.ssh/id_rsa") }
   private_hosts = [ module.proxy.configuration, module.sles12sp5-terminal.configuration, module.sles15sp4-terminal.configuration ]
 }
 ```

--- a/modules/dhcp_dns/main.tf
+++ b/modules/dhcp_dns/main.tf
@@ -28,10 +28,13 @@ resource "null_resource" "standalone_provisioning" {
   count = var.base_configuration["additional_network"] != null ? var.quantity : 0
 
   connection {
-    host     = "${local.prefix}.53"
-    user     = "root"
-    password = "linux"
-    timeout  = "3m"
+    host                = "${local.prefix}.53"
+    user                = "root"
+    password            = "linux"
+    timeout             = "3m"
+    bastion_host        = var.hypervisor != null ? var.hypervisor.host : null
+    bastion_user        = var.hypervisor != null ? var.hypervisor.user : null
+    bastion_private_key = var.hypervisor != null ? var.hypervisor.private_key : null
   }
 
   provisioner "local-exec" {

--- a/modules/dhcp_dns/variables.tf
+++ b/modules/dhcp_dns/variables.tf
@@ -26,3 +26,13 @@ variable "image" {
   type        = string
   default     = "opensuse155o"
 }
+
+variable "hypervisor" {
+  description = "the hypervisor where the DHCP and DNS VM runs"
+  type        = object({
+                  host = string
+                  user = string
+                  private_key = string
+                })
+  default     = null
+}


### PR DESCRIPTION
## What does this PR change?

The worker and the hypervisor may be two different hosts.

Reminder: the DHCP and DNS server is exclusively on the private network.