### PR TITLE
Remove iam role creation when deploying a none paygo instance

### DIFF
--- a/backend_modules/aws/base/iam_instance_profile.tf
+++ b/backend_modules/aws/base/iam_instance_profile.tf
@@ -6,6 +6,7 @@ resource "aws_iam_instance_profile" "metering_full_access_instance_profile" {
 }
 
 resource "aws_iam_role" "metering_full_access_role" {
+  count  = var.is_server_paygo_instance ? 1 : 0
   name   = "${var.name_prefix}-metering-full-access-role"
 
   assume_role_policy = jsonencode({


### PR DESCRIPTION
## What does this PR change?

Make sure iam role is not created when running a non paygo instance.
