### PR TITLE
terracumber does not install MU repositories on containerized server

### DIFF
--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -1,20 +1,20 @@
 variable "images" {
   default = {
-    "4.2-released"   = "sles15sp3o"
-    "4.2-nightly"    = "sles15sp3o"
-    "4.2-build_image"= "sles15sp3o"
-    "4.3-released"   = "sles15sp4o"
-    "4.3-nightly"    = "sles15sp4o"
-    "4.3-pr"         = "sles15sp4o"
-    "4.3-beta"       = "sles15sp4o"
-    "4.3-build_image"= "sles15sp4o"
-    "4.3-paygo"      = "suma-server-43-paygo"
-    "4.3-VM-nightly"         = "suma43VM-ign"
-    "4.3-VM-released"= "suma43VM-ign"
-    "head"           = "sles15sp4o"
-    "uyuni-master"   = "opensuse155o"
-    "uyuni-released" = "opensuse155o"
-    "uyuni-pr"       = "opensuse155o"
+    "4.2-released"    = "sles15sp3o"
+    "4.2-nightly"     = "sles15sp3o"
+    "4.2-build_image" = "sles15sp3o"
+    "4.3-released"    = "sles15sp4o"
+    "4.3-nightly"     = "sles15sp4o"
+    "4.3-pr"          = "sles15sp4o"
+    "4.3-beta"        = "sles15sp4o"
+    "4.3-build_image" = "sles15sp4o"
+    "4.3-paygo"       = "suma-server-43-paygo"
+    "4.3-VM-nightly"  = "suma43VM-ign"
+    "4.3-VM-released" = "suma43VM-ign"
+    "head"            = "sles15sp4o"
+    "uyuni-master"    = "opensuse155o"
+    "uyuni-released"  = "opensuse155o"
+    "uyuni-pr"        = "opensuse155o"
   }
 }
 
