### PR TITLE
Remove duplicate Manager 5.0 tools repo

### DIFF
--- a/salt/repos/proxy_containerized.sls
+++ b/salt/repos/proxy_containerized.sls
@@ -4,8 +4,9 @@
 include:
   - repos.proxy_containerizedUyuni
 {% elif '5.0' in grains.get('product_version') %}
-include:
-  - repos.proxy50
+# we already include this with cloud-init for SLE Micro 5.5
+# include:
+#  - repos.proxy50
 {%- endif %}
 
 {% endif %}

--- a/salt/repos/server_containerized.sls
+++ b/salt/repos/server_containerized.sls
@@ -4,8 +4,9 @@
 include:
   - repos.server_containerizedUyuni
 {% elif '5.0' in grains.get('product_version') %}
-include:
-  - repos.server50
+# we already include this with cloud-init for SLE Micro 5.5
+# include:
+#  - repos.server50
 {%- endif %}
 
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Fixes

```bash
module.cucumber_testsuite.module.server_containerized[0].module.server_containerized.module.host.null_resource.provisioning[0] (remote-exec): ----------
module.cucumber_testsuite.module.server_containerized[0].module.server_containerized.module.host.null_resource.provisioning[0] (remote-exec):           ID: manager50_repo
module.cucumber_testsuite.module.server_containerized[0].module.server_containerized.module.host.null_resource.provisioning[0] (remote-exec):     Function: pkgrepo.managed
module.cucumber_testsuite.module.server_containerized[0].module.server_containerized.module.host.null_resource.provisioning[0] (remote-exec):       Result: False
module.cucumber_testsuite.module.server_containerized[0].module.server_containerized.module.host.null_resource.provisioning[0] (remote-exec):      Comment: Failed to configure repo 'manager50_repo': Repository 'manager50_repo' already exists as 'container_tools_repo'.
```
when using `5.0-released` or `5.0-nightly` as `product_version` in the `main.tf`.

For now, I simply commented the including files out, due to other changes that we could need in the future. I know, YAGNI, but still :wink: 
