### PR TITLE
Enable salt_testenv module to use openSUSE Tumbleweed

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -52,6 +52,7 @@ locals {
     slmicro60o               = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_60/SL-Micro.x86_64-sumaform.qcow2"
     suma43VM-ign             = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.suse.de"}/ibs/Devel:/Galaxy:/Manager:/4.3/images/SUSE-Manager-Server.x86_64-KVM-x86_64.qcow2"
     leapmicro55o             = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/distribution/leap-micro/5.5/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2"
+    tumbleweedo              = "${var.use_mirror_images ? "http://${var.mirror}" : "https://download.opensuse.org"}/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2"
   }
   pool               = lookup(var.provider_settings, "pool", "default")
   network_name       = lookup(var.provider_settings, "network_name", "default")

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -7,6 +7,22 @@ chpasswd:
   list: |
      root:linux
 
+%{ if image == "tumbleweedo"}
+runcmd:
+  - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+  - systemctl restart sshd
+zypper:
+  repos:
+    - id: tools_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/saltstack/openSUSE_Tumbleweed/
+      enabled: true
+      gpgcheck: false
+      name: tools_pool_repo
+# For openSUSE Tumbleweed venv-salt-minion is not available.
+# The goal is to be able to run Salt Shaker tests for the classic Salt package in Tumbleweed.
+packages: ["salt", "salt-minion", "avahi", "avahi-lang"]
+%{endif}
+
 %{ if image == "centos7o" }
 yum_repos:
   # repo for salt

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -67,7 +67,7 @@ variable "provider_settings" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default     = [ "almalinux8o", "almalinux9o", "amazonlinux2o", "centos7o", "libertylinux9o", "opensuse154o", "opensuse155o", "oraclelinux9o", "rocky8o", "rocky9o", "sles12sp4o", "sles12sp5o", "sles15sp3o", "sles15sp4o", "ubuntu2004o", "ubuntu2204o" ]
+  default     = [ "almalinux8o", "almalinux9o", "amazonlinux2o", "centos7o", "libertylinux9o", "opensuse154o", "opensuse155o", "tumbleweedo", "oraclelinux9o", "rocky8o", "rocky9o", "sles12sp4o", "sles12sp5o", "sles15sp3o", "sles15sp4o", "ubuntu2004o", "ubuntu2204o"]
   type        = set(string)
 }
 

--- a/modules/salt_testenv/main.tf
+++ b/modules/salt_testenv/main.tf
@@ -11,7 +11,7 @@ module "salt_testenv" {
   ssh_key_path                  = var.ssh_key_path
   image                         = var.image
   provider_settings             = var.provider_settings
-  install_salt_bundle           = true
+  install_salt_bundle           = var.install_salt_bundle
 
   grains = {
     mirror                  = var.base_configuration["mirror"]

--- a/modules/salt_testenv/variables.tf
+++ b/modules/salt_testenv/variables.tf
@@ -53,3 +53,8 @@ variable "image" {
   type        = string
   default = "opensuse155o"
 }
+
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = true
+}

--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -30,7 +30,7 @@ legacy_permanent_hostname:
     - follow_symlinks: False
     - contents: {{ grains['hostname'] }}.{{ grains['domain'] }}
 
-{% if grains['os_family'] == 'Suse' and grains["osfullname"] != 'SL-Micro' %}
+{% if grains['os_family'] == 'Suse' and grains["osfullname"] not in ['SL-Micro', 'openSUSE Tumbleweed'] %}
 change_searchlist:
   file.replace:
     - name: /etc/sysconfig/network/config

--- a/salt/salt_testenv/init.sls
+++ b/salt/salt_testenv/init.sls
@@ -1,8 +1,9 @@
 include:
   - default
 
-{% if (grains['os'] == 'SUSE' and grains['osrelease_info'][0] == 15) or (grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro') %}
-{% if grains['osfullname'] == 'SLES' %}
+{% if grains['os'] == 'SUSE' %}
+
+{% if grains['osfullname'] == 'SLES' and grains['osrelease_info'][0] == 15  %}
 {% set repo_path = "15" if grains["osrelease"] == 15 else "15-SP" + grains["osrelease_info"][1]|string %}
 development_tools_repo_pool:
   pkgrepo.managed:
@@ -34,15 +35,17 @@ containers_updates_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/{{ repo_path }}/x86_64/update/
     - refresh: True
-{% endif %}
 
-{% if grains['osfullname'] == 'SLES' and grains['osrelease_info'][1] >= 3 %}
+{% if grains['osrelease_info'][1] >= 3 %}
 {% set repo_path = grains["osrelease"] %}
 {% else %}
 {% set repo_path = "SLE_15_SP" + grains["osrelease_info"][1]|string %}
 {% endif %}
 
-{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
+{% endif %}
+
+
+{% if grains['osfullname'] == 'SL-Micro' %}
 {% set repo_path = 'SLMicro' + grains['osrelease_info'][0]|string + grains['osrelease_info'][1]|string %}
 os_pool_repo:
   pkgrepo.managed:
@@ -53,6 +56,15 @@ alp_sources_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/ALP:/Source:/Standard:/Core:/1.0:/Build/standard/
     - refresh: True
+{% endif %}
+
+{% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
+{% set repo_path = 'openSUSE_Tumbleweed' %}
+repo-oss:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/tumbleweed/repo/oss/
+    - refresh: True
+    - gpgcheck: False
 {% endif %}
 
 salt_testsuite_dependencies_repo:
@@ -91,6 +103,7 @@ start_docker_service:
 {% endif %}
     - requires:
       - pkg: install_salt_testsuite
+
 {% endif %}
 
 {% if grains['os'] == 'Debian' %}
@@ -135,6 +148,8 @@ start_docker_service:
     {% endif %}
 {% endif %}
 
+{% if grains['osfullname'] != 'openSUSE Tumbleweed' %}
+
 {% if grains["salt_obs_flavor"] == "saltstack:products" %}
     {% set salt_flavor_path = "saltstack:bundle" %}
 {% elif grains["salt_obs_flavor"] == "saltstack:products:testing" %}
@@ -169,6 +184,8 @@ install_salt_bundle_testsuite:
 {% endif %}
     - require:
       - pkgrepo: salt_bundle_testsuite_repo
+
+{% endif %}
 
 {% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
 copy_salt_classic_testsuite:


### PR DESCRIPTION
## What does this PR change?

The goal is to be able to run Salt Shaker tests in openSUSE Tumbleweed (for the classic Salt package).
