### PR TITLE
Do not check for gpg keys for additional repos for uyuni pr testing

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -87,7 +87,11 @@ zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repos
 for i in ${additional_repos};do
   name=$(echo $i | cut -d= -f1)
   url=$(echo $i | cut -d= -f2)
-  zypper ar $url $name
+  %{ if 'uyuni-pr' in grains.get('product_version', '') }
+    zypper ar --no-gpgcheck $url $name
+  {% else %}
+    zypper ar $url $name
+  %{ endif }
 done
 
 


### PR DESCRIPTION
## What does this PR change?

Otherwise, testing with Pull Requests fail because the additional_repos are not signed

Fixes https://github.com/SUSE/spacewalk/issues/24908
