### PR TITLE
Add missing symlink for containerized proxy module

### DIFF
--- a/modules/proxy_containerized/versions.tf
+++ b/modules/proxy_containerized/versions.tf
@@ -1,0 +1,1 @@
+../backend/host/versions.tf


### PR DESCRIPTION
## What does this PR change?

Fixes this:
```
jenkins@jenkins-worker:~/workspace/manager-5.0-qe-build-validation-PRV/results/sumaform> terraform validate
╷
│ Error: Provider libvirt is undefined
│
│   on main.tf line 355, in module "proxy_containerized":
│  355:     libvirt = libvirt.terminus
│
│ Module module.proxy_containerized does not declare a provider named libvirt.
│ If you wish to specify a provider configuration for the module, add an entry for libvirt in the required_providers block within the module.
╵
```
