### PR TITLE
Do not crash when "product_version" is not defined for "host" and "salt_testenv" nodes

### DIFF
--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -15,7 +15,7 @@ include:
   - repos.testsuite
   - repos.tools
   - repos.jenkins
-  {% if '4.3' not in grains.get('product_version') %}
+  {% if '4.3' not in grains.get('product_version', '') %}
   - repos.ruby
   {% endif %}
   {% endif %}


### PR DESCRIPTION
## What does this PR change?

This PR fixes a regression introduced by https://github.com/uyuni-project/sumaform/pull/1248/ which breaks the deployment of some node types, like the generic `host` or `salt_testenv`, as those don't have a `product_version` defined.


