### PR TITLE
Leap: Add dependecies for `mgr-push`

### DIFF
--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -50,4 +50,21 @@ update_ca_truststore:
 {% endif %}
 {% endif %}
 
+# WORKAROUND for not syncing openSUSE Leap 15.5 in the Uyuni CIs
+# We need some dependencies for the package mgr-push, otherwise the installation in the test suite will fail
+{% if grains['osfullname'] == 'Leap' and grains['osrelease'] == '15.5' %}
+suse_minion_mgr_push_requisites:
+  pkg.installed:
+    - pkgs:
+      - hwdata
+      - libgudev-1_0-0
+      - python3-dmidecode
+      - python3-extras
+      - python3-hwdata
+      - python3-libxml2
+      - python3-pyudev
+      - python3-rhnlib
+      - zchunk
+{% endif %}
+
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Due to killing the Leap 15.5 reposync in the CI, we need those dependencies already fulfilled.
Fixes https://github.com/SUSE/spacewalk/issues/24979

```bash
uyuni-master-podman-min-suse:~/salt # venv-salt-call --local --file-root=. state.sls dom
/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/salt/utils/pycrypto.py:26: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
  import crypt
/usr/lib/venv-salt-minion/lib/python3.11/site-packages/salt/modules/linux_shadow.py:21: DeprecationWarning: 'spwd' is deprecated and slated for removal in Python 3.13
  import spwd
local:
----------
          ID: suse_minion_mgr_push_requisites
    Function: pkg.installed
      Result: True
     Comment: 9 targeted packages were installed/updated.
     Started: 14:19:37.615343
    Duration: 35566.602 ms
     Changes:
              ----------
              hwdata:
                  ----------
                  new:
                      0.380-150000.3.68.1
                  old:
              libgudev-1_0-0:
                  ----------
                  new:
                      237-150400.1.6
                  old:
              python3-dmidecode:
                  ----------
                  new:
                      3.12.2-150400.18.64
                  old:
              python3-extras:
                  ----------
                  new:
                      1.0.0-4.22
                  old:
              python3-hwdata:
                  ----------
                  new:
                      2.3.5-150000.3.9.1
                  old:
              python3-libxml2:
                  ----------
                  new:
                      2.10.3-150500.5.17.1
                  old:
              python3-pyudev:
                  ----------
                  new:
                      0.22.0+git.1642212208.d5630bf-150400.5.50
                  old:
              python3-rhnlib:
                  ----------
                  new:
                      5.0.3-2.1.uyuni
                  old:
              zchunk:
                  ----------
                  new:
                      1.1.16-150400.3.7.1
                  old:

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  35.567 s
```

With that, we can install `mgr-push` since the remaining dependencies can be met with the Uyuni Client Tools.

```bash
uyuni-master-podman-min-suse:~/salt # zypper in mgr-push
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 5 NEW packages are going to be installed:
  mgr-push python3-mgr-push python3-spacewalk-client-tools python3-uyuni-common-libs spacewalk-client-tools

5 new packages to install.
```

```sls
----------
          ID: pkg_installed
    Function: pkg.installed
        Name: pkg_installed
      Result: true
     Comment: 1 targeted package was installed/updated.
     Started: 14:25:20.274864
    Duration: 64768.56
         SLS: packages.pkginstall
     Changed: python3-uyuni-common-libs:
                  old: ''
                  new:
                  -   install_date_time_t: 1.723724783E9
                      version: 5.0.4
                      epoch: null
                      release: 2.1.uyuni
                      arch: x86_64
              python3-spacewalk-client-tools:
                  old: ''
                  new:
                  -   install_date_time_t: 1.723724783E9
                      version: 5.0.7
                      epoch: null
                      release: 2.1.uyuni
                      arch: noarch
              python3-mgr-push:
                  old: ''
                  new:
                  -   install_date_time_t: 1.723724784E9
                      version: 5.0.2
                      epoch: null
                      release: 2.1.uyuni
                      arch: noarch
              mgr-push:
                  old: ''
                  new:
                  -   install_date_time_t: 1.723724784E9
                      version: 5.0.2
                      epoch: null
                      release: 2.1.uyuni
                      arch: noarch
              spacewalk-client-tools:
                  old: ''
                  new:
                  -   install_date_time_t: 1.723724784E9
                      version: 5.0.7
                      epoch: null
                      release: 2.1.uyuni
                      arch: noarch
```
