### PR TITLE
correct image registry usage for server config

### DIFF
--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -12,7 +12,7 @@ scc:
 email: {{ grains.get("traceback_email") | default('galaxy-noise@suse.de', true) }}
 emailFrom: {{ grains.get("from_email") | default('galaxy-noise@suse.de', true) }}
 {%- if grains.get('container_repository') %}
-image: {{ grains.get('container_repository') }}/server
+registry: {{ grains.get('container_repository') }}
 {% endif %}
 {%- if grains.get('container_tag') %}
 tag: {{ grains.get('container_tag') }}


### PR DESCRIPTION
## What does this PR change?

Use the container registry flag instead of hard-code the image name/path.
