### PR TITLE
Salt Shaker: Make sure "python3-salt" is upgraded after final repos are set

### DIFF
--- a/salt/salt_testenv/init.sls
+++ b/salt/salt_testenv/init.sls
@@ -72,10 +72,10 @@ salt_testing_repo:
 install_salt_testsuite:
 {% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
   cmd.run:
-    - name: transactional-update -c -n pkg in python3-salt-testsuite python3-salt-test
+    - name: transactional-update -c -n pkg in python3-salt-testsuite python3-salt-test python3-salt
 {% else %}
-  pkg.installed:
-    - pkgs: ["python3-salt-testsuite", "python3-salt-test"]
+  pkg.latest:
+    - pkgs: ["python3-salt-testsuite", "python3-salt-test", "python3-salt"]
 {% endif %}
     - require:
       - pkgrepo: salt_testsuite_dependencies_repo


### PR DESCRIPTION
## What does this PR change?

As title mentions, this PR make sure `python3-salt`, which is preinstalled on the VM by cloud-unit/combustion, get upgraded to latest version available after setting up the corresponding repositories (depending on salt flavor) during sumaform deployment.

Without this change, there are changes that the `python3-salt-testsuite` package gets installed but not aligned with the actual codebase provided by `python3-salt`, as this package was not updated after configuring the final repos.