### PR TITLE
Do not declare container repositories twice

### DIFF
--- a/salt/repos/proxy_containerized50.sls
+++ b/salt/repos/proxy_containerized50.sls
@@ -4,11 +4,12 @@
 {% if grains['osfullname'] == 'SLE Micro' %}
 
 
-manager50_repo:
-  pkgrepo.managed:
-    - baseurl: http://download.suse.de/ibs/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/
-    - refresh: True
-    - gpgkey: http://download.suse.de/ibs/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+# Commented out because we already add this repo in cloud-init:
+# manager50_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 
 {% endif %}
 {% endif %}

--- a/salt/repos/proxy_containerizedHead.sls
+++ b/salt/repos/proxy_containerizedHead.sls
@@ -4,12 +4,12 @@
 {% if grains['osfullname'] == 'SLE Micro' %}
 
 
-proxy_devel_repo:
-  pkgrepo.managed:
-    # 5.0 should probably become 5.1 in the following URLs:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/
-    - refresh: True
-    - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+# Commented out because we already add this repo in cloud-init:
+# proxy_devel_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-5.1-POOL-x86_64-Media1/
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-5.1-POOL-x86_64-Media1/repodata/repomd.xml.key
 
 {% endif %}
 {% endif %}

--- a/salt/repos/server_containerized50.sls
+++ b/salt/repos/server_containerized50.sls
@@ -4,11 +4,12 @@
 {% if grains['osfullname'] == 'SLE Micro' %}
 
 
-manager50_repo:
-  pkgrepo.managed:
-    - baseurl: http://download.suse.de/ibs/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1
-    - refresh: True
-    - gpgkey: http://download.suse.de/ibs/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+# Commented out because we already add this repo in cloud-init:
+# manager50_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 
 {% endif %}
 {% endif %}

--- a/salt/repos/server_containerizedHead.sls
+++ b/salt/repos/server_containerizedHead.sls
@@ -4,12 +4,12 @@
 {% if grains['osfullname'] == 'SLE Micro' %}
 
 
-server_devel_repo:
-  pkgrepo.managed:
-    # 5.0 should probably become 5.1 in the following URLs:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/
-    - refresh: True
-    - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+# Commented out because we already add this repo in cloud-init:
+# server_devel_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-5.1-POOL-x86_64-Media1/
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-5.1-POOL-x86_64-Media1/repodata/repomd.xml.key
 
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

This PR avoids this issue:
```
Failed to configure repo 'manager50_repo': Repository 'manager50_repo' already exists
as 'container_tools_repo'.
```

(we did not see this issue in Head because of subtle differences with `/ibs` in the URL or not).
