### PR TITLE
Refactor `Do not check for gpg keys` in combustion

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -87,9 +87,9 @@ zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repos
 for i in ${additional_repos};do
   name=$(echo $i | cut -d= -f1)
   url=$(echo $i | cut -d= -f2)
-  %{ if "uyuni-pr" in grains.get('product_version', '') }
+  %{ if "uyuni-pr" in grains.get("product_version", "") }
     zypper ar --no-gpgcheck $url $name
-  {% else %}
+  %{ else }
     zypper ar $url $name
   %{ endif }
 done

--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -83,17 +83,17 @@ zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repos
 %{ endif }
 %{ endif } # end of image == "slmicro60o" block
 
-
-for i in ${additional_repos};do
+for i in ${additional_repos}; do
   name=$(echo $i | cut -d= -f1)
   url=$(echo $i | cut -d= -f2)
-  if [ "uyuni-pr" in grains.get("product_version", "" ]; then
+  product_version=$(grains.get "product_version" "")
+
+  if [[ $product_version == *"uyuni-pr"* ]]; then
     zypper ar --no-gpgcheck $url $name
   else
     zypper ar $url $name
   fi
 done
-
 
 # Install packages
 PACKAGES="qemu-guest-agent avahi ca-certificates"

--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -87,11 +87,11 @@ zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repos
 for i in ${additional_repos};do
   name=$(echo $i | cut -d= -f1)
   url=$(echo $i | cut -d= -f2)
-  %{ if "uyuni-pr" in grains.get("product_version", "") }
+  if [ "uyuni-pr" in grains.get("product_version", "" ]; then
     zypper ar --no-gpgcheck $url $name
-  %{ else }
+  else
     zypper ar $url $name
-  %{ endif }
+  fi
 done
 
 

--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -87,7 +87,7 @@ zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repos
 for i in ${additional_repos};do
   name=$(echo $i | cut -d= -f1)
   url=$(echo $i | cut -d= -f2)
-  %{ if 'uyuni-pr' in grains.get('product_version', '') }
+  %{ if "uyuni-pr" in grains.get('product_version', '') }
     zypper ar --no-gpgcheck $url $name
   {% else %}
     zypper ar $url $name


### PR DESCRIPTION
## What does this PR change?

The current way of configuring combustion is incorrect with the last changes and prevent sumaform to deploy.
`failed to render : <template_file>:90,20-22: Extra characters in if marker; Expected a closing brace to end the sequence, but found extra characters`
and 
`failed to render : <template_file>:90,9-10: Invalid character; Single quotes are not valid. Use double quotes (") to enclose strings., and 2 other diagnostic(s)`

Fix the issue by refactoring this block

Related to : https://github.com/uyuni-project/sumaform/pull/1629
