### PR TITLE
Fix system domain to avoid having double -

### DIFF
--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -30,7 +30,7 @@ locals {
   private_security_group_id            = var.base_configuration.private_security_group_id
   private_additional_security_group_id = var.base_configuration.private_additional_security_group_id
   private_ip                           = local.provider_settings["private_ip"]
-  overwrite_fqdn                       = local.route53_domain == null ? local.provider_settings["overwrite_fqdn"] : "${var.base_configuration["name_prefix"]}-${var.name}.${var.base_configuration["route53_domain"]}"
+  overwrite_fqdn                       = local.route53_domain == null ? local.provider_settings["overwrite_fqdn"] : "${var.base_configuration["name_prefix"]}${var.name}.${var.base_configuration["route53_domain"]}"
   route53_zone_id                      = lookup(var.base_configuration, "route53_zone_id", null)
   route53_domain                       = lookup(var.base_configuration, "route53_domain", null)
 


### PR DESCRIPTION
## What does this PR change?

Currently, using the overwrite_fqdn will create wrong fqdn with a double `-`.
Remove this issue by removing the extra `-` in sumaform.
