### PR TITLE
Install dbus-tools package in RH-Like images to have available dbus-uuidgen

### DIFF
--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -98,7 +98,7 @@ yum_repos:
     gpgcheck: false
     name: temp_tools_pool_repo
 
-packages: ["venv-salt-minion"]
+packages: ["venv-salt-minion", "dbus-tools"]
 runcmd:
   # WORKAROUND: rhel9 change ssh security for ssh key
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
@@ -115,7 +115,7 @@ yum_repos:
     gpgcheck: false
     name: temp_tools_pool_repo
 
-packages: ["venv-salt-minion"]
+packages: ["venv-salt-minion", "dbus-tools"]
 %{ endif }
 %{ if image == "rocky8"}
 yum_repos:
@@ -127,7 +127,7 @@ yum_repos:
     gpgcheck: false
     name: temp_tools_pool_repo
 
-packages: ["venv-salt-minion"]
+packages: ["venv-salt-minion", "dbus-tools"]
 %{ endif }
 %{ if image == "centos7" || image == "rhel7"}
 yum_repos:

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -800,9 +800,9 @@ yum_repos:
     name: epel
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns"]
+packages: ["venv-salt-minion", "avahi", "nss-mdns", "dbus-tools"]
 %{ else }
-packages: ["avahi", "nss-mdns", "salt-minion"]
+packages: ["avahi", "nss-mdns", "salt-minion", "dbus-tools"]
 %{ endif }
 
 %{ endif }
@@ -829,9 +829,9 @@ runcmd:
   - systemctl restart sshd
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns"]
+packages: ["venv-salt-minion", "avahi", "nss-mdns", "dbus-tools"]
 %{ else }
-packages: ["avahi", "nss-mdns", "salt-minion"]
+packages: ["avahi", "nss-mdns", "salt-minion", "dbus-tools"]
 %{ endif }
 %{ endif }
 


### PR DESCRIPTION
## What does this PR change?

This PR aims to solve:

```
Command "rm -f /etc/machine-id && rm -f /var/lib/dbus/machine-id && mkdir -p /var/lib/dbus && dbus-uuidgen --ensure && systemd-machine-id-setup && touch /etc/machine-id-already-setup" run[0;0m
(...)
[2024-05-15T12:14:41.850Z] [0m[1mmodule.rocky9-minion.module.minion.module.host.null_resource.provisioning[0] (remote-exec):[0m [0m                  [0;32m/bin/bash: line 1: dbus-uuidgen: command not found[0;0m
```
