### PR TITLE
Add RES8 product tool to minimal mirror list for rocky8 deployment on aws

### DIFF
--- a/salt/mirror/etc/minimum_repositories_testsuite.yaml
+++ b/salt/mirror/etc/minimum_repositories_testsuite.yaml
@@ -49,6 +49,9 @@ http:
   - url:  http://download.suse.de/ibs/SUSE/Updates/RES/8-CLIENT-TOOLS/x86_64/update/
     archs: [x86_64]
 
+  - url: http://download.suse.de/ibs/SUSE/Products/RES/8-CLIENT-TOOLS/x86_64/product/
+    archs: [ x86_64 ]
+
   - url:  http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15-BETA/x86_64/product/
     archs: [x86_64]
 


### PR DESCRIPTION
## What does this PR change?
RES8 product tool is missing for rocky8 deployment on aws