### PR TITLE
Fix cloud init issue with rocky8

### DIFF
--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -117,18 +117,23 @@ yum_repos:
 
 packages: ["venv-salt-minion", "dbus-tools"]
 %{ endif }
-%{ if image == "rocky8"}
-yum_repos:
-  # repo for salt
-  temp_tools_pool_repo:
-    baseurl: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
-    failovermethod: priority
-    enabled: true
-    gpgcheck: false
-    name: temp_tools_pool_repo
 
-packages: ["venv-salt-minion", "dbus-tools"]
+%{ if image == "rocky8"}
+runcmd:
+  - |
+    cat <<EOF > /etc/yum.repos.d/temp_tools_pool_repo.repo
+    [temp_tools_pool_repo]
+    name=temp_tools_pool_repo
+    baseurl=http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
+    failovermethod=priority
+    enabled=1
+    gpgcheck=0
+    EOF
+  - yum clean all
+  - yum repolist
+  - dnf -y install venv-salt-minion
 %{ endif }
+
 %{ if image == "centos7" || image == "rhel7"}
 yum_repos:
   # repo for salt


### PR DESCRIPTION
## What does this PR change?
Currently, rocky8 cloud init is failing to install venv-salt-minion. On minion side, the temporary repository is not visible. 

Adding repository using `yum_repo` ( not visible using yum repolist ) and installing venv-salt using `packages` ( even with the repository correctly declared ) seem to not be correctly executed during the cloud init on Rocky8.

I moved the steps using runcmd to install venv-salt and I can correctly see the repository and the venv-salt-minion package install.

## Notes
I also removed `dbus-tools` package because this package is not available in the temporary repository.
