### PR TITLE
Fix Network Manager connection names for Leap micro

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -64,7 +64,7 @@ PACKAGES="$PACKAGES salt-minion"
 %{ endif }
 
 %{ if testsuite }
-PACKAGES="$PACKAGES andromeda-dummy milkyway-dummy virgo-dummy timezone expect"
+PACKAGES="$PACKAGES andromeda-dummy milkyway-dummy virgo-dummy timezone expect bind-utils"
 %{ endif }
 zypper --non-interactive install $PACKAGES
 

--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -1,8 +1,41 @@
 #!/bin/bash
-# combustion: network
+# combustion: network prepare
+set -euxo pipefail
+
+function nm_config() {
+  connectiondir="/etc/NetworkManager/system-connections"
+  connectionfile="$connectiondir/Wired connection $1.nmconnection"
+  mkdir -p "$connectiondir"
+  cat > "$connectionfile" <<EOF
+[connection]
+id=Wired connection $1
+type=ethernet
+interface-name=$2
+
+[ipv4]
+dhcp-timeout=30
+method=auto
+
+[ipv6]
+addr-gen-mode=eui64
+method=auto
+EOF
+  chmod go-r "$connectionfile"
+}
+
+# Name the Network Manager connections (preparation phase in initrd)
+if [ "$${1-}" = "--prepare" ]; then
+  nm_config 1 eth0
+  nm_config 2 eth1
+  exit 0
+fi
 
 # Redirect output to the console
 exec > >(exec tee -a /var/log/combustion) 2>&1
+
+# Name the Network Manager connections (final phase on real filesystem)
+nm_config 1 eth0
+nm_config 2 eth1
 
 # Set linux as password for root
 echo 'root:$6$3aQC9rrDLHiTf1yR$NoKe9tko0kFIpu0rQ2y/OzOOtbVvs0Amr2bx0T4cGf6aq8PG74EmVy8lSDJdbLVVFpOSzwELWyReRCiPHa7DG0' | chpasswd -e


### PR DESCRIPTION
## What does this PR change?

This PR changes "Network Connection" into "Network connection 1" and "Network connection 2".

It also installs bind-utils, needed for "host" utility by test suite.
