### PR TITLE
Update opensuse155 name for aws

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -1,6 +1,6 @@
 data "aws_ami" "opensuse155o" {
   most_recent = true
-  name_regex  = "^openSUSE-Leap-15-5-v"
+  name_regex  = "^openSUSE-Leap-15.5-HVM"
   owners      = ["679593333241"]
 
   filter {


### PR DESCRIPTION
## What does this PR change?

Update opensuse 15.5 name regex with the new opensuse name.
