### PR TITLE
Use correct kernel package for SLE15 SP4

### DIFF
--- a/salt/minion/init.sls
+++ b/salt/minion/init.sls
@@ -79,3 +79,18 @@ minion_service:
     - watch:
       - file: master_configuration
 {% endif %}
+
+# WORKAROUND: The minimal VM images use a different kernel package that causes issues when trying to upgrade the
+# server and the proxy/minions via SUMA
+{% if grains['osfullname'] == 'SLES' and grains['osrelease'] == '15.4'  %}
+remove_kernel_default_base:
+  pkg.removed:
+    - name: kernel-default-base
+
+use_correct_kernel_package:
+  pkg.installed:
+    - pkgs:
+        - kernel-default
+    - require:
+      - pkg: remove_kernel_default_base
+{% endif %}

--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -348,3 +348,18 @@ testsuite_packages:
       - sls: repos
 {% endif %}
 {% endif %}
+
+# WORKAROUND: The minimal VM images use a different kernel package that causes issues when trying to upgrade the
+# server and the proxy/minions via SUMA
+{% if grains['osfullname'] == 'SLES' and grains['osrelease'] == '15.4'  %}
+remove_kernel_default_base:
+  pkg.removed:
+    - name: kernel-default-base
+
+use_correct_kernel_package:
+  pkg.installed:
+    - pkgs:
+        - kernel-default
+    - require:
+      - pkg: remove_kernel_default_base
+{% endif %}

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -172,3 +172,18 @@ change_product_tree_to_beta:
     - require:
       - cmd: server_setup
 {% endif %}
+
+# WORKAROUND: The minimal VM images use a different kernel package that causes issues when trying to upgrade the
+# server and the proxy/minions via SUMA
+{% if grains['osfullname'] == 'SLES' and grains['osrelease'] == '15.4'  %}
+remove_kernel_default_base:
+  pkg.removed:
+    - name: kernel-default-base
+
+use_correct_kernel_package:
+  pkg.installed:
+    - pkgs:
+        - kernel-default
+    - require:
+      - pkg: remove_kernel_default_base
+{% endif %}


### PR DESCRIPTION
## What does this PR change?

This removes the kernel package `kernel-default-base` and use `kernel-default` instead on our SLES 15 SP4 VMs. The former one is used due to the nature of the minimal VM image, we use.
For more information, take a look at the issue: https://github.com/SUSE/spacewalk/issues/24903

Running the change on e.g. the 4.3 proxy:

```bash
suma-bv-43-pxy:~ # venv-salt-call --local --file-root=. state.sls dom
/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/salt/utils/pycrypto.py:26: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
  import crypt
/usr/lib/venv-salt-minion/lib/python3.11/site-packages/salt/modules/linux_shadow.py:21: DeprecationWarning: 'spwd' is deprecated and slated for removal in Python 3.13
  import spwd
local:
----------
          ID: remove_kernel_default_base
    Function: pkg.removed
        Name: kernel-default-base
      Result: True
     Comment: All targeted packages were removed.
     Started: 15:34:15.157703
    Duration: 3016.966 ms
     Changes:
              ----------
              kernel-default-base:
                  ----------
                  new:
                  old:
                      5.14.21-150400.24.125.1.150400.24.60.1
----------
          ID: use_correct_kernel_package
    Function: pkg.installed
      Result: True
     Comment: The following packages were installed/updated: kernel-default
     Started: 15:34:18.678868
    Duration: 29788.695 ms
     Changes:
              ----------
              kernel-default:
                  ----------
                  new:
                      5.14.21-150400.24.125.1
                  old:

Summary for local
------------
Succeeded: 2 (changed=2)
Failed:    0
------------
Total states run:     2
Total run time:  32.806 s
```

```bash
suma-bv-43-pxy:~ # zypper se kernel-default
Loading repository data...
Reading installed packages...

S  | Name                 | Summary                                                 | Type
---+----------------------+---------------------------------------------------------+--------
i+ | kernel-default       | The Standard Kernel                                     | package
   | kernel-default-base  | The Standard Kernel - base modules                      | package
   | kernel-default-devel | Development files necessary for building kernel modules | package

    Note: For an extended search including not yet activated remote resources please use 'zypper
    search-packages'.
```
