### PR TITLE
SLE Micro uses Network Manager too

### DIFF
--- a/salt/default/network.sls
+++ b/salt/default/network.sls
@@ -19,7 +19,7 @@ ipv6_accept_ra_{{ iface }}:
 {% endif %}
 {% endfor %}
 
-{% if (grains['osfullname'] == 'SLE Micro') and (grains['osrelease'] != '5.1') and (grains['osrelease'] != '5.2') %}
+{% if (grains['osfullname'] == 'SLE Micro' or grains['osfullname'] == 'openSUSE Leap Micro') and (grains['osrelease'] != '5.1' and grains['osrelease'] != '5.2') %}
 avoid_network_manager_messing_up:
   cmd.run:
     - name: |


### PR DESCRIPTION
## What does this PR change?

Before:
```
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether aa:b2:93:01:00:22 brd ff:ff:ff:ff:ff:ff
(...)
    inet6 2a07:de40:b208:1:b6b6:4e36:289d:e13c/64 scope global dynamic mngtmpaddr noprefixroute 
       valid_lft 2591520sec preferred_lft 604320sec
(...)
```

Running command:
```
uyuni-master-podman-pxy:/etc/salt # nmcli device modify eth0 ipv6.addr-gen-mode eui64
Connection successfully reapplied to device 'eth0'.
```

After:
```
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether aa:b2:93:01:00:22 brd ff:ff:ff:ff:ff:ff
(...)
    inet6 2a07:de40:b208:1:a8b2:93ff:fe01:22/64 scope global dynamic mngtmpaddr noprefixroute 
       valid_lft 2591996sec preferred_lft 604796sec
(...)
```
