### PR TITLE
support standard openSUSE Leap 15.5 as server and proxy os

### DIFF
--- a/salt/repos/proxy_containerizedUyuni.sls
+++ b/salt/repos/proxy_containerizedUyuni.sls
@@ -7,7 +7,7 @@
 {% if grains['osfullname'] == 'openSUSE Leap Micro' %}
 {% set repo = 'openSUSE_Leap_Micro_5.5' %}
 
-{% if 'uyuni' in grains['product_version'] %}
+{% if 'uyuni' == grains['product_version'] %}
 # Commented out because we already add this repo in combustion:
 # containerutils_uyuni_stable:
 #     pkgrepo.managed:
@@ -16,7 +16,7 @@
 #     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
 {% endif %}
 
-{% if 'uyuni-master' in grains.get('product_version') %}
+{% if 'uyuni-master' == grains.get('product_version') %}
 # Commented out because we already add this repo in combustion:
 # containerutils_uyuni_master:
 #     pkgrepo.managed:
@@ -26,6 +26,29 @@
 {% endif %}
 
 {% endif %}
+
+{% if grains['osfullname'] == 'Leap' %}
+{% set repo = 'openSUSE_Leap_15.5' %}
+
+
+{% if 'uyuni' == grains['product_version'] %}
+containerutils_uyuni_stable:
+    pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+{% endif %}
+
+{% if 'uyuni-master' == grains.get('product_version') %}
+containerutils_uyuni_master:
+    pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+{% endif %}
+
+{% endif %}
+
 {% endif %}
 {% endif %}
 

--- a/salt/repos/server_containerizedUyuni.sls
+++ b/salt/repos/server_containerizedUyuni.sls
@@ -5,7 +5,7 @@
 {% set repo = 'openSUSE_Leap_Micro_5.5' %}
 
 
-{% if 'uyuni' in grains['product_version'] %}
+{% if 'uyuni' == grains['product_version'] %}
 # Commented out because we already add this repo in combustion:
 # containerutils_uyuni_stable:
 #     pkgrepo.managed:
@@ -14,7 +14,7 @@
 #     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
 {% endif %}
 
-{% if 'uyuni-master' in grains.get('product_version') %}
+{% if 'uyuni-master' == grains.get('product_version') %}
 # Commented out because we already add this repo in combustion:
 # containerutils_uyuni_master:
 #     pkgrepo.managed:
@@ -25,6 +25,30 @@
 
 
 {% endif %}
+
+{% if grains['osfullname'] == 'Leap' %}
+{% set repo = 'openSUSE_Leap_15.5' %}
+
+
+{% if 'uyuni' == grains['product_version'] %}
+containerutils_uyuni_stable:
+    pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+{% endif %}
+
+{% if 'uyuni-master' == grains.get('product_version') %}
+containerutils_uyuni_master:
+    pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+{% endif %}
+
+
+{% endif %}
+
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
## What does this PR change?

Leap Micro does not exist in Public Cloud. To run our Uyuni testsuite in the cloud, we need to support standard Leap.



