### PR TITLE
Fix: Do include repos.os for server and proxy

### DIFF
--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -3,7 +3,9 @@ include:
   - repos.vendor
   {% if not grains.get('additional_repos_only') %}
   - repos.default_settings
+  {% if not ('server' in grains.get('roles') or 'proxy' in grains.get('roles')) %}
   - repos.os
+  {% endif %}
   - repos.clienttools
   - repos.minion
   - repos.proxy

--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -3,9 +3,7 @@ include:
   - repos.vendor
   {% if not grains.get('additional_repos_only') %}
   - repos.default_settings
-  {% if not ('server' in grains.get('roles') or 'proxy' in grains.get('roles')) %}
   - repos.os
-  {% endif %}
   - repos.clienttools
   - repos.minion
   - repos.proxy

--- a/salt/repos/os.sls
+++ b/salt/repos/os.sls
@@ -98,10 +98,12 @@ os_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP4/{{ grains.get("cpuarch") }}/update/
     - refresh: True
 
+{% if not ('server' in grains.get('roles') or 'proxy' in grains.get('roles')) %}
 os_ltss_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-SP4-LTSS/{{ grains.get("cpuarch") }}/update/
     - refresh: True
+{% endif %}
 
 {% elif '15.5' == grains['osrelease'] %}
 


### PR DESCRIPTION
## What does this PR change?

Do not include `os_ltss_repo` for server and proxy.


```bash
suma-43-pxy:~/salt/repos # venv-salt-call --local --file-root=. state.sls os
local:
----------
          ID: os_pool_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'os_pool_repo'
     Started: 17:02:53.049577
    Duration: 186.698 ms
     Changes:
              ----------
              repo:
                  os_pool_repo
----------
          ID: os_update_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Configured package repo 'os_update_repo'
     Started: 17:02:53.236404
    Duration: 97.605 ms
     Changes:
              ----------
              repo:
                  os_update_repo
----------
          ID: os_nop
    Function: test.nop
      Result: True
     Comment: Success!
     Started: 17:02:53.334560
    Duration: 0.494 ms
     Changes:

Summary for local
------------
Succeeded: 3 (changed=2)
Failed:    0
------------
Total states run:     3
Total run time: 284.797 ms
```

```bash
suma-43-pxy:~/salt/repos # zypper lr
Repository priorities in effect:                                                                                                                              (See 'zypper lr -P' for details)
      96 (raised priority)  :  3 repositories
      99 (default priority) : 10 repositories

#  | Alias                                  | Name                                   | Enabled | GPG Check | Refresh
---+----------------------------------------+----------------------------------------+---------+-----------+--------
 1 | containers_pool_repo                   | containers_pool_repo                   | Yes     | (r ) Yes  | Yes
 2 | containers_updates_repo                | containers_updates_repo                | Yes     | (r ) Yes  | Yes
 3 | module_server_applications_pool_repo   | module_server_applications_pool_repo   | Yes     | (r ) Yes  | Yes
 4 | module_server_applications_update_repo | module_server_applications_update_repo | Yes     | (r ) Yes  | Yes
 5 | os_pool_repo                           | os_pool_repo                           | Yes     | ( p) Yes  | Yes
 6 | os_update_repo                         | os_update_repo                         | Yes     | ( p) Yes  | Yes
 7 | proxy_devel_releasenotes_repo          | proxy_devel_releasenotes_repo          | Yes     | (r ) Yes  | Yes
 8 | proxy_devel_repo                       | proxy_devel_repo                       | Yes     | (r ) Yes  | Yes
 9 | proxy_module_pool_repo                 | proxy_module_pool_repo                 | Yes     | (r ) Yes  | Yes
10 | proxy_module_update_repo               | proxy_module_update_repo               | Yes     | (r ) Yes  | Yes
11 | proxy_product_pool_repo                | proxy_product_pool_repo                | Yes     | (r ) Yes  | Yes
12 | proxy_product_update_repo              | proxy_product_update_repo              | Yes     | (r ) Yes  | Yes
13 | testing_overlay_devel_repo             | testing_overlay_devel_repo             | Yes     | (r ) Yes  | Yes
14 | tools_pool_repo                        | tools_pool_repo                        | No      | ----      | ----
suma-43-pxy:~/salt/repos
```