### PR TITLE
QE: Use correct kernel for SLES 15 SP4

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -325,10 +325,13 @@ zypper:
       gpgcheck: false
       name: tools_pool_repo
 
+runcmd:
+  - zypper remove kernel-default-base
+
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent", "kernel-default"]
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+packages: ["avahi", "nss-mdns", "qemu-guest-agent", "kernel-default"]
 %{ endif }
 
 runcmd:
@@ -927,7 +930,7 @@ packages: ["salt-minion"]
 runcmd:
   - zypper removerepo --all
 %{ endif }
-  
+
 %{ if image == "opensuse156armo" }
 
 runcmd:


### PR DESCRIPTION
## What does this PR change?

Make the kernel changes earlier in `cloud-init` instead of using the test suite. For SLES 15 SP4 only.

See https://github.com/SUSE/spacewalk/issues/24903 and https://github.com/SUSE/spacewalk/pull/24942.
