### PR TITLE
Force installation of docker instead of podman-docker in salt_testenv

### DIFF
--- a/salt/salt_testenv/salt_classic_package.sls
+++ b/salt/salt_testenv/salt_classic_package.sls
@@ -96,10 +96,15 @@ install_salt_testsuite:
 {% else %}
   {# HACK: we call zypper manually to ensure right packages are installed regardless upgrade/downgrade #}
   cmd.run:
+    {# We install docker first to ensure zypper does not resolve this dependency to podman-docker #}
     {% if salt_minion_is_installed %}
-    - name: zypper --non-interactive in --force --from salt_testing_repo python3-salt salt python3-salt-testsuite salt-minion
+    - name: |
+        zypper --non-interactive in --force docker
+        zypper --non-interactive in --force --from salt_testing_repo python3-salt salt python3-salt-testsuite salt-minion
     {% else %}
-    - name: zypper --non-interactive in --force --from salt_testing_repo python3-salt salt python3-salt-testsuite
+    - name: |
+        zypper --non-interactive in --force docker
+        zypper --non-interactive in --force --from salt_testing_repo python3-salt salt python3-salt-testsuite
     {% endif %}
     - fromrepo: salt_testing_repo
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

In the context of the `salt_testenv` module, for some OSes, zypper resolves the `docker` symbol to the `podman-docker` package instead of the `docker` package, which causes the docker service not being available. This happens during the application of the `install_salt_testuiste` state (`podman-docker` is resolved as a dependency of `python3-salt-testsuite` for some OSes).

This PR forces the installation of docker beforehand.