### PR TITLE
Don't update zypper and libzypp for opensuse leap15.5

### DIFF
--- a/salt/default/minimal.sls
+++ b/salt/default/minimal.sls
@@ -28,7 +28,8 @@ minimal_package_update:
 {% else %}
       - salt-minion
 {% endif %}
-{% if grains['os_family'] == 'Suse' %}
+# WORKAROUND: don't update zypper and libzypp for opensuse leap 15.5 because the last zypper version is broken
+{% if grains['os_family'] == 'Suse' and grains['oscodename'] != 'openSUSE Leap 15.5' %}
       - zypper
       - libzypp
       # WORKAROUND: avoid a segfault on old versions


### PR DESCRIPTION

## What does this PR change?

Temporary disable opensuse leap 15.5 zypper update because the last last version is broken.
