### PR TITLE
Fix issue with Debian 10 and Debian Uyuni Client Tools and refactor Salt Shaker state

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -670,6 +670,8 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
   - systemctl start qemu-guest-agent
+  # HACK: buster-backports repository has changed
+  - sed -i 's/deb.debian.org\/debian buster-backports/archive.debian.org\/debian buster-backports/g' /etc/apt/sources.list
 
 bootcmd:
   # HACK: Make "gnupg" to be installed before configuring repos, so gpg key can be imported

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -833,9 +833,9 @@ tools_update_repo:
 {% elif '4.3-VM-released' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Debian/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Master:/Debian' + release + '-Uyuni-Client-Tools/Debian' + release %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Master:/Debian' + release + '-Uyuni-Client-Tools/Debian_' + release %}
 {% else %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Stable:/Debian' + release + '-Uyuni-Client-Tools/Debian' + release %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Stable:/Debian' + release + '-Uyuni-Client-Tools/Debian_' + release %}
 {% endif %}
     - refresh: True
     - name: deb {{ tools_repo_url }} /

--- a/salt/salt_testenv/init.sls
+++ b/salt/salt_testenv/init.sls
@@ -1,208 +1,42 @@
 include:
   - default
-
-{% if grains['os'] == 'SUSE' %}
-
 {% if grains['osfullname'] == 'SLES' and grains['osrelease_info'][0] == 15 %}
