### PR TITLE
Add `xauth` for debugging with a remote Chromium

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -169,8 +169,14 @@ extra_pkgs:
   pkg.installed:
     - pkgs:
       - screen
+      - xauth
     - require:
       - sls: repos
+
+# needed together with the `xauth` package for debugging with chromedriver in non-headlesss mode with `export DEBUG=1`
+create_xauthority_file:
+  cmd.run:
+   - name: touch /root/.Xauthority
 
 chrome_certs:
   file.directory:


### PR DESCRIPTION
## What does this PR change?

With this, we are able to use `ssh -X`/`ssh -Y` on the controller to open Chromium remotely with X11.
Please see also the required test suite changes: https://github.com/uyuni-project/uyuni/pull/9170

