### PR TITLE
Always force dhcp dns host setup

### DIFF
--- a/modules/dhcp_dns/main.tf
+++ b/modules/dhcp_dns/main.tf
@@ -24,6 +24,9 @@ locals {
 }
 
 resource "null_resource" "standalone_provisioning" {
+  triggers = {
+    always_run = "${timestamp()}"
+  }
 
   count = var.base_configuration["additional_network"] != null ? var.quantity : 0
 


### PR DESCRIPTION


## What does this PR change?
dhcp dns host setup is not happening, so we add a trigger to make it run always.

