### PR TITLE
Set default namespace for kubernetes server installation

### DIFF
--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -26,6 +26,7 @@ helm:
   uyuni:
     chart: {{ grains.get("helm_chart_url") | default(helm_chart_default, true) }}
     values: /root/chart-values.yaml
+    namespace: uyuni
 {%- if grains.get("java_debugging") %}
 debug:
   java: true


### PR DESCRIPTION
## What does this PR change?

Ensures a namespace is provided when installing uyuni via sumaform
