### PR TITLE
QE: Add documentation for head with containerized setup

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -5,6 +5,7 @@
 Some modules have a `product_version` variable that determines the software product version. Specifically:
 
 - in `server`, `proxy` etc. `product_version` determines the SUSE Manager/Uyuni product version,
+- in `server_containerized`, `proxy_containerized` etc. `product_version` determines the SUSE Manager/Uyuni product version - this is currently the recommended setup for head,
 - in `minion`, `client`, etc. `product_version` determines the SUSE Manager/Uyuni Tools version.
 
 Legal values for released software are:
@@ -20,7 +21,7 @@ Legal values for work-in-progress software are:
 - `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
 - `4.3-VM-nightly`       (corresponds to the Virtual Image in the Build Service project Devel:Galaxy:Manager:4.3)
 - `4.3-beta`    (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
-- `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, for `server` and `proxy`only works with SLE15SP4 image)
+- `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, **must be used with `server_containerized` and `proxy_containerized` modules**, uses SLE Micro 5.5 as base image for server)
 - `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap image)
 
 Legal values for CI:

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -21,7 +21,7 @@ Legal values for work-in-progress software are:
 - `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
 - `4.3-VM-nightly`       (corresponds to the Virtual Image in the Build Service project Devel:Galaxy:Manager:4.3)
 - `4.3-beta`    (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
-- `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, **must be used with `server_containerized` and `proxy_containerized` modules**, uses SLE Micro 5.5 as base image for server)
+- `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, **must be used with `server_containerized` and `proxy_containerized` modules**, uses SLE Micro as base image for server)
 - `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap image)
 
 Legal values for CI:

--- a/README_TESTING.md
+++ b/README_TESTING.md
@@ -104,11 +104,11 @@ ssh -t head-ctl.tf.local screen -r
 
 ## Using Salt Bundle (venv-salt-minion) in "Head" and "Uyuni"
 
-Currently, our `head` and `uyuni-master` testing deployments require the Salt Bundle (`venv-salt-minion` package) to be installed on each client instance and some other tunings, before the testsuite is started. To be sure that all necessary adjustments are in place for the testsuite to run for HEAD or Uyuni, you need to set some flags on each of your instances (except for the server instance) in your `main.tf` file:
+Currently, our `head` and `uyuni-master` testing deployments require the Salt Bundle (`venv-salt-minion` package) to be installed on each client instance and some other tunings, before the testsuite is started. Also, bear in mind that the `head` setup requires a containerized setup - use `server_containerized` and `proxy_containerized` modules (refer to the `main.tf.libvirt-testsuite.example` file to see how to configure this). To be sure that all necessary adjustments are in place for the testsuite to run for HEAD or Uyuni, you need to set some flags on each of your instances (except for the server/ server_containerized instance) in your `main.tf` file:
 
 ```hcl
 host_settings = {
-  proxy = {
+  proxy_containerized = {
     additional_packages = [ "venv-salt-minion" ]
     install_salt_bundle = true
   }


### PR DESCRIPTION
## What does this PR change?
Adds the heads up about `head` needing to use a containerized setup to `README_ADVANCED.md` and `README_TESTING.md` files.
Related to https://github.com/SUSE/spacewalk/issues/24332
