### PR TITLE
Force GPG import in containerized server

### DIFF
--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -81,7 +81,7 @@ uyuni_key_copy_host:
 
 repo_key_import:
   cmd.run:
-    - name: "mgradm gpg add /tmp/uyuni.key"
+    - name: "mgradm gpg add -f /tmp/uyuni.key"
     - onchanges:
       - file: uyuni_key_copy_host
 {% else %}
@@ -93,7 +93,7 @@ galaxy_key_copy_host:
 
 repo_key_import:
   cmd.run:
-    - name: "mgradm gpg add /tmp/galaxy.key"
+    - name: "mgradm gpg add -f /tmp/galaxy.key"
     - onchanges:
       - file: galaxy_key_copy_host
 
@@ -106,7 +106,7 @@ suse_staging_key_copy_host:
 
 suse_staging_key_import:
   cmd.run:
-    - name: "mgradm gpg add /tmp/suse_staging.key"
+    - name: "mgradm gpg add -f /tmp/suse_staging.key"
     - onchanges:
       - file: suse_staging_key_copy_host
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Since we cannot confirm anything during the sumaform setup, we need to force the import. Otherwise, sumaform does not succeed because it will wait for confirmation forever.
![image](https://github.com/user-attachments/assets/6d1c6df3-eea4-42a1-99ce-48e35e1619a6)