@@ -56,49 +56,50 @@ module "server" {
     server_mounted_mirror  = var.server_mounted_mirror
     iss_master             = var.iss_master
     iss_slave              = var.iss_slave
-    server                 = var.register_to_server != null? lookup(var.register_to_server, "hostname", null): null
+    server                 = var.register_to_server != null ? lookup(var.register_to_server, "hostname", null) : null
     auto_connect_to_master = var.auto_register
     susemanager = {
       activation_key = var.activation_key
     }
-    download_private_ssl_key       = var.download_private_ssl_key
-    smt                            = var.smt
-    server_username                = var.server_username
-    server_password                = var.server_password
-    allow_postgres_connections     = var.allow_postgres_connections
-    unsafe_postgres                = var.unsafe_postgres
-    postgres_log_min_duration      = var.postgres_log_min_duration
-    java_debugging                 = var.java_debugging
-    java_hibernate_debugging       = var.java_hibernate_debugging
-    java_salt_debugging            = var.java_salt_debugging
-    skip_changelog_import          = var.skip_changelog_import
-    create_first_user              = var.create_first_user
-    scc_access_logging             = var.scc_access_logging
-    mgr_sync_autologin             = var.mgr_sync_autologin
-    create_sample_channel          = var.create_sample_channel
-    create_sample_activation_key   = var.create_sample_activation_key
-    create_sample_bootstrap_script = var.create_sample_bootstrap_script
-    publish_private_ssl_key        = var.publish_private_ssl_key
-    disable_download_tokens        = var.disable_download_tokens
-    disable_auto_bootstrap         = var.disable_auto_bootstrap
-    auto_accept                    = var.auto_accept
-    monitored                      = var.monitored
-    from_email                     = var.from_email
-    traceback_email                = var.traceback_email
-    saltapi_tcpdump                = var.saltapi_tcpdump
-    main_disk_size                 = var.main_disk_size
-    repository_disk_size           = var.repository_disk_size
-    database_disk_size             = var.database_disk_size
-    repository_disk_use_cloud_setup= var.repository_disk_use_cloud_setup
-    forward_registration           = var.forward_registration
-    server_registration_code       = var.server_registration_code
-    accept_all_ssl_protocols       = var.accept_all_ssl_protocols
-    login_timeout                  = var.login_timeout
-    db_configuration               = var.db_configuration
-    c3p0_connection_timeout        = var.c3p0_connection_timeout
-    c3p0_connection_debug          = var.c3p0_connection_debug
-    large_deployment               = var.large_deployment
-    beta_enabled                   = var.beta_enabled
+    download_private_ssl_key        = var.download_private_ssl_key
+    smt                             = var.smt
+    server_username                 = var.server_username
+    server_password                 = var.server_password
+    allow_postgres_connections      = var.allow_postgres_connections
+    unsafe_postgres                 = var.unsafe_postgres
+    postgres_log_min_duration       = var.postgres_log_min_duration
+    java_debugging                  = var.java_debugging
+    java_hibernate_debugging        = var.java_hibernate_debugging
+    java_salt_debugging             = var.java_salt_debugging
+    skip_changelog_import           = var.skip_changelog_import
+    create_first_user               = var.create_first_user
+    scc_access_logging              = var.scc_access_logging
+    mgr_sync_autologin              = var.mgr_sync_autologin
+    create_sample_channel           = var.create_sample_channel
+    create_sample_activation_key    = var.create_sample_activation_key
+    create_sample_bootstrap_script  = var.create_sample_bootstrap_script
+    publish_private_ssl_key         = var.publish_private_ssl_key
+    disable_download_tokens         = var.disable_download_tokens
+    disable_auto_bootstrap          = var.disable_auto_bootstrap
+    auto_accept                     = var.auto_accept
+    monitored                       = var.monitored
+    from_email                      = var.from_email
+    traceback_email                 = var.traceback_email
+    saltapi_tcpdump                 = var.saltapi_tcpdump
+    main_disk_size                  = var.main_disk_size
+    repository_disk_size            = var.repository_disk_size
+    database_disk_size              = var.database_disk_size
+    repository_disk_use_cloud_setup = var.repository_disk_use_cloud_setup
+    forward_registration            = var.forward_registration
+    server_registration_code        = var.server_registration_code
+    accept_all_ssl_protocols        = var.accept_all_ssl_protocols
+    login_timeout                   = var.login_timeout
+    db_configuration                = var.db_configuration
+    c3p0_connection_timeout         = var.c3p0_connection_timeout
+    c3p0_connection_debug           = var.c3p0_connection_debug
+    large_deployment                = var.large_deployment
+    beta_enabled                    = var.beta_enabled
+    additional_repos                = var.additional_repos
   }
 }
 

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -37,15 +37,15 @@ module "server_containerized" {
   volume_provider_settings      = var.volume_provider_settings
 
   grains = {
-    product_version        = var.product_version
-    container_runtime      = var.runtime
-    container_repository   = var.container_repository
-    container_tag          = var.container_tag
-    helm_chart_url         = var.helm_chart_url
-    cc_username            = var.base_configuration["cc_username"]
-    cc_password            = var.base_configuration["cc_password"]
-    mirror                 = var.base_configuration["mirror"]
-    server_mounted_mirror  = var.server_mounted_mirror
+    product_version                = var.product_version
+    container_runtime              = var.runtime
+    container_repository           = var.container_repository
+    container_tag                  = var.container_tag
+    helm_chart_url                 = var.helm_chart_url
+    cc_username                    = var.base_configuration["cc_username"]
+    cc_password                    = var.base_configuration["cc_password"]
+    mirror                         = var.base_configuration["mirror"]
+    server_mounted_mirror          = var.server_mounted_mirror
     server_username                = var.server_username
     server_password                = var.server_password
     java_debugging                 = var.java_debugging
@@ -67,6 +67,7 @@ module "server_containerized" {
     disable_auto_bootstrap         = var.disable_auto_bootstrap
     large_deployment               = var.large_deployment
     beta_enabled                   = var.beta_enabled
+    additional_repos               = var.additional_repos
   }
 }
 

--- a/salt/repos/additional.sls
+++ b/salt/repos/additional.sls
@@ -1,5 +1,5 @@
-# Skip Micro OSes, given the additional repos are set up by combustion/ignition/cloud-init
-{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
+# Skip Micro OSes, given the additional repos are set up by combustion/ignition/cloud-init, always add them to the server and server_containerized.
+{% if (grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro']) or ('server' in grains.get('roles')) or ('server_containerized' in grains.get('roles')) %}
 {% if grains['additional_repos'] %}
 {% for label, url in grains['additional_repos'].items() %}
 {{ label }}_repo:


### PR DESCRIPTION
## What does this PR change?

Following the [SUMA interlock](https://confluence.suse.com/display/SUSEMANAGER/Engineering+Interlock+5.0+-+Sign+off?preview=%2F1359085797%2F1386250774%2FSUSE+Manager+5.0+Engnieering+Interlock+v5.0.pdf), the server containerized is deployed on top of SLE Micro 5.5. Therefore, given the grains, additional repositories are not added to the server in the later stages. This PR adds them to ensure their inclusion in the Jenkins 5.0 BV pipelines.

Server and server_containerized modules were treated with `fmt` afterwards.
