### PR TITLE
Remove RMT registration for Liberty 9

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -690,6 +690,7 @@ runcmd:
   # WORKAROUND: cloud-init in Liberty 9 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
+  - dnf -y install venv-salt-minion
 
 %{ endif }
 

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -687,17 +687,7 @@ yum_repos:
     name: epel
 
 runcmd:
-  # Registration with SUSEConnect
-  - curl http://rmt.scc.suse.de/tools/rmt-client-setup-res --output rmt-client-setup-res
-  # WORKARAOUND for https://github.com/SUSE/rmt/issues/994
-  - sed -i -e's/REGURL=$1;;/REGURL="http:\/\/\$\{RMTNAME\}";;/' rmt-client-setup-res
-  - yes | sh rmt-client-setup-res https://rmt.scc.suse.de
-  # Packages installation after registration
-  - dnf config-manager --set-enabled epel
-  # EL9 only supports Salt Bundle, so we can't offer the possibility to install salt-minion package
-  - dnf -y install venv-salt-minion avahi nss-mdns
   # WORKAROUND: cloud-init in Liberty 9 does not take care of the following
-  - dnf -y install dbus-tools
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
 

--- a/salt/repos/os.sls
+++ b/salt/repos/os.sls
@@ -150,44 +150,6 @@ os_update_repo:
 {% endif %}{# grains['osfullname'] == 'SLES' #}
 {% endif %} {# grains['os'] == 'SUSE' #}
 
-
-{% if grains['os_family'] == 'RedHat' %}
-
-{% set release = grains.get('osmajorrelease', None)|int() %}
-
-{% if release == 9 %}
-{% if salt['file.search']('/etc/os-release', 'Liberty') %}
-
-os_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://rmt.scc.suse.de/repo/SUSE/Updates/SLL/9/x86_64/update
-    - refresh: True
-
-os_as_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://rmt.scc.suse.de/repo/SUSE/Updates/SLL-AS/9/x86_64/update
-    - refresh: True
-
-os_updates_repo:
-  pkgrepo.managed:
-    - baseurl: https://rmt.scc.suse.de/repo/SUSE/Updates/SLL/9/x86_64/update/?credentials=SUSE_Liberty_Linux_x86_64
-    - refresh: True
-
-os_as_updates_repo:
-  pkgrepo.managed:
-    - baseurl: https://rmt.scc.suse.de/repo/SUSE/Updates/SLL-AS/9/x86_64/update/?credentials=SUSE_Liberty_Linux_x86_64
-    - refresh: True
-
-os_cb_updates_repo:
-  pkgrepo.managed:
-    - baseurl: https://rmt.scc.suse.de/repo/SUSE/Updates/SLL-CB/9/x86_64/update/?credentials=SUSE_Liberty_Linux_x86_64
-    - refresh: True
-{% endif %} {# salt['file.search']('/etc/os-release', 'Liberty') #}
-{% endif %} {# release == 9 #}
-
-{% endif %} {# grains['os_family'] == 'RedHat' #}
-
-
 {# WORKAROUND: see github:saltstack/salt#10852 #}
 {{ sls }}_nop:
   test.nop: []


### PR DESCRIPTION
## What does this PR change?

`rmt.scc.suse.de` had issues in the past which caused issues in our BV deployments. With this, we remove this dependency.

Fixes https://github.com/SUSE/spacewalk/issues/24567

Bootstrapping the Liberty 9 Minion that was created via sumaform worked without RMT.
![image](https://github.com/user-attachments/assets/4e39d388-8d0f-461e-9406-d7ce6ea819bd)
![image](https://github.com/user-attachments/assets/0525d57a-63f3-4cbe-b142-5df03cd13a36)
![image](https://github.com/user-attachments/assets/1e52397e-a72b-4077-aa02-42cc0c8a0fd2)
![image](https://github.com/user-attachments/assets/28c976f7-c905-4922-8b4a-2a497f0fa6c8)
![image](https://github.com/user-attachments/assets/d460a70f-355b-4cfa-a507-fea69909816a)




