### PR TITLE
Adding Uyuni Client Tools for Leap 15 in Combustion

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -15,6 +15,8 @@ ${ gpg_keys }
 
 # Add repositories
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/15.5/ ca_suse
+zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/ client_tools_repo
+
 %{ if container_server || container_proxy }
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/openSUSE_Leap_Micro_5.5/ container_utils
 %{ endif }


### PR DESCRIPTION
## What does this PR change?

To solve this issue deploying a Leap Micro 5.5 VM

```
transactional update # zypper lr
Repository priorities are without effect. All enabled repositories share the same priority.

# | Alias              | Name                         | Enabled | GPG Check | Refresh
--+--------------------+------------------------------+---------+-----------+--------
1 | ca_suse            | ca_suse                      | Yes     | (r ) Yes  | No
2 | container_utils    | container_utils              | Yes     | (r ) Yes  | No
3 | repo-debug         | Leap Micro Debug Repository  | No      | ----      | ----
4 | repo-main          | Leap Micro Main Repository   | Yes     | (r ) Yes  | Yes
5 | repo-sle-update    | SLE Micro Update Repository  | Yes     | (r ) Yes  | Yes
6 | repo-source        | Leap Micro Source Repository | No      | ----      | ----
7 | test_packages_pool | test_packages_pool           | Yes     | (r ) Yes  | No
transactional update # zypper --non-interactive install venv-salt-minion                                                     
Loading repository data...
Reading installed packages...
'venv-salt-minion' not found in package names. Trying capabilities.
No provider of 'venv-salt-minion' found.
```

We inject through Combustion the uyuni client tools for Leap 15.x (that will also support Leap Micro 5)