### PR TITLE
Proxy and Server we need the extension repos and the tools repo for salt

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -346,10 +346,18 @@ write_files: ${ files }
 
 zypper:
   repos:
-%{ if container_proxy || container_server }
+%{ if container_server }
     - id: container_tools_repo
       name: container_tools_repo
-      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Head/SLE_15_SP5/
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: false
+%{ endif }
+%{ if container_proxy }
+    - id: container_tools_repo
+      name: container_tools_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/
       enabled: 1
       autorefresh: 1
       gpgcheck: false
@@ -378,6 +386,12 @@ zypper:
     - id: micro_update_repo
       name: micro_update_repo
       baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/SUSE/Updates/SLE-Micro/5.5/x86_64/update/
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: false
+    - id: tools_pool_repo
+      name: tools_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
       enabled: 1
       autorefresh: 1
       gpgcheck: false


### PR DESCRIPTION
## What does this PR change?

Using Devel:Galaxy:Manager:Head can introduce unwanted extra packages. Better to use the repos which were build only with the packages which are available on the product.
