### PR TITLE
QE: Downgrade chronium and chromedriver version

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -60,10 +60,12 @@ cucumber_requisites:
 install_chromium:
   pkg.installed:
   - name: chromium
+  - version: 125.0.6422.141-bp155.2.91.1
 
 install_chromedriver:
   pkg.installed:
   - name: chromedriver
+  - version: 125.0.6422.141-bp155.2.91.1
 
 create_syslink_for_chromedriver:
   file.symlink:


### PR DESCRIPTION
## What does this PR change?

Controller upgraded chromedriver and chromium to version `126.0.6478.126`. This version is creating timeout error during the testsuite execution. This timeout is related to `client.read_timeout = 240` and probably cause by the session being lost.
*Error*
`Net::ReadTimeout (Net::ReadTimeout)`

To prevent this issue, this PR is downgrading chromedriver and chromium to version `125.0.6422.141-bp155.2.91.1` that was the previous version.

Related card: https://github.com/SUSE/spacewalk/issues/24883