### PR TITLE
Install expect on proxy

### DIFF
--- a/salt/proxy_containerized/init.sls
+++ b/salt/proxy_containerized/init.sls
@@ -61,6 +61,19 @@ install_mgr_tools:
       - podman
       - mgrpxy
       - mgrctl
+{% else %}
+{% if grains.get('testsuite') %}
+install_testsuite_helpers:
+  cmd.run:
+    - name: |
+        transactional-update -c run bash -c "zypper mr -e os_pool_repo && zypper -n install expect && zypper mr -d os_pool_repo"
+
+reboot:
+  module.run:
+    - name: system.reboot
+    - at_time: +2
+    - order: last
+{% endif %}
 {% endif %}
 
 # This will only work if the proxy is part of the cucumber_testsuite module, otherwise the server might not be ready


### PR DESCRIPTION
## What does this PR change?

This PR installs `expect` package on the SLE micro proxy.


## Context

This is the third attempt to do the same thing.

The first 2 were done at test suite level:
 * the first one failed because it required too many reboots;
 * the second one failed because Foreign type proxies don't use the activation key.

Now trying from sumaform.

