### PR TITLE
split default.sls in default_settings, os and clienttools

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -443,10 +443,10 @@ zypper:
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-%{ for repo in jsondecode(additional_repos) }
-    - id: {{ repo[0] }}_repo
-      name: {{ repo[0] }}_repo
-      baseurl: {{ repo[1] }} 
+%{ for name, url in jsondecode(additional_repos) }
+    - id: ${name}_repo
+      name: ${name}_repo
+      baseurl: ${url}
       enabled: 1
       autorefresh: 1
       gpgcheck: false

--- a/salt/repos/clienttools.sls
+++ b/salt/repos/clienttools.sls
@@ -1,56 +1,18 @@
-{% for keypath in grains.get('gpg_keys') | default([], true) %}
-{% set keyname =  salt['file.basename'](keypath)  %}
-gpg_key_copy_{{ keypath }}:
-  file.managed:
-    - name: /tmp/{{ keyname }}
-    - source: salt://{{ keypath }}
-install_{{ keypath }}:
-  cmd.wait:
-    - name: rpm --import /tmp/{{ salt['file.basename'](keypath) }}
-    - watch:
-      - file: /tmp/{{ keyname }}
-{% endfor %}
+{# This state setup client tools repositories for all supported OSes #}
+
+{% if not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles')) %} {# no clienttools on server or proxy #}
 
 {% if grains['os'] == 'SUSE' %}
 {% if grains['osfullname'] == 'Leap' %}
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/distribution/leap/{{ grains['osrelease'] }}/repo/oss/
-    - refresh: True
 
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/oss/
-    - refresh: True
-
-{% if grains['osrelease_info'][0] == 15 and grains['osrelease_info'][1] >= 3 %}
-sle_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/sle/
-    - refresh: True
-
-backports_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/backports/
-    - refresh: True
-{% endif %}
-
-{% if not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles')) %}
 {% if grains.get('product_version') and 'uyuni-master' in grains.get('product_version') | default('', true) %}
+
 tools_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
     - refresh: True
     - gpgcheck: 1
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
-
-{% if grains['osrelease_info'][0] == 15 and grains['osrelease_info'][1] >= 3 %}
-# Needed because in sles15SP3 and opensuse 15.3 and higher firewalld will replace this package.
-# But the tools_update_repo priority don't allow to cope with the Obsoletes option from firewalld
-lock_firewalld_prometheus_config_leap_cmd:
-   cmd.run:
-     - name: zypper addlock firewalld-prometheus-config
-{% endif %}
 
 {% elif not grains.get('product_version') or not 'uyuni-pr' in grains.get('product_version') | default('', true) %}
 
@@ -59,59 +21,36 @@ tools_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
     - refresh: True
-{% else %}
+{% else %} ## Leap on SUMA
 tools_pool_repo:
   pkgrepo.managed:
-    {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15-BETA/x86_64/product/
-    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/
-    {% endif %}
     - refresh: True
 
 tools_update_repo:
   pkgrepo.managed:
-    {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15-BETA/x86_64/update/
-    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/
-    {% endif %}
     - refresh: True
-{% endif %}
 
-{% endif %}
-{% endif %} {# not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles')) #}
+{% if 'beta' in grains.get('product_version') | default('', true) %}
+beta_tools_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15-BETA/x86_64/product/
+    - refresh: True
+
+beta_tools_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15-BETA/x86_64/update/
+    - refresh: True
+
+{% endif %} {# 'beta' in grains.get('product_version') #}
+
+{% endif %} {# not grains.get('product_version') or grains.get('product_version').startswith('uyuni-') #}
+{% endif %} {# grains.get('product_version') and 'uyuni-master' in grains.get('product_version') #}
 
 {% elif grains['osfullname'] == 'SLES' %}
 
 {% if grains['osrelease'] == '11.4' %}
-
-os_pool_repo:
-  pkgrepo.managed:
-    {% if grains.get('mirror') %}
-    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-Pool/sle-11-x86_64/
-    {% else %}
-    - baseurl: http://euklid.nue.suse.com/mirror/SuSE/zypp-patches.suse.de/x86_64/update/SLE-SERVER/11-SP4-POOL/
-    {% endif %}
-    - refresh: True
-
-os_update_repo:
-  pkgrepo.managed:
-    {% if grains.get('mirror') %}
-    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-Updates/sle-11-x86_64/
-    {% else %}
-    - baseurl: http://euklid.nue.suse.com/mirror/SuSE/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SP4/x86_64/update/
-    {% endif %}
-    - refresh: True
-
-os_ltss_repo:
-  pkgrepo.managed:
-    {% if grains.get('mirror') %}
-    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-LTSS-Updates/sle-11-x86_64/
-    {% else %}
-    - baseurl: http://euklid.nue.suse.com/mirror/SuSE/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SP4-LTSS/x86_64/update/
-    {% endif %}
-    - refresh: True
 
 tools_pool_repo:
   pkgrepo.managed:
@@ -143,83 +82,41 @@ tools_additional_repo:
 
 
 {% if '12' in grains['osrelease'] %}
-{% if not grains.get('sles_registration_code') %} ## Skip if SCC support
-{% if grains['osrelease'] == '12.3' %}
 
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/
-    - refresh: True
+{% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %} {# Released Tools Repos #}
 
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/
-    - refresh: True
-
-{% elif grains['osrelease'] == '12.4' %}
-
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
-    - refresh: True
-
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP4/x86_64/update/
-    - refresh: True
-
-os_ltss_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP4-LTSS/x86_64/update/
-    - refresh: True
-
-{% elif grains['osrelease'] == '12.5' %}
-
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-SERVER/12-SP5/x86_64/product/
-    - refresh: True
-
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/
-    - refresh: True
-
-# uncomment when it goes LTSS
-# os_ltss_repo:
-#   pkgrepo.managed:
-#           - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP5-LTSS/x86_64/update/
-
-{% endif %}
-{% endif %} ## End skip if SCC support
-
-{% if not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles')) %}
-{% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %}
 tools_pool_repo:
   pkgrepo.managed:
-    {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/12-BETA/x86_64/product/
-    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/
-    {% endif %}
     - refresh: True
 
 tools_update_repo:
   pkgrepo.managed:
-    {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/12-BETA/x86_64/update/
-    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/
-    {% endif %}
     - refresh: True
+
+{% if 'beta' in grains.get('product_version') | default('', true) %}
+beta_tools_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/12-BETA/x86_64/product/
+    - refresh: True
+
+beta_tools_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/12-BETA/x86_64/update/
+    - refresh: True
+{% endif %} {# 'beta' in grains.get('product_version') #}
+
 {% else %}
+
 tools_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
     - refresh: True
-{% endif %}
+{% endif %} {# Released Tools Repos #}
 
-{% if 'nightly' in grains.get('product_version') | default('', true) %}
+{% if 'nightly' in grains.get('product_version') | default('', true) %} {# DEVEL Tools Repos #}
+
 tools_additional_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.3:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1/
@@ -227,6 +124,7 @@ tools_additional_repo:
     - priority: 98
 
 {% elif 'head' in grains.get('product_version') | default('', true) %}
+
 tools_additional_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-Beta-POOL-x86_64-Media1/
@@ -234,254 +132,141 @@ tools_additional_repo:
     - priority: 98
 
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
+
 tools_additional_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/
     - refresh: True
     - priority: 98
-{% endif %}
 
-{% endif %} {# not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles')) #}
+{% endif %} {# DEVEL Tools Repos #}
+
 {% endif %} {# '12' in grains['osrelease'] #}
 
 
 {% if '15' in grains['osrelease'] %}
-{% if (not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles'))) %}
-{% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %}
+{% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %} {# Released Tools repos #}
+
 tools_pool_repo:
   pkgrepo.managed:
-    {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15-BETA/{{ grains.get("cpuarch") }}/product/
-    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15/{{ grains.get("cpuarch") }}/product/
-    {% endif %}
     - refresh: True
 
 tools_update_repo:
   pkgrepo.managed:
-    {% if 'beta' in grains.get('product_version') | default('', true) %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15-BETA/{{ grains.get("cpuarch") }}/update/
-    {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15/{{ grains.get("cpuarch") }}/update/
-    {% endif %}
     - refresh: True
+
+{% if 'beta' in grains.get('product_version') | default('', true) %}
+beta_tools_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools/15-BETA/{{ grains.get("cpuarch") }}/product/
+    - refresh: True
+
+beta_tools_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools/15-BETA/{{ grains.get("cpuarch") }}/update/
+    - refresh: True
+{% endif %} {# 'beta' in grains.get('product_version') #}
+
 {% else %}
+
 tools_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
     - refresh: True
-{% endif %}
 
-{% if 'nightly' in grains.get('product_version') | default('', true) %}
+{% endif %} {# Released Tools repos #}
+
+{% if 'nightly' in grains.get('product_version') | default('', true) %} {# Devel Tools Repos #}
+
 tools_additional_repo:
   pkgrepo.managed:
   - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.3:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
   - refresh: True
   - priority: 98
 
-{% if grains['osrelease_info'][0] == 15 and grains['osrelease_info'][1] >= 3 %}
-# Needed because in sles15SP3 and opensuse 15.3 and higher firewalld will replace this package.
-# But the tools_update_repo priority don't allow to cope with the Obsoletes option from firewalld
-lock_firewalld_prometheus_config_cmd:
-   cmd.run:
-     - name: zypper addlock firewalld-prometheus-config
-{% endif %}
-
 {% elif 'head' in grains.get('product_version') | default('', true) %}
+
 tools_additional_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
     - refresh: True
     - priority: 98
 
-{% if grains['osrelease_info'][0] == 15 and grains['osrelease_info'][1] >= 3 %}
-# Needed because in sles15SP3 and opensuse 15.3 and higher firewalld will replace this package.
-# But the tools_update_repo priority don't allow to cope with the Obsoletes option from firewalld
-lock_firewalld_prometheus_config_cmd:
-   cmd.run:
-     - name: zypper addlock firewalld-prometheus-config
-{% endif %}
-
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
+
 tools_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
     - refresh: True
 
-{% if grains['osrelease_info'][0] == 15 and grains['osrelease_info'][1] >= 3 %}
-# Needed because in sles15SP3 and opensuse 15.3 and higher firewalld will replace this package.
-# But the tools_update_repo priority don't allow to cope with the Obsoletes option from firewalld
-lock_firewalld_prometheus_config_cmd:
-   cmd.run:
-     - name: zypper addlock firewalld-prometheus-config
-{% endif %}
-
-{% endif %}
-
-
-{% endif %} {# not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles')) #}
+{% endif %} {# Devel Tools Repos #}
 {% endif %} {# '15' in grains['osrelease'] #}
 
-{% if '15' == grains['osrelease'] %}
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
-    - refresh: True
+{% elif grains['osfullname'] == 'SLE Micro' %}
 
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
-    - refresh: True
+{% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %} {# Released Tools repos #}
 
-os_ltss_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-LTSS/x86_64/update/
-    - refresh: True
-
-{% endif %} {# '15' == grains['osrelease'] #}
-
-{% if '15.1' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true)) %}
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/
-    - refresh: True
-
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/
-    - refresh: True
-
-os_ltss_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-SP1-LTSS/x86_64/update/
-    - refresh: True
-
-{% endif %} {# '15.1' == grains['osrelease'] #}
-
-{% if '15.2' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true)) %}
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
-    - refresh: True
-
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/
-    - refresh: True
-
-os_ltss_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
-
-{% endif %} {# '15.2' == grains['osrelease'] #}
-
-{% if '15.3' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true)) %}
-
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP3/{{ grains.get("cpuarch") }}/product/
-    - refresh: True
-
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP3/{{ grains.get("cpuarch") }}/update/
-    - refresh: True
-
-os_ltss_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/{{ grains.get("cpuarch") }}/update/
-
-{% endif %} {# '15.3' == grains['osrelease'] #}
-
-{% if '15.4' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true) ) %}
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP4/{{ grains.get("cpuarch") }}/product/
-    - refresh: True
-
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP4/{{ grains.get("cpuarch") }}/update/
-    - refresh: True
-
-os_ltss_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-SP4-LTSS/{{ grains.get("cpuarch") }}/update/
-    - refresh: True
-
-{% endif %} {# '15.4' == grains['osrelease'] #}
-
-{% if '15.5' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true) ) %}
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP5/x86_64/product/
-    - refresh: True
-
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP5/x86_64/update/
-    - refresh: True
-
-# uncomment when it goes LTSS
-#os_ltss_repo:
-#  pkgrepo.managed:
-#    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP5-LTSS/x86_64/update/
-#    - refresh: True
-
-{% endif %} {# '15.5' == grains['osrelease'] #}
-
-{% if '15.6' == grains['osrelease'] and not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true) ) %}
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP6/x86_64/product/
-    - refresh: True
-
-os_update_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP6/x86_64/update/
-    - refresh: True
-
-  # uncomment when it goes LTSS
-  #os_ltss_repo:
-  #  pkgrepo.managed:
-  #    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP6-LTSS/x86_64/update/
-  #    - refresh: True
-
-{% endif %} {# '15.6' == grains['osrelease'] #}
-{% endif %}{# grains['osfullname'] == 'SLES' #}
-
-{% if grains['osfullname'] in ['SLE Micro', 'SL-Micro'] and (not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles'))) %}
-{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-released' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') %}
 tools_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools-For-Micro/5/{{ grains.get("cpuarch") }}/product/
     - refresh: True
-    - gpgcheck: 1
-    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
-{% elif 'head' in grains.get('product_version', '') %}
-tools_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools-For-Micro/5/x86_64/product/
-    - refresh: True
-    - gpgcheck: 1
-    - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools-For-Micro/5/x86_64/product/repodata/repomd.xml.key
+
 tools_update_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools-For-Micro/5/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools-For-Micro/5/{{ grains.get("cpuarch") }}/update/
+    - refresh: True
+
+{% if 'beta' in grains.get('product_version') | default('', true) %}
+beta_tools_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Manager-Tools-Beta-For-Micro/5/{{ grains.get("cpuarch") }}/product/
+    - refresh: True
+
+beta_tools_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools-Beta-For-Micro/5/{{ grains.get("cpuarch") }}/update/
+    - refresh: True
+{% endif %} {# 'beta' in grains.get('product_version') #}
+
+{% else %}
+
+tools_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+    - refresh: True
+
+{% endif %} {# Released Tools repos #}
+
+{% if 'nightly' in grains.get('product_version') | default('', true) %} {# Devel Tools Repos #}
+
+tools_additional_repo:
+  pkgrepo.managed:
+  - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.3:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
+  - refresh: True
+  - priority: 98
+
+{% elif 'head' in grains.get('product_version') | default('', true) %}
+
+tools_additional_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
+    - refresh: True
+    - priority: 98
+
+{% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
+
+tools_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
     - refresh: True
     - gpgcheck: 1
-    - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Manager-Tools-For-Micro/5/x86_64/update/repodata/repomd.xml.key
-{% endif %}
-{% endif %}
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.keya
 
-install_recommends:
-  file.comment:
-    - name: /etc/zypp/zypp.conf
-    - regex: ^solver.onlyRequires =.*
-{%- if grains['saltversioninfo'][0] >= 3005 %}
-    - ignore_missing: True
-{% endif %}
-    - onlyif: grep ^solver.onlyRequires /etc/zypp/zypp.conf
+
+{% endif %} {# Devel Tools Repos #}
+{% endif %} {# grains['osfullname'] == 'SLE Micro' #}
 
 {% endif %} {# grains['os'] == 'SUSE' #}
 
@@ -489,75 +274,8 @@ install_recommends:
 
 {% set release = grains.get('osmajorrelease', None)|int() %}
 
-{# Soon this key will be used for all non-suse repos. When it happens, replace galaxy_key with this #}
-suse_el9_key:
-  file.managed:
-    - name: /tmp/suse_el9.key
-    - source: salt://default/gpg_keys/suse_el9.key
-  cmd.wait:
-    - name: rpm --import /tmp/suse_el9.key
-    - watch:
-      - file: suse_el9_key
 
-galaxy_key:
-  file.managed:
-    - name: /tmp/galaxy.key
-    - source: salt://default/gpg_keys/galaxy.key
-  cmd.wait:
-    - name: rpm --import /tmp/galaxy.key
-    - watch:
-      - file: galaxy_key
-
-suse_res7_key:
-  file.managed:
-    - name: /tmp/suse_res7.key
-    - source: salt://default/gpg_keys/suse_res7.key
-  cmd.wait:
-    - name: rpm --import /tmp/suse_res7.key
-    - watch:
-      - file: suse_res7_key
-{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-released' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') %}
-uyuni_key:
-  file.managed:
-    - name: /tmp/uyuni.key
-    - source: salt://default/gpg_keys/uyuni.key
-  cmd.wait:
-    - name: rpm --import /tmp/uyuni.key
-    - watch:
-      - file: uyuni_key
-{% endif %}
-
-{% if release == 9 %}
-{% if salt['file.search']('/etc/os-release', 'Liberty') %}
-
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://rmt.scc.suse.de/repo/SUSE/Updates/SLL/9/x86_64/update
-    - refresh: True
-
-os_as_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://rmt.scc.suse.de/repo/SUSE/Updates/SLL-AS/9/x86_64/update
-    - refresh: True
-
-os_updates_repo:
-  pkgrepo.managed:
-    - baseurl: https://rmt.scc.suse.de/repo/SUSE/Updates/SLL/9/x86_64/update/?credentials=SUSE_Liberty_Linux_x86_64
-    - refresh: True
-
-os_as_updates_repo:
-  pkgrepo.managed:
-    - baseurl: https://rmt.scc.suse.de/repo/SUSE/Updates/SLL-AS/9/x86_64/update/?credentials=SUSE_Liberty_Linux_x86_64
-    - refresh: True
-
-os_cb_updates_repo:
-  pkgrepo.managed:
-    - baseurl: https://rmt.scc.suse.de/repo/SUSE/Updates/SLL-CB/9/x86_64/update/?credentials=SUSE_Liberty_Linux_x86_64
-    - refresh: True
-{% endif %} {# salt['file.search']('/etc/os-release', 'Liberty') #}
-{% endif %} {# release == 9 #}
-
-{% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %}
+{% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %} {# Released Tools Repos #}
 
 {% set rhlike_client_tools_prefix = 'EL' %}
 {% if release < 9 %}
@@ -592,22 +310,7 @@ tools_pool_repo:
     {% endif %}
     {% endif %}
     - refresh: True
-    - require:
-      - cmd: galaxy_key
-    {% if release >= 9 %}
-      - cmd: suse_el9_key
-    {% else %}
-      - cmd: suse_res7_key
-    {% endif %}
 
-suse_res6_key:
-  file.managed:
-    - name: /tmp/suse_res6.key
-    - source: salt://default/gpg_keys/suse_res6.key
-  cmd.wait:
-    - name: rpm --import /tmp/suse_res6.key
-    - watch:
-      - file: suse_res6_key
 {% else %}
 
 {% set rhlike_client_tools_prefix = 'EL' %}
@@ -622,9 +325,9 @@ tools_pool_repo:
     - refresh: True
     - require:
       - cmd: uyuni_key
-{% endif %}
+{% endif %} {# Released Tools Repos #}
 
-{% if 'nightly' in grains.get('product_version') | default('', true) %}
+{% if 'nightly' in grains.get('product_version') | default('', true) %} {# Devel Tools Repos #}
 
 {% set rhlike_client_tools_prefix = 'EL' %}
 {% if release < 9 %}
@@ -680,7 +383,9 @@ tools_update_repo:
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/{{ rhlike_client_tools_prefix }}{{ release }}-Uyuni-Client-Tools/{{ rhlike_client_tools_prefix }}_{{ release }}/repodata/repomd.xml.key
     - require:
       - cmd: uyuni_key
+
 {% else %}
+
 {% if release >= 8 %}
 
 {% set rhlike_client_tools_prefix = 'EL' %}
@@ -704,8 +409,9 @@ tools_update_repo:
     {% else %}
       - cmd: suse_res7_key
     {% endif %}
-{% endif %}
-{% endif %}
+
+{% endif %} {# release >= 8 #}
+{% endif %} {# Devel Tools Repos #}
 
 clean_repo_metadata:
   cmd.run:
@@ -713,40 +419,6 @@ clean_repo_metadata:
 
 {% endif %} {# grains['os_family'] == 'RedHat' #}
 
-{% if grains['os_family'] == 'Debian' %}
-
-{% set release = grains.get('osrelease', None) %}
-{% set short_release = release | replace('.', '') %}
-
-disable_apt_daily_timer:
-  service.dead:
-    - name: apt-daily.timer
-    - enable: False
-
-disable_apt_daily_upgrade_timer:
-  service.dead:
-    - name: apt-daily-upgrade.timer
-    - enable: False
-
-disable_apt_daily_service:
-  service.dead:
-    - name: apt-daily.service
-    - enable: False
-
-disable_apt_daily_upgrade_service:
-  service.dead:
-    - name: apt-daily-upgrade.service
-    - enable: False
-
-wait_until_apt_lock_file_unlock:
-  cmd.run:
-    - name: "test ! -f /var/lib/apt/lists/lock || ! lsof /var/lib/apt/lists/lock"
-    - retry:
-      - attempts: 10
-      - interval: 5
-      - until: True
-
-{% endif %} {# grains['os_family'] == 'Debian' #}
 
 {% if grains['os'] == 'Ubuntu' %}
 
@@ -876,12 +548,7 @@ tools_update_repo_raised_priority:
         Pin-Priority: 800
 {% endif %}
 {% endif %} {# grains['os'] == 'Debian' #}
-
-{% if grains['os_family'] == 'Debian' %}
-remove_no_install_recommends:
-  file.absent:
-    - name: /etc/apt/apt.conf.d/00InstallRecommends
-{% endif %}
+{% endif %} {# no clienttools on server or proxy #}
 
 {# WORKAROUND: see github:saltstack/salt#10852 #}
 {{ sls }}_nop:

--- a/salt/repos/clienttools.sls
+++ b/salt/repos/clienttools.sls
@@ -204,6 +204,9 @@ tools_update_repo:
 {% endif %} {# Devel Tools Repos #}
 {% endif %} {# '15' in grains['osrelease'] #}
 
+{% elif grains['osfullname'] == 'SL-Micro' %}
+{# TODO: add SL Micro 6 #}
+
 {% elif grains['osfullname'] == 'SLE Micro' %}
 
 {% if not grains.get('product_version') or not grains.get('product_version').startswith('uyuni-') %} {# Released Tools repos #}

--- a/salt/repos/default_settings.sls
+++ b/salt/repos/default_settings.sls
@@ -1,0 +1,124 @@
+{# This state setup special settings which are needed for various OSes #}
+
+{% for keypath in grains.get('gpg_keys') | default([], true) %}
+{% set keyname =  salt['file.basename'](keypath)  %}
+gpg_key_copy_{{ keypath }}:
+  file.managed:
+    - name: /tmp/{{ keyname }}
+    - source: salt://{{ keypath }}
+install_{{ keypath }}:
+  cmd.wait:
+    - name: rpm --import /tmp/{{ salt['file.basename'](keypath) }}
+    - watch:
+      - file: /tmp/{{ keyname }}
+{% endfor %}
+
+
+{% if grains['os'] == 'SUSE' %}
+
+{% if grains['osrelease_info'][0] == 15 and grains['osrelease_info'][1] >= 3 %}
+# Needed because in sles15SP3 and opensuse 15.3 and higher firewalld will replace this package.
+# But the tools_update_repo priority don't allow to cope with the Obsoletes option from firewalld
+lock_firewalld_prometheus_config_leap_cmd:
+   cmd.run:
+     - name: zypper addlock firewalld-prometheus-config
+{% endif %}
+
+install_recommends:
+  file.comment:
+    - name: /etc/zypp/zypp.conf
+    - regex: ^solver.onlyRequires =.*
+{%- if grains['saltversioninfo'][0] >= 3005 %}
+    - ignore_missing: True
+{% endif %}
+    - onlyif: grep ^solver.onlyRequires /etc/zypp/zypp.conf
+
+{% endif %} {# grains['os'] == 'SUSE' #}
+
+
+{% if grains['os_family'] == 'RedHat' %}
+
+{% set release = grains.get('osmajorrelease', None)|int() %}
+
+{# Soon this key will be used for all non-suse repos. When it happens, replace galaxy_key with this #}
+suse_el9_key:
+  file.managed:
+    - name: /tmp/suse_el9.key
+    - source: salt://default/gpg_keys/suse_el9.key
+  cmd.wait:
+    - name: rpm --import /tmp/suse_el9.key
+    - watch:
+      - file: suse_el9_key
+
+galaxy_key:
+  file.managed:
+    - name: /tmp/galaxy.key
+    - source: salt://default/gpg_keys/galaxy.key
+  cmd.wait:
+    - name: rpm --import /tmp/galaxy.key
+    - watch:
+      - file: galaxy_key
+
+suse_res7_key:
+  file.managed:
+    - name: /tmp/suse_res7.key
+    - source: salt://default/gpg_keys/suse_res7.key
+  cmd.wait:
+    - name: rpm --import /tmp/suse_res7.key
+    - watch:
+      - file: suse_res7_key
+
+{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-released' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') %}
+
+uyuni_key:
+  file.managed:
+    - name: /tmp/uyuni.key
+    - source: salt://default/gpg_keys/uyuni.key
+  cmd.wait:
+    - name: rpm --import /tmp/uyuni.key
+    - watch:
+      - file: uyuni_key
+
+{% endif %}
+{% endif %} {# grains['os_family'] == 'RedHat' #}
+
+
+{% if grains['os_family'] == 'Debian' %}
+
+disable_apt_daily_timer:
+  service.dead:
+    - name: apt-daily.timer
+    - enable: False
+
+disable_apt_daily_upgrade_timer:
+  service.dead:
+    - name: apt-daily-upgrade.timer
+    - enable: False
+
+disable_apt_daily_service:
+  service.dead:
+    - name: apt-daily.service
+    - enable: False
+
+disable_apt_daily_upgrade_service:
+  service.dead:
+    - name: apt-daily-upgrade.service
+    - enable: False
+
+wait_until_apt_lock_file_unlock:
+  cmd.run:
+    - name: "test ! -f /var/lib/apt/lists/lock || ! lsof /var/lib/apt/lists/lock"
+    - retry:
+      - attempts: 10
+      - interval: 5
+      - until: True
+
+remove_no_install_recommends:
+  file.absent:
+    - name: /etc/apt/apt.conf.d/00InstallRecommends
+
+{% endif %} {# grains['os_family'] == 'Debian' #}
+
+{# WORKAROUND: see github:saltstack/salt#10852 #}
+{{ sls }}_nop:
+  test.nop: []

--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -2,7 +2,9 @@ include:
   - repos.disable_local
   - repos.vendor
   {% if not grains.get('additional_repos_only') %}
-  - repos.default
+  - repos.default_settings
+  - repos.os
+  - repos.clienttools
   - repos.minion
   - repos.proxy
   - repos.server

--- a/salt/repos/os.sls
+++ b/salt/repos/os.sls
@@ -1,0 +1,284 @@
+{# This state setup OS Vendor repositories #}
+
+{% if grains['os'] == 'SUSE' %}
+{% if grains['osfullname'] == 'Leap' %}
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/distribution/leap/{{ grains['osrelease'] }}/repo/oss/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/oss/
+    - refresh: True
+
+{% if grains['osrelease_info'][0] == 15 and grains['osrelease_info'][1] >= 3 %}
+sle_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/sle/
+    - refresh: True
+
+backports_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/backports/
+    - refresh: True
+{% endif %} {# grains['osfullname'] == 'Leap' #}
+
+
+{% elif grains['osfullname'] == 'SLES' %}
+
+{% if grains['osrelease'] == '11.4' %}
+os_pool_repo:
+  pkgrepo.managed:
+    {% if grains.get('mirror') %}
+    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-Pool/sle-11-x86_64/
+    {% else %}
+    - baseurl: http://euklid.nue.suse.com/mirror/SuSE/zypp-patches.suse.de/x86_64/update/SLE-SERVER/11-SP4-POOL/
+    {% endif %}
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    {% if grains.get('mirror') %}
+    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-Updates/sle-11-x86_64/
+    {% else %}
+    - baseurl: http://euklid.nue.suse.com/mirror/SuSE/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SP4/x86_64/update/
+    {% endif %}
+    - refresh: True
+
+os_ltss_repo:
+  pkgrepo.managed:
+    {% if grains.get('mirror') %}
+    - baseurl: http://{{ grains.get("mirror") }}/repo/$RCE/SLES11-SP4-LTSS-Updates/sle-11-x86_64/
+    {% else %}
+    - baseurl: http://euklid.nue.suse.com/mirror/SuSE/build-ncc.suse.de/SUSE/Updates/SLE-SERVER/11-SP4-LTSS/x86_64/update/
+    {% endif %}
+    - refresh: True
+{% endif %} {# grains['osrelease'] == '11.4' #}
+
+
+{% if '12' in grains['osrelease'] %}
+{% if not grains.get('sles_registration_code') %} ## Skip if SCC support
+{% if grains['osrelease'] == '12.3' %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/
+    - refresh: True
+
+{% elif grains['osrelease'] == '12.4' %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-SERVER/12-SP4/x86_64/product/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP4/x86_64/update/
+    - refresh: True
+
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP4-LTSS/x86_64/update/
+    - refresh: True
+
+{% elif grains['osrelease'] == '12.5' %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-SERVER/12-SP5/x86_64/product/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/
+    - refresh: True
+
+# uncomment when it goes LTSS
+# os_ltss_repo:
+#   pkgrepo.managed:
+#           - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP5-LTSS/x86_64/update/
+
+{% endif %}
+{% endif %} ## End skip if SCC support
+
+{% endif %} {# '12' in grains['osrelease'] #}
+
+{% if '15' in grains['osrelease'] %}
+{% if not ( grains.get('server_registration_code') or grains.get('proxy_registration_code') or grains.get('sles_registration_code') or 'paygo' in grains.get('product_version') | default('', true)) %} ## Skip if SCC support or PAYG
+
+{% if '15' == grains['osrelease'] %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
+    - refresh: True
+
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-LTSS/x86_64/update/
+    - refresh: True
+
+{% elif '15.1' == grains['osrelease'] %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP1/x86_64/update/
+    - refresh: True
+
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-SP1-LTSS/x86_64/update/
+    - refresh: True
+
+{% elif '15.2' == grains['osrelease'] %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/
+    - refresh: True
+
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
+
+{% elif '15.3' == grains['osrelease'] %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP3/{{ grains.get("cpuarch") }}/product/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP3/{{ grains.get("cpuarch") }}/update/
+    - refresh: True
+
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/{{ grains.get("cpuarch") }}/update/
+
+{% elif '15.4' == grains['osrelease'] %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP4/{{ grains.get("cpuarch") }}/product/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP4/{{ grains.get("cpuarch") }}/update/
+    - refresh: True
+
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-SP4-LTSS/{{ grains.get("cpuarch") }}/update/
+    - refresh: True
+
+{% elif '15.5' == grains['osrelease'] %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP5/x86_64/product/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP5/x86_64/update/
+    - refresh: True
+
+# uncomment when it goes LTSS
+#os_ltss_repo:
+#  pkgrepo.managed:
+#    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP5-LTSS/x86_64/update/
+#    - refresh: True
+
+{% elif '15.6' == grains['osrelease'] %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP6/x86_64/product/
+    - refresh: True
+
+os_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP6/x86_64/update/
+    - refresh: True
+
+# uncomment when it goes LTSS
+#os_ltss_repo:
+#  pkgrepo.managed:
+#    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP6-LTSS/x86_64/update/
+#    - refresh: True
+
+{% endif %} {# '15.6' == grains['osrelease'] #}
+
+{% endif %} {# '15' in grains['osrelease'] #}
+{% endif %} {# Skip if SCC support or PAYG #}
+
+
+{% endif %}{# grains['osfullname'] == 'SLES' #}
+{% endif %} {# grains['os'] == 'SUSE' #}
+
+
+{% if grains['os_family'] == 'RedHat' %}
+
+{% set release = grains.get('osmajorrelease', None)|int() %}
+
+{% if release == 9 %}
+{% if salt['file.search']('/etc/os-release', 'Liberty') %}
+
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://rmt.scc.suse.de/repo/SUSE/Updates/SLL/9/x86_64/update
+    - refresh: True
+
+os_as_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://rmt.scc.suse.de/repo/SUSE/Updates/SLL-AS/9/x86_64/update
+    - refresh: True
+
+os_updates_repo:
+  pkgrepo.managed:
+    - baseurl: https://rmt.scc.suse.de/repo/SUSE/Updates/SLL/9/x86_64/update/?credentials=SUSE_Liberty_Linux_x86_64
+    - refresh: True
+
+os_as_updates_repo:
+  pkgrepo.managed:
+    - baseurl: https://rmt.scc.suse.de/repo/SUSE/Updates/SLL-AS/9/x86_64/update/?credentials=SUSE_Liberty_Linux_x86_64
+    - refresh: True
+
+os_cb_updates_repo:
+  pkgrepo.managed:
+    - baseurl: https://rmt.scc.suse.de/repo/SUSE/Updates/SLL-CB/9/x86_64/update/?credentials=SUSE_Liberty_Linux_x86_64
+    - refresh: True
+{% endif %} {# salt['file.search']('/etc/os-release', 'Liberty') #}
+{% endif %} {# release == 9 #}
+
+{% endif %} {# grains['os_family'] == 'RedHat' #}
+
+
+{# WORKAROUND: see github:saltstack/salt#10852 #}
+{{ sls }}_nop:
+  test.nop: []

--- a/salt/repos/testsuite.sls
+++ b/salt/repos/testsuite.sls
@@ -24,7 +24,7 @@ test_repo_rpm_pool:
     - refresh: True
     - gpgcheck: 1
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/repodata/repomd.xml.key
-{% endif %}
+{% endif %} {# already added via combustion #}
 
 {% elif grains['os_family'] == 'Debian' %}
 


### PR DESCRIPTION
## What does this PR change?

default.sls is too big and confusing.
This PR split it into 3 parts:
- os.sls to setup OS Vendor repositories only
- clienttools.sls to setup the Client Tools repositories for the various OSes
- default_settings.sls which contains special settings needed for the various OSes
