### PR TITLE
Use Leap Micro in Uyuni Proxy Containerized

### DIFF
--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -38,7 +38,7 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = ["centos7o", "opensuse155o", "rocky8o", "rocky9o", "sles12sp4o", "sles12sp5o", "sles15sp3o", "sles15sp4o", "ubuntu2004o", "ubuntu2204o", "suma43VM-ign"]
+  default     = ["centos7o", "opensuse155o", "leapmicro55o", "slemicro55o", "rocky8o", "rocky9o", "sles12sp4o", "sles12sp5o", "sles15sp3o", "sles15sp4o", "ubuntu2004o", "ubuntu2204o", "suma43VM-ign"]
 }
 
 variable "main_disk_size" {

--- a/modules/proxy_containerized/main.tf
+++ b/modules/proxy_containerized/main.tf
@@ -1,11 +1,9 @@
 variable "images" {
   default = {
     "head"           = "slemicro55o"
-    // TODO: Replace Uyuni images with OpenSUSE Leap Micro 15.5 images
-    // (not yet supported in sumaform)
-    "uyuni-master"   = "opensuse155o"
-    "uyuni-released" = "opensuse155o"
-    "uyuni-pr"       = "opensuse155o"
+    "uyuni-master"   = "leapmicro55o"
+    "uyuni-released" = "leapmicro55o"
+    "uyuni-pr"       = "leapmicro55o"
   }
 }
 

--- a/salt/repos/proxy_containerizedUyuni.sls
+++ b/salt/repos/proxy_containerizedUyuni.sls
@@ -1,6 +1,6 @@
 {% if 'proxy_containerized' in grains.get('roles') and 'uyuni' in grains.get('product_version') %}
 
-# TODO: Remove this SLS file once we add support for Leap Micro 5.5 images, and we move this repository to cloud-init phase
+# TODO: Remove this SLS file once we add support for Leap Micro 5.5 images in K3s, and we move this repository to cloud-init phase
 #       This only affects Uyuni, as we use slemicro55o image for Head/5.0
 
 {% if grains.get("os") == "SUSE" %}


### PR DESCRIPTION
## What does this PR change?

Use Leap Micro in Uyuni Proxy Containerized.
This change the default image for all the uyuni product versions.

**WARNING**:
- We need to change the default image if we are under a K3S deployment. In such case, for now, we will keep using Leap Micro 5.5, to be aligned with the server, as we encountered some technical issues there.


**Related PR**:
- https://github.com/SUSE/susemanager-ci/pull/1190