### PR TITLE
Non-interactive mode for transactional-update

### DIFF
--- a/salt/default/minimal.sls
+++ b/salt/default/minimal.sls
@@ -16,9 +16,9 @@ minimal_package_update:
 {% if grains['os_family'] == 'Suse' and grains['osfullname'] in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
   cmd.run:
 {% if grains['install_salt_bundle'] %}
-    - name: transactional-update -c package up zypper libzypp venv-salt-minion
+    - name: transactional-update -n -c package up zypper libzypp venv-salt-minion
 {% else %}
-    - name: transactional-update -c package up zypper libzypp salt-minion
+    - name: transactional-update -n -c package up zypper libzypp salt-minion
 {% endif %}
 {% else %}
   pkg.latest:


### PR DESCRIPTION
## What does this PR change?

Do not remain blocked on:
```
Resolving package dependencies...

The following package is going to be upgraded:
  venv-salt-minion

1 package to upgrade.
Overall download size: 31.1 MiB. Already cached: 0 B. After the operation, additional 48.9 KiB will be used.

Backend:  classic_rpmtrans
Continue? [y/n/v/...? shows all options] (y):
```