### PR TITLE
Uyuni: Do not declare container repos twice

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -59,7 +59,11 @@ zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repos
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/ client_tools_repo
 
 %{ if container_server || container_proxy }
+%{ if product_version == "uyuni-master" || product_version == "uyuni-pr" }
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/openSUSE_Leap_Micro_5.5/ container_utils
+%{ else }
+zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/openSUSE_Leap_Micro_5.5/ container_utils
+%{ endif }
 %{ endif }
 
 %{ if testsuite }

--- a/salt/repos/proxy_containerizedUyuni.sls
+++ b/salt/repos/proxy_containerizedUyuni.sls
@@ -7,22 +7,23 @@
 {% if grains['osfullname'] == 'openSUSE Leap Micro' %}
 {% set repo = 'openSUSE_Leap_Micro_5.5' %}
 
+{% if 'uyuni' in grains['product_version'] %}
 # Commented out because we already add this repo in combustion:
-# {% if 'uyuni' in grains['product_version'] %}
 # containerutils_uyuni_stable:
 #     pkgrepo.managed:
 #     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/
 #     - refresh: True
 #     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
-# {% endif %}
+{% endif %}
 
-# {% if 'uyuni-master' in grains.get('product_version') %}
+{% if 'uyuni-master' in grains.get('product_version') %}
+# Commented out because we already add this repo in combustion:
 # containerutils_uyuni_master:
 #     pkgrepo.managed:
 #     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/
 #     - refresh: True
 #     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
-# {% endif %}
+{% endif %}
 
 {% endif %}
 {% endif %}

--- a/salt/repos/proxy_containerizedUyuni.sls
+++ b/salt/repos/proxy_containerizedUyuni.sls
@@ -4,14 +4,25 @@
 #       This only affects Uyuni, as we use slemicro55o image for Head/5.0
 
 {% if grains.get("os") == "SUSE" %}
-{% if grains['osfullname'] == 'Leap' %}
-{% set repo = 'openSUSE_Leap_15.5' %}
+{% if grains['osfullname'] == 'openSUSE Leap Micro' %}
+{% set repo = 'openSUSE_Leap_Micro_5.5' %}
 
-systemsmanagement_Uyuni_Master_ContainerUtils:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/
-    - refresh: True
-    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+# Commented out because we already add this repo in combustion:
+# {% if 'uyuni' in grains['product_version'] %}
+# containerutils_uyuni_stable:
+#     pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+# {% endif %}
+
+# {% if 'uyuni-master' in grains.get('product_version') %}
+# containerutils_uyuni_master:
+#     pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+# {% endif %}
 
 {% endif %}
 {% endif %}

--- a/salt/repos/server_containerizedUyuni.sls
+++ b/salt/repos/server_containerizedUyuni.sls
@@ -1,14 +1,26 @@
 {% if 'server_containerized' in grains.get('roles')  %}
 
 {% if grains.get("os") == "SUSE" %}
-{% if grains['osfullname'] == 'Leap' %}
-{% set repo = 'openSUSE_Leap_15.5' %}
+{% if grains['osfullname'] == 'openSUSE Leap Micro' %}
+{% set repo = 'openSUSE_Leap_Micro_5.5' %}
 
-systemsmanagement_Uyuni_Master_ContainerUtils:
-    pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/
-    - refresh: True
-    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+# Commented out because we already add this repo in combustion:
+# {% if 'uyuni' in grains['product_version'] %}
+# containerutils_uyuni_stable:
+#     pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+# {% endif %}
+
+# {% if 'uyuni-master' in grains.get('product_version') %}
+# containerutils_uyuni_master:
+#     pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+# {% endif %}
+
 
 {% endif %}
 {% endif %}

--- a/salt/repos/server_containerizedUyuni.sls
+++ b/salt/repos/server_containerizedUyuni.sls
@@ -4,22 +4,24 @@
 {% if grains['osfullname'] == 'openSUSE Leap Micro' %}
 {% set repo = 'openSUSE_Leap_Micro_5.5' %}
 
+
+{% if 'uyuni' in grains['product_version'] %}
 # Commented out because we already add this repo in combustion:
-# {% if 'uyuni' in grains['product_version'] %}
 # containerutils_uyuni_stable:
 #     pkgrepo.managed:
 #     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/
 #     - refresh: True
 #     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
-# {% endif %}
+{% endif %}
 
-# {% if 'uyuni-master' in grains.get('product_version') %}
+{% if 'uyuni-master' in grains.get('product_version') %}
+# Commented out because we already add this repo in combustion:
 # containerutils_uyuni_master:
 #     pkgrepo.managed:
 #     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/
 #     - refresh: True
 #     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
-# {% endif %}
+{% endif %}
 
 
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

The same as https://github.com/uyuni-project/sumaform/pull/1673, but for Uyuni.

Basically, we already have the repos added with Combustion, so we do not want to add them again with Salt. Furthermore, this differentiates between Uyuni Master and Uyuni Stable in Combustion.
