### PR TITLE
roles is a list and we need to check for all exact values we expect

### DIFF
--- a/salt/repos/server.sls
+++ b/salt/repos/server.sls
@@ -1,4 +1,4 @@
-{% if 'server' in grains.get('roles') %}
+{% if 'server' in grains.get('roles') or 'server_containerized' in grains.get('roles') %}
 
 include:
   {%- if '4.2' in grains['product_version'] %}


### PR DESCRIPTION
## What does this PR change?

Using "in" for a list, requires exact matching. This is different to use in match on a string
