### PR TITLE
Take product version from grains for cloud-init

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -63,7 +63,7 @@ data "template_file" "user_data" {
     testsuite           = lookup(var.base_configuration, "testsuite", false)
     files               = jsonencode(local.gpg_keys)
     additional_repos    = jsonencode(var.additional_repos)
-    product_version     = var.product_version
+    product_version     = local.product_version
   }
 }
 


### PR DESCRIPTION
## What does this PR change?

"product_version" was always "5.0-released" because it was taken from module variables in the case of cloud-init.

Combustion is already okay.