-{% set repo_path = "15" if grains["osrelease"] == 15 else "15-SP" + grains["osrelease_info"][1]|string %}
-development_tools_repo_pool:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Development-Tools/{{ repo_path }}/x86_64/product/
-    - refresh: True
-
-development_tools_repo_updates:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ repo_path }}/x86_64/update/
-    - refresh: True
-
-# needed for libhttp_parser_2_7_1, dependency of libgit2
-sle_module_hpc_repo_pool:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-HPC/{{ repo_path }}/x86_64/product/
-    - refresh: True
-
-sle_module_hpc_repo_updates:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-HPC/{{ repo_path }}/x86_64/update/
-    - refresh: True
-
-containers_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/{{ repo_path }}/x86_64/product/
-    - refresh: True
-
-containers_updates_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/{{ repo_path }}/x86_64/update/
-    - refresh: True
-
-{% if grains['osrelease_info'][1] >= 3 %}
-{% set repo_path = grains["osrelease"] %}
-{% else %}
-{% set repo_path = "SLE_15_SP" + grains["osrelease_info"][1]|string %}
-{% endif %}
-
-{% endif %}
-
-
-{% if grains['osfullname'] == 'SL-Micro' %}
-{% set repo_path = 'SLMicro' + grains['osrelease_info'][0]|string + grains['osrelease_info'][1]|string %}
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SL-Micro/{{ grains['osrelease'] }}/x86_64/product/
-    - refresh: True
-
-alp_sources_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/ALP:/Source:/Standard:/Core:/1.0:/Build/standard/
-    - refresh: True
-{% endif %}
-
-{% if grains['osfullname'] == 'Leap' %}
-{% set repo_path = grains['osrelease'] %}
-{% endif %}
-
-{% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
-{% set repo_path = 'openSUSE_Tumbleweed' %}
-repo-oss:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/tumbleweed/repo/oss/
-    - refresh: True
-    - gpgcheck: False
-{% endif %}
-
-salt_testsuite_dependencies_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:products:test-dependencies/{{ repo_path }}/
-    - refresh: True
-    - gpgcheck: 0
-    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:products:test-dependencies/{{ repo_path }}/repodata/repomd.xml.key
-
-salt_testing_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ grains["salt_obs_flavor"] }}/{{ repo_path }}/
-    - refresh: True
-    - gpgcheck: 0
-    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ grains["salt_obs_flavor"] }}/{{ repo_path }}/repodata/repomd.xml.key
-
-install_salt_testsuite:
-{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
-  cmd.run:
-    - name: transactional-update -c -n pkg in python3-salt-testsuite python3-salt-test python3-salt
-{% else %}
-  pkg.latest:
-    - pkgs: ["python3-salt-testsuite", "python3-salt-test", "python3-salt"]
-{% endif %}
-    - require:
-      - pkgrepo: salt_testsuite_dependencies_repo
-      - pkgrepo: salt_testing_repo
-
-start_docker_service:
-{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
-  cmd.run:
-    - name: transactional-update -c run systemctl enable docker
-{% else %}
-  service.running:
-    - name: docker
-{% endif %}
-    - requires:
-      - pkg: install_salt_testsuite
-
-{% endif %}
-
-{% if grains['os'] == 'Debian' %}
-    {% if grains['osrelease'] == '9' %}
-        {% set repo_path = 'Debian_9.0' %}
-    {% elif grains['osrelease'] == '10' %}
-        {% set repo_path = 'Debian_10' %}
-    {% elif grains['osrelease'] == '11' %}
-        {% set repo_path = 'Debian_11' %}
-    {% elif grains['osrelease'] == '12' %}
-        {% set repo_path = 'Debian_12' %}
-    {% endif %}
-{% elif grains['osfullname'] == 'Ubuntu' %}
-    {% if grains['osrelease'] == '20.04' %}
-        {% set repo_path = 'Ubuntu_20.04' %}
-    {% elif grains['osrelease'] == '22.04' %}
-        {% set repo_path = 'Ubuntu_22.04' %}
-    {% endif %}
-{% elif grains['osfullname'] == 'AlmaLinux' %}
-    {% if grains['osrelease_info'][0] == 8 %}
-        {% set repo_path = 'AlmaLinux_8' %}
-    {% elif grains['osrelease_info'][0] == 9 %}
-        {% set repo_path = 'AlmaLinux_9' %}
-    {% endif %}
-{% elif grains['osfullname'] == 'CentOS Linux' %}
-    {% if grains['osrelease_info'][0] == 7 %}
-        {% set repo_path = 'CentOS_7' %}
-    {% endif %}
-{% elif grains['osfullname'] == 'SLES' %}
-    {% if grains['osrelease_info'][0] == 12 %}
-        {% set repo_path = 'SLE_12' %}
-    {% elif grains['osrelease_info'][0] == 15 %}
-        {% set repo_path = 'SLE_15' %}
-    {% endif %}
-{% elif grains['osfullname'] == 'Leap' %}
-    {% if grains['osrelease_info'][0] == 15 %}
-        {% set repo_path = 'openSUSE_Leap_15' %}
-    {% endif %}
+  - .salt_classic_package
+  - .salt_bundle_package
+{% elif grains['osfullname'] == 'SLES' and grains['osrelease_info'][0] == 12 %}
+  - .salt_bundle_package
 {% elif grains['osfullname'] == 'SL-Micro' %}
-    {% if grains['osrelease'] == '6.0' %}
-        {% set repo_path = 'SLMicro60' %}
-    {% endif %}
-{% endif %}
-
-{% if grains['salt_obs_flavor'] != 'saltstack' %}
-
-{% if grains["salt_obs_flavor"] == "saltstack:products" %}
-    {% set salt_flavor_path = "saltstack:bundle" %}
-{% elif grains["salt_obs_flavor"] == "saltstack:products:testing" %}
-    {% set salt_flavor_path = "saltstack:bundle:testing" %}
-{% elif grains["salt_obs_flavor"] == "saltstack:products:next" %}
-    {% set salt_flavor_path = "saltstack:bundle:next" %}
+  - .salt_classic_package
+  - .salt_bundle_package
+{% elif grains['osfullname'] == 'Leap' %}
+  - .salt_classic_package
+  - .salt_bundle_package
+{% elif grains['osfullname'] == 'openSUSE Tumbleweed' %}
+  - .salt_classic_package
+{% elif grains['os'] == 'Debian' %}
+  {% if grains['osrelease'] == '10' %}
+  - .salt_classic_package
+  - .salt_bundle_package
+  {% else %}
+  - .salt_bundle_package
+  {% endif %}
+{% elif grains['osfullname'] == 'Ubuntu' %}
+  {% if grains['osrelease'] == '20.04' %}
+  - .salt_classic_package
+  - .salt_bundle_package
+  {% else %}
+  - .salt_bundle_package
+  {% endif %}
+{% elif grains['osfullname'] == 'AlmaLinux' %}
+  {% if grains['osrelease_info'][0] == 8 %}
+  - .salt_classic_package
+  - .salt_bundle_package
+  {% else %}
+  - .salt_bundle_package
+  {% endif %}
+{% elif grains['osfullname'] == 'CentOS Linux' %}
+  - .salt_bundle_package
 {% else %}
-    {{ raise("Unknown salt_obs_flavor set") }}
+    {{ raise("Salt Shaker unsupported OS") }}
 {% endif %}
-
-salt_bundle_testsuite_repo:
-  pkgrepo.managed:
-{% if grains['os'] in ["Debian", "Ubuntu"] %}
-    - humanname: salt_bundle_testsuite_repo
-    - file: /etc/apt/sources.list.d/salt_bundle_testsuite_repo.list
-    - name: deb http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/ /
-    - key_url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/Release.key
-{% else %}
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/
-    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/repodata/repomd.xml.key
-    - gpgcheck: 0
-{% endif %}
-    - refresh: True
-
-install_salt_bundle_testsuite:
-{% if grains['os_family'] == 'Suse' and grains['osfullname'] in ['SLE Micro', 'SL-Micro'] %}
-  cmd.run:
-    - name: transactional-update -c -n pkg in venv-salt-minion-testsuite
-{% else %}
-  pkg.installed:
-    - name: venv-salt-minion-testsuite
-{% endif %}
-    - require:
-      - pkgrepo: salt_bundle_testsuite_repo
-
-{% endif %}
-
-{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
-copy_salt_classic_testsuite:
-  cmd.run:
-    - name: transactional-update -c run cp -r /usr/lib/python3.{{ grains["pythonversion"][1] }}/site-packages/salt-testsuite /opt/salt-testsuite-classic
-
-copy_salt_bundle_testsuite:
-  cmd.run:
-    - name: transactional-update -c run cp -r /usr/lib/venv-salt-minion/lib/python3.{{ grains["pythonversion"][1] }}/site-packages/salt-testsuite /opt/salt-testsuite-bundle
-
-reboot_transactional_system:
-  module.run:
-    - name: system.reboot
-    - at_time: +1
-    - order: last
-{% endif %}
+  - .postinstallation

--- a/salt/salt_testenv/postinstallation.sls
+++ b/salt/salt_testenv/postinstallation.sls
@@ -1,0 +1,26 @@
+{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
+copy_salt_classic_testsuite:
+  cmd.run:
+    - name: transactional-update -c run cp -r /usr/lib/python3.{{ grains["pythonversion"][1] }}/site-packages/salt-testsuite /opt/salt-testsuite-classic
+
+copy_salt_bundle_testsuite:
+  cmd.run:
+    - name: transactional-update -c run cp -r /usr/lib/venv-salt-minion/lib/python3.{{ grains["pythonversion"][1] }}/site-packages/salt-testsuite /opt/salt-testsuite-bundle
+
+disable_rebootmgr_to_avoid_reboots:
+  file.managed:
+    - name: /etc/rebootmgr.conf
+    - contents: |
+            [rebootmgr]
+            strategy=off
+
+reboot_transactional_system:
+  module.run:
+    - name: system.reboot
+    - at_time: +1
+    - order: last
+{% endif %}
+
+# WORKAROUND: see github:saltstack/salt#10852
+{{ sls }}_nop:
+  test.nop: []

--- a/salt/salt_testenv/salt_bundle_package.sls
+++ b/salt/salt_testenv/salt_bundle_package.sls
@@ -1,0 +1,84 @@
+{% if grains['os'] == 'Debian' %}
+    {% if grains['osrelease'] == '9' %}
+        {% set repo_path = 'Debian_9.0' %}
+    {% elif grains['osrelease'] == '10' %}
+        {% set repo_path = 'Debian_10' %}
+    {% elif grains['osrelease'] == '11' %}
+        {% set repo_path = 'Debian_11' %}
+    {% elif grains['osrelease'] == '12' %}
+        {% set repo_path = 'Debian_12' %}
+    {% endif %}
+{% elif grains['osfullname'] == 'Ubuntu' %}
+    {% if grains['osrelease'] == '20.04' %}
+        {% set repo_path = 'Ubuntu_20.04' %}
+    {% elif grains['osrelease'] == '22.04' %}
+        {% set repo_path = 'Ubuntu_22.04' %}
+    {% endif %}
+{% elif grains['osfullname'] == 'AlmaLinux' %}
+    {% if grains['osrelease_info'][0] == 8 %}
+        {% set repo_path = 'AlmaLinux_8' %}
+    {% elif grains['osrelease_info'][0] == 9 %}
+        {% set repo_path = 'AlmaLinux_9' %}
+    {% endif %}
+{% elif grains['osfullname'] == 'CentOS Linux' %}
+    {% if grains['osrelease_info'][0] == 7 %}
+        {% set repo_path = 'CentOS_7' %}
+    {% endif %}
+{% elif grains['osfullname'] == 'SLES' %}
+    {% if grains['osrelease_info'][0] == 12 %}
+        {% set repo_path = 'SLE_12' %}
+    {% elif grains['osrelease_info'][0] == 15 %}
+        {% set repo_path = 'SLE_15' %}
+    {% endif %}
+{% elif grains['osfullname'] == 'Leap' %}
+    {% if grains['osrelease_info'][0] == 15 %}
+        {% set repo_path = 'openSUSE_Leap_15' %}
+    {% endif %}
+{% elif grains['osfullname'] == 'SL-Micro' %}
+    {% if grains['osrelease'] == '6.0' %}
+        {% set repo_path = 'SLMicro60' %}
+    {% endif %}
+{% endif %}
+
+{% if grains['salt_obs_flavor'] != 'saltstack' %}
+
+{% if grains["salt_obs_flavor"] == "saltstack:products" %}
+    {% set salt_flavor_path = "saltstack:bundle" %}
+{% elif grains["salt_obs_flavor"] == "saltstack:products:testing" %}
+    {% set salt_flavor_path = "saltstack:bundle:testing" %}
+{% elif grains["salt_obs_flavor"] == "saltstack:products:next" %}
+    {% set salt_flavor_path = "saltstack:bundle:next" %}
+{% else %}
+    {{ raise("Unknown salt_obs_flavor set") }}
+{% endif %}
+
+salt_bundle_testsuite_repo:
+  pkgrepo.managed:
+{% if grains['os'] in ["Debian", "Ubuntu"] %}
+    - humanname: salt_bundle_testsuite_repo
+    - file: /etc/apt/sources.list.d/salt_bundle_testsuite_repo.list
+    - name: deb http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/ /
+    - key_url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/Release.key
+{% else %}
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/repodata/repomd.xml.key
+    - gpgcheck: 0
+{% endif %}
+    - refresh: True
+
+install_salt_bundle_testsuite:
+{% if grains['os_family'] == 'Suse' and grains['osfullname'] in ['SLE Micro', 'SL-Micro'] %}
+  cmd.run:
+    - name: transactional-update -c -n pkg in venv-salt-minion-testsuite
+{% else %}
+  pkg.installed:
+    - name: venv-salt-minion-testsuite
+{% endif %}
+    - require:
+      - pkgrepo: salt_bundle_testsuite_repo
+
+{% endif %}
+
+# WORKAROUND: see github:saltstack/salt#10852
+{{ sls }}_nop:
+  test.nop: []

--- a/salt/salt_testenv/salt_classic_package.sls
+++ b/salt/salt_testenv/salt_classic_package.sls
@@ -1,0 +1,133 @@
+{% if grains['os'] == 'SUSE' %}
+
+{% if grains['osfullname'] == 'SLES' and grains['osrelease_info'][0] == 15 %}
+{% set repo_path = "15" if grains["osrelease"] == 15 else "15-SP" + grains["osrelease_info"][1]|string %}
+development_tools_repo_pool:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Development-Tools/{{ repo_path }}/x86_64/product/
+    - refresh: True
+
+development_tools_repo_updates:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ repo_path }}/x86_64/update/
+    - refresh: True
+
+# needed for libhttp_parser_2_7_1, dependency of libgit2
+sle_module_hpc_repo_pool:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-HPC/{{ repo_path }}/x86_64/product/
+    - refresh: True
+
+sle_module_hpc_repo_updates:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-HPC/{{ repo_path }}/x86_64/update/
+    - refresh: True
+
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/{{ repo_path }}/x86_64/product/
+    - refresh: True
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/{{ repo_path }}/x86_64/update/
+    - refresh: True
+
+{% if grains['osrelease_info'][1] >= 3 %}
+{% set repo_path = grains["osrelease"] %}
+{% else %}
+{% set repo_path = "SLE_15_SP" + grains["osrelease_info"][1]|string %}
+{% endif %}
+
+{% endif %}
+
+
+{% if grains['osfullname'] == 'SL-Micro' %}
+{% set repo_path = 'SLMicro' + grains['osrelease_info'][0]|string + grains['osrelease_info'][1]|string %}
+os_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SL-Micro/{{ grains['osrelease'] }}/x86_64/product/
+    - refresh: True
+
+alp_sources_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/ALP:/Source:/Standard:/Core:/1.0:/Build/standard/
+    - refresh: True
+{% endif %}
+
+{% if grains['osfullname'] == 'Leap' %}
+{% set repo_path = grains['osrelease'] %}
+{% endif %}
+
+{% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
+{% set repo_path = 'openSUSE_Tumbleweed' %}
+repo-oss:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/tumbleweed/repo/oss/
+    - refresh: True
+    - gpgcheck: False
+{% endif %}
+
+salt_testsuite_dependencies_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:products:test-dependencies/{{ repo_path }}/
+    - refresh: True
+    - gpgcheck: 0
+{% if grains['os'] == 'SUSE' %}
+    - priority: 1
+{% endif %}
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:products:test-dependencies/{{ repo_path }}/repodata/repomd.xml.key
+
+salt_testing_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ grains["salt_obs_flavor"] }}/{{ repo_path }}/
+    - refresh: True
+    - gpgcheck: 0
+{% if grains['os'] == 'SUSE' %}
+    - priority: 1
+{% endif %}
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ grains["salt_obs_flavor"] }}/{{ repo_path }}/repodata/repomd.xml.key
+
+install_salt_testsuite:
+{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
+  cmd.run:
+    - name: transactional-update -c -n pkg in python3-salt-testsuite python3-salt-test python3-salt
+{% else %}
+  {# HACK: we call zypper manually to ensure right packages are installed regardless upgrade/downgrade #}
+  cmd.run:
+    {% if grains["install_salt_bundle"] %}
+    - name: zypper --non-interactive in --force --from salt_testing_repo python3-salt salt python3-salt-testsuite
+    {% else %}
+    - name: zypper --non-interactive in --force --from salt_testing_repo python3-salt salt python3-salt-testsuite salt-minion
+    {% endif %}
+    - fromrepo: salt_testing_repo
+{% endif %}
+    - require:
+      - pkgrepo: salt_testsuite_dependencies_repo
+      - pkgrepo: salt_testing_repo
+
+install_salt_tests_executor:
+{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
+  cmd.run:
+    - name: transactional-update -c -n pkg in python3-salt-test
+{% else %}
+  pkg.installed:
+    - pkgs:
+      - python3-salt-test
+{% endif %}
+    - require:
+      - cmd: install_salt_testsuite
+
+start_docker_service:
+{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
+  cmd.run:
+    - name: transactional-update -c run systemctl enable docker
+{% else %}
+  service.running:
+    - name: docker
+{% endif %}
+    - requires:
+      - pkg: install_salt_testsuite
+
+{% endif %}
+


### PR DESCRIPTION
## What does this PR change?

This PR does a refactor on the Salt state to deploy the Salt Shaker in order to make it cleaner and also fix several detected issues:

- The Salt state to configure Salt Bundle and Salt classic package are now splited in two different files.
- The main `salt/salt_testenv/init.sls`  contains now the mapping between "OS -> Salt packages to install"
- Ensure the right Salt classic package is installed by forcing upgrade/downgrade from a specific repository to use.
- Disable rebootmgr to not reboot SLMicro 60 at night.
- Fix issues rendering the Salt Shaker state for some OSes.

Additionaly, this PR fixes some issues around Debian 10 backport repository, where repository has been archived but the image still contains references to the old repo, causing errors, and also fixes a wrong path to Uyuni Client Tools for Debian clients.