### PR TITLE
Add 5.0 to list of products that use the bundle

### DIFF
--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -99,7 +99,7 @@ testsuite_salt_packages:
       - sls: repos
 {% endif %}
 
-{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "4.3-released", "4.3-nightly", "4.3-pr", "4.2-nightly", "4.2-released", "4.3-VM-nightly", "4.3-VM-released"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "5.0-nightly", "5.0-released", "4.3-nightly", "4.3-released", "4.3-pr", "4.3-VM-nightly", "4.3-VM-released", "4.2-nightly", "4.2-released"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,


### PR DESCRIPTION
## What does this PR change?

Ideally, we should get rid of the list of products that use the Salt bundle, since now all our products do that by default.

However, Dominik still needs that flag to work on another card.

For now, just add 5.0 to that list.

