### PR TITLE
Address test suite dependencies not included in the container images

### DIFF
--- a/salt/server/download_ubuntu_repo.sh
+++ b/salt/server/download_ubuntu_repo.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-DIR=/srv/www/htdocs/pub/$1
-mkdir -p $DIR
-cd $DIR
-wget -r -np -A deb,dsc,tar.xz,tar.gz,gz,key,gpg,Packages,Release,Sources http://$2
-mv $2/* .
-HOST=$(echo $2 | awk -F/ '{print $1}')
-if [ -n "$HOST" -a x"$HOST" != "x/" ]; then
-  rm -rf "$HOST"
+DIRECTORY="/srv/www/htdocs/pub/${1}"
+OPENSUSE_REPOSITORY_URL="${2}"
+EXTENSIONS=(".deb" ".dsc" ".tar.xz" ".tar.gz" ".gz" ".key" ".gpg" "Packages" "Release" ".Sources")
+
+if [ ! -d "${DIRECTORY}" ]; then
+  mkdir --parents "${DIRECTORY}"
 fi
 
+files=$(
+    curl --silent "${OPENSUSE_REPOSITORY_URL}" | \
+    grep --only-matching --perl-regexp '<td\s+class="name"><a\s+href=".*?">(.*?)</a></td>' | \
+    sed -r 's/<[^>]*>//g'
+)
+
+for filename in ${files[@]}; do
+    for extension in ${EXTENSIONS[@]}; do
+        if [[ $filename == *"$extension"* ]]; then
+            curl --output "${DIRECTORY}/$filename" "${OPENSUSE_REPOSITORY_URL}/$filename"
+        fi
+    done
+done

--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -55,7 +55,16 @@ test_repo_debian_updates:
 {% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
       - pkg: uyuni-tools
 {% endif %}
-      - cmd: testsuite_packages
+
+test_repo_debian_updates_packages:
+  cmd.run:
+    - name: mgrctl exec /root/download_ubuntu_repo.sh "TestRepoDebUpdates/all {{ grains.get('mirror') | default('download.opensuse.org', true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb/all/"
+    - unless: mgrctl exec "ls -d /srv/www/htdocs/pub/TestRepoDebUpdates/all"
+    - require:
+      - cmd: test_repo_debian_updates_script_copy
+{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
+      - pkg: uyuni-tools
+{% endif %}
 
 # modify cobbler to be executed from remote-machines..
 cobbler_configuration:
@@ -108,14 +117,6 @@ repo_key_import:
     - name: "mgrctl exec 'rpm --import /tmp/galaxy.key'"
     - onchanges:
       - cmd: galaxy_key_copy
-{% endif %}
-
-testsuite_packages:
-  cmd.run:
-    - name: mgrctl exec "zypper -n in iputils expect wget OpenIPMI"
-{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
-    - require:
-      - pkg: uyuni-tools
 {% endif %}
 
 {% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head"] %}


### PR DESCRIPTION
## What does this PR change?

Adjusting `server_containerized` and scripts involved to do not preinstall packages that are required by the testsuite.
