### PR TITLE
Break chicken and egg issue

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -13,7 +13,6 @@ type=ethernet
 interface-name=$2
 
 [ipv4]
-dhcp-timeout=30
 method=auto
 
 [ipv6]


### PR DESCRIPTION
## What does this PR change?

DHCP and DNS VM has a dependency to proxy and PXE boot VMs, but the latter do not get an IP address until the former is running.

Let DHCP fail after 0 second.
