### PR TITLE
Add factory 'saltstack' flavor in salt_testenv module

### DIFF
--- a/modules/salt_testenv/variables.tf
+++ b/modules/salt_testenv/variables.tf
@@ -13,9 +13,9 @@ variable "use_os_released_updates" {
 }
 
 variable "salt_obs_flavor" {
-  description = "One of: products, products:testing or products:next"
+  description = "One of: saltstack, saltstack:products, saltstack:products:testing or saltstack:products:next"
   type        = string
-  default     = "products:testing"
+  default     = "saltstack:products:testing"
 }
 
 variable "additional_repos" {

--- a/salt/salt_testenv/init.sls
+++ b/salt/salt_testenv/init.sls
@@ -51,10 +51,10 @@ salt_testsuite_dependencies_repo:
 
 salt_testing_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:{{ grains["salt_obs_flavor"] }}/{{ repo_path }}/
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ grains["salt_obs_flavor"] }}/{{ repo_path }}/
     - refresh: True
     - gpgcheck: 0
-    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:{{ grains["salt_obs_flavor"] }}/{{ repo_path }}/repodata/repomd.xml.key
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ grains["salt_obs_flavor"] }}/{{ repo_path }}/repodata/repomd.xml.key
 
 install_salt_testsuite:
   pkg.installed:
@@ -123,11 +123,11 @@ salt_bundle_testsuite_repo:
 {% if grains['os'] in ["Debian", "Ubuntu"] %}
     - humanname: salt_bundle_testsuite_repo
     - file: /etc/apt/sources.list.d/salt_bundle_testsuite_repo.list
-    - name: deb http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/ /
-    - key_url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/Release.key
+    - name: deb http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/ /
+    - key_url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/Release.key
 {% else %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/
-    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/repodata/repomd.xml.key
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/repodata/repomd.xml.key
     - gpgcheck: 0
 {% endif %}
     - refresh: True


### PR DESCRIPTION
## What does this PR change?

As we want to test Salt from the `systemsmanagement:saltstack` repo in addition to the already existing testing jobs for `systemsmanagement:saltstack:products` and `systemsmanagement:saltstack:next`,  we need to adapt to a more convenient expected value for the `salt_obs_flavor` grain.
