### PR TITLE
Fix conditional for transactional systems

### DIFF
--- a/salt/server_containerized/large_deployment.sls
+++ b/salt/server_containerized/large_deployment.sls
@@ -8,7 +8,7 @@ include:
 large_deployment_increase_tasko_parallel_threads:
   cmd.run:
     - name: mgrctl exec 'echo "taskomatic.com.redhat.rhn.taskomatic.task.MinionActionExecutor.parallel_threads = 3" >> /etc/rhn/rhn.conf'
-{% if grains['osfullname'] != 'SLE Micro' %}
+{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
     - require:
       - pkg: uyuni-tools
 {% endif %}
@@ -16,7 +16,7 @@ large_deployment_increase_tasko_parallel_threads:
 large_deployment_increase_hibernate_max_connections:
   cmd.run:
     - name: mgrctl exec 'echo "hibernate.c3p0.max_size = 100" >> /etc/rhn/rhn.conf'
-{% if grains['osfullname'] != 'SLE Micro' %}
+{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
     - require:
       - pkg: uyuni-tools
 {% endif %}
@@ -49,7 +49,7 @@ large_deployment_tomcat_restart:
 large_deployment_increase_database_max_connections:
   cmd.run:
     - name: mgrctl exec 'sed -i "s/max_connections = (.*)/max_connections = 400/" /var/lib/pgsql/data/postgresql.conf'
-{% if grains['osfullname'] != 'SLE Micro' %}
+{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
     - require:
       - pkg: uyuni-tools
 {% endif %}
@@ -57,7 +57,7 @@ large_deployment_increase_database_max_connections:
 large_deployment_increase_database_work_memory:
   cmd.run:
     - name: mgrctl exec 'sed -i "s/work_mem = (.*)/work_mem = 20MB/" /var/lib/pgsql/data/postgresql.conf'
-{% if grains['osfullname'] != 'SLE Micro' %}
+{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
     - require:
       - pkg: uyuni-tools
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Fix conditional for transactional systems and aligns the conditions for `pkg: uyuni-tools` with the other occurrences.


```bash
null_resource.provisioning[0] (remote-exec): ----------
null_resource.provisioning[0] (remote-exec):           ID: large_deployment_increase_tasko_parallel_threads
null_resource.provisioning[0] (remote-exec):     Function: cmd.run
null_resource.provisioning[0] (remote-exec):         Name: mgrctl exec 'echo "taskomatic.com.redhat.rhn.taskomatic.task.MinionActionExecutor.parallel_threads = 3" >> /etc/rhn/rhn.conf'
null_resource.provisioning[0] (remote-exec):       Result: False
null_resource.provisioning[0] (remote-exec):      Comment: The following requisites were not found:
null_resource.provisioning[0] (remote-exec):                                  require:
null_resource.provisioning[0] (remote-exec):                                      pkg: uyuni-tools
null_resource.provisioning[0] (remote-exec):      Started: 14:07:39.296035
null_resource.provisioning[0] (remote-exec):     Duration: 0.003 ms
null_resource.provisioning[0] (remote-exec):      Changes:
null_resource.provisioning[0] (remote-exec): ----------
null_resource.provisioning[0] (remote-exec):           ID: large_deployment_increase_hibernate_max_connections
null_resource.provisioning[0] (remote-exec):     Function: cmd.run
null_resource.provisioning[0] (remote-exec):         Name: mgrctl exec 'echo "hibernate.c3p0.max_size = 100" >> /etc/rhn/rhn.conf'
null_resource.provisioning[0] (remote-exec):       Result: False
null_resource.provisioning[0] (remote-exec):      Comment: The following requisites were not found:
null_resource.provisioning[0] (remote-exec):                                  require:
null_resource.provisioning[0] (remote-exec):                                      pkg: uyuni-tools
null_resource.provisioning[0] (remote-exec):      Started: 14:07:39.296433
null_resource.provisioning[0] (remote-exec):     Duration: 0.002 ms
null_resource.provisioning[0] (remote-exec):      Changes:
```
