### PR TITLE
Don't add the repo when we already added it on Combustion

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -63,7 +63,7 @@ zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repos
 %{ endif }
 
 %{ if testsuite }
-zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/ test_packages_pool
+zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/ test_repo_rpm_pool
 
 # Leap repos are required to install expect
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/distribution/leap/15.5/repo/oss/ leap_pool_repo
@@ -79,7 +79,7 @@ zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/updat
 zypper ar http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Products/SL-Micro/6.0/x86_64/product/ os_pool_repo
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/SLMicro6-Uyuni-Client-Tools/SL-Micro6/ client_tools_repo
 %{ if testsuite }
-zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/ test_packages_pool
+zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/ test_repo_rpm_pool
 %{ endif }
 %{ endif } # end of image == "slmicro60o" block
 

--- a/salt/repos/testsuite.sls
+++ b/salt/repos/testsuite.sls
@@ -17,12 +17,14 @@ uyuni_key_for_fake_packages:
     - name: transactional-update -c run rpm --import http://{{ grains.get("mirror") | default("minima-mirror-ci-bv.mgr.prv.suse.net", true) }}/uyuni.key
 {% endif %}
 
+{% if not (grains['osfullname'] in ['SL-Micro'] and grains['osrelease'] in ['6.0']) and not (grains['osfullname'] in ['openSUSE Leap Micro'] and grains['osrelease'] in ['5.5']) %}
 test_repo_rpm_pool:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/
     - refresh: True
     - gpgcheck: 1
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/repodata/repomd.xml.key
+{% endif %}
 
 {% elif grains['os_family'] == 'Debian' %}
 


### PR DESCRIPTION
## What does this PR change?

This PR aims to fix this issue when deploying a SL Micro 6.0 in BV:

```
----------
          ID: test_repo_rpm_pool
    Function: pkgrepo.managed
      Result: False
     Comment: Failed to configure repo 'test_repo_rpm_pool': Repository 'test_repo_rpm_pool' already exists as 'test_packages_pool'.
     Started: 14:58:55.901492
    Duration: 3.084 ms
     Changes:   
```

I don't really like the solution, that's more a quick fix to have this deploying.

I think we need a [card](https://github.com/SUSE/spacewalk/issues/24483), and refactor the combustion/cloud-init stages, so we don't install test-packages there but in salt states phase.