### PR TITLE
Fix deployment for CentOS7 instances as "mirrorlist.centos.org" doesn't exist anymore

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -24,6 +24,12 @@ packages: ["salt", "salt-minion", "avahi", "avahi-lang"]
 %{endif}
 
 %{ if image == "centos7o" }
+bootcmd:
+  # HACK: mirrorlist.centos.org doesn't exist anymore
+  - sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+  - sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+  - sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 yum_repos:
   # repo for salt
   tools_pool_repo:


### PR DESCRIPTION
## What does this PR change?

This PR fixes the deployments for CentOS 7 instances that was broken since July 1st, as `mirrorlist.centos.org` is not existing anymore, therefore neither Salt or Salt Bundle can be installed by cloudinit and sumaform deployment fails with:

```
Error: Cannot find venv-salt-call or salt-call on the system
```

Example: https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-products-testing-centos7-bundle/

To fix this, we just switch to not use mirror list and use vault.centos.org repository.
