### PR TITLE
Don't trigger server deployment when changing the additional repos

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -247,7 +247,6 @@ resource "null_resource" "provisioning" {
         roles                     = var.roles
         use_os_released_updates   = var.use_os_released_updates
         install_salt_bundle       = var.install_salt_bundle
-        additional_repos          = var.additional_repos
         additional_repos_only     = var.additional_repos_only
         additional_certs          = var.additional_certs
         additional_packages       = var.additional_packages


### PR DESCRIPTION
## What does this PR change?

### Context
Currently, when the `additional_repos` parameter is added, removed, or modified in a server declaration, `sumaform` triggers the Salt stages. However, these stages run without actually adding the new repositories. Moreover, this process unnecessarily scans all repository files, which can take several hours, without making any meaningful changes.

After reviewing various pipeline scenarios, I found no use case where triggering the Salt event is necessary when modifying `additional_repos`. This behavior is particularly problematic in the redeployment feature I'm working on for BV (see [PR #1292](https://github.com/SUSE/susemanager-ci/pull/1292)), as it significantly slows down the redeployment process without any tangible benefit.

### Solution
To address this, I propose that we stop triggering the server deployment when changes are made to the additional repositories. This adjustment will streamline the process, eliminating unnecessary delays in deployment.
