### PR TITLE
Disable non-containerized deployments for head

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -731,7 +731,7 @@ It is possible to install Prometheus exporters on a SUSE Manager Server instance
 
 ```hcl
 module "server" {
-  source = "./modules/server"
+  source = "./modules/server_containerized"
   base_configuration = module.base.configuration
 
   name = "server"
@@ -840,7 +840,7 @@ It is possible to run SUSE Manager servers, proxies, clients and minions with th
 
 ```hcl
 module "server" {
-  source = "./modules/server"
+  source = "./modules/server_containerized"
   base_configuration = module.base.configuration
 
   name = "server"
@@ -857,7 +857,7 @@ This setting can be overridden with a custom 'from' address by supplying the par
 
 ```hcl
 module "server" {
-  source = "./modules/server"
+  source = "./modules/server_containerized"
   base_configuration = module.base.configuration
 
   name = "server"
@@ -872,7 +872,7 @@ By suppling the parameter `traceback_email` you can override that address to hav
 
 ```hcl
 module "sumamail3" {
-  source = "./modules/server"
+  source = "./modules/server_containerized"
   base_configuration = module.base.configuration
 
   name = "sumamail3"

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -4,25 +4,27 @@
 
 Some modules have a `product_version` variable that determines the software product version. Specifically:
 
-- in `server`, `proxy` etc. `product_version` determines the SUSE Manager/Uyuni product version,
-- in `server_containerized`, `proxy_containerized` etc. `product_version` determines the SUSE Manager/Uyuni product version - this is currently the recommended setup for head,
-- in `minion`, `client`, etc. `product_version` determines the SUSE Manager/Uyuni Tools version.
+- in `server`, `proxy`, `server_containerized` and `proxy_containerized`, `product_version` determines the SUSE Manager/Uyuni product version
+- in `minion`, `client`, etc. `product_version` determines the SUSE Manager/Uyuni Tools version
 
 Legal values for released software are:
 
-- `4.2-released`   (latest released Maintenance Update for SUSE Manager 4.2 and Tools)
-- `4.3-released`   (latest released Maintenance Update for SUSE Manager 4.3 and Tools)
-- `4.3-VM-released` (latest released Maintenance Update for SUSE Manager 4.3Virtual Machine)
+- `4.2-released` (latest released maintenance update for SUSE Manager 4.2 and Tools)
+- `4.3-released` (latest released maintenance update for SUSE Manager 4.3 and Tools)
+- `4.3-VM-released` (latest released maintenance update for SUSE Manager 4.3 virtual machine)
 - `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
 
 Legal values for work-in-progress software are:
 
 - `4.2-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.2)
 - `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
-- `4.3-VM-nightly`       (corresponds to the Virtual Image in the Build Service project Devel:Galaxy:Manager:4.3)
-- `4.3-beta`    (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
-- `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, **must be used with `server_containerized` and `proxy_containerized` modules**, uses SLE Micro as base image for server)
+- `4.3-VM-nightly` (corresponds to the VM image in the Build Service project Devel:Galaxy:Manager:4.3)
+- `4.3-beta` (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
+- `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, uses SLE Micro as the base image for server)
 - `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap image)
+
+**Important:** sumaform only supports containerized deployments for SUSE Manager versions 5.0 and later.
+Please use `server_containerized` and `proxy_containerized` modules with product versions `head` and `5.0-X`.
 
 Legal values for CI:
 

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -10,7 +10,6 @@ variable "images" {
     "4.3-build_image"= "sles15sp4o"
     "4.3-VM-nightly" = "sles15sp4o"
     "4.3-VM-released"= "sles15sp4o"
-    "head"           = "sles15sp4o"
     "uyuni-master"   = "opensuse155o"
     "uyuni-released" = "opensuse155o"
     "uyuni-pr"       = "opensuse155o"
@@ -57,7 +56,7 @@ module "proxy" {
     proxy_containerized       = var.proxy_containerized
   }
 
-  image                    = var.image == "default" || var.product_version == "head" ? var.images[var.product_version] : var.image
+  image                    = var.image == "default" ? var.images[var.product_version] : var.image
   provider_settings        = var.provider_settings
   additional_disk_size     = var.repository_disk_size
   volume_provider_settings = var.volume_provider_settings

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -11,7 +11,6 @@ variable "images" {
     "4.3-paygo"       = "suma-server-43-paygo"
     "4.3-VM-nightly"  = "suma43VM-ign"
     "4.3-VM-released" = "suma43VM-ign"
-    "head"            = "sles15sp4o"
     "uyuni-master"    = "opensuse155o"
     "uyuni-released"  = "opensuse155o"
     "uyuni-pr"        = "opensuse155o"
@@ -38,7 +37,7 @@ module "server" {
   connect_to_additional_network = false
   roles                         = var.register_to_server == null ? ["server"] : ["server", "minion"]
   disable_firewall              = var.disable_firewall
-  image                         = var.image == "default" || var.product_version == "head" ? var.images[var.product_version] : var.image
+  image                         = var.image == "default" ? var.images[var.product_version] : var.image
   provider_settings             = var.provider_settings
   main_disk_size                = var.main_disk_size
   additional_disk_size          = var.repository_disk_size


### PR DESCRIPTION
Prevents deploying `server` and `proxy` modules with versions `head` and `5.0-X`. Updates the advanced readme to reflect this constraint.

Unfortunately with `terraform-1.0.10` it's not possible to print out a specific clear message for this case. Below is an example output when attempting to deploy `server` on `head` (same error when using a non-existent `product_version`):

```
Error: Invalid index

  on modules/server/main.tf line 40, in module "server":
  40:   image = var.image == "default" ? var.images[var.product_version] : var.image
    ├────────────────
    │ var.images is object with 14 attributes
    │ var.product_version is "head"

The given key does not identify an element in this collection value.
```

There are some features that help with this in `1.5.x` and later. We can revisit this when we finally update to a newer version.

Fixes https://github.com/SUSE/spacewalk/issues/24332