### PR TITLE
Add repository for AppStream tests

### DIFF
--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -32,7 +32,7 @@ test_repo_appstream:
     - name: mgrctl exec -e MINIMA_CONFIG minima sync
     - env:
       - MINIMA_CONFIG: |
-          - url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Appstream/rhlike
+          - url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Appstream/rhlike
             path: /srv/www/htdocs/pub/TestRepoAppStream
     - require:
       - cmd: minima_unpack

--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -32,7 +32,7 @@ test_repo_appstream:
     - name: mgrctl exec -e MINIMA_CONFIG minima sync
     - env:
       - MINIMA_CONFIG: |
-          - url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Appstream/CentOS_8
+          - url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Appstream/rhlike
             path: /srv/www/htdocs/pub/TestRepoAppStream
     - require:
       - cmd: minima_unpack

--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -27,6 +27,16 @@ test_repo_rpm_updates:
     - require:
       - cmd: minima_unpack
 
+test_repo_appstream:
+  cmd.run:
+    - name: mgrctl exec -e MINIMA_CONFIG minima sync
+    - env:
+      - MINIMA_CONFIG: |
+          - url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Appstream/CentOS_8
+            path: /srv/www/htdocs/pub/TestRepoAppStream
+    - require:
+      - cmd: minima_unpack
+
 another_test_repo:
   cmd.run:
     - name: mgrctl exec "ln -s TestRepoRpmUpdates /srv/www/htdocs/pub/AnotherRepo"


### PR DESCRIPTION
## What does this PR change?

As the title implies: adding a new dummy modular repository which will be used for testing AppStream features.

