### PR TITLE
Add a file for salt output

### DIFF
--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -22,7 +22,7 @@ fi
 
 echo "starting first call to update salt and do minimal configuration"
 
-${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info $MODULE_EXEC state.sls default.minimal ||:
+${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info --out-file=/var/log/salt-deployment.log $MODULE_EXEC state.sls default.minimal ||:
 
 NEXT_TRY=0
 until [ $NEXT_TRY -eq 10 ] || ${SALT_CALL} --local test.ping
@@ -39,6 +39,6 @@ fi
 
 echo "apply highstate"
 
-${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color $MODULE_EXEC state.highstate || exit 1
+${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info --out-file=/var/log/salt-deployment.log --retcode-passthrough --force-color $MODULE_EXEC state.highstate || exit 1
 
 chmod +x ${FILE_ROOT}/highstate.sh

--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -24,6 +24,9 @@ echo "starting first call to update salt and do minimal configuration"
 
 ${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info --out-file=/var/log/salt-deployment.log $MODULE_EXEC state.sls default.minimal ||:
 
+# Display the output from the Salt execution
+cat /var/log/salt-deployment.log
+
 NEXT_TRY=0
 until [ $NEXT_TRY -eq 10 ] || ${SALT_CALL} --local test.ping
 do
@@ -40,5 +43,8 @@ fi
 echo "apply highstate"
 
 ${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info --out-file=/var/log/salt-deployment.log --retcode-passthrough --force-color $MODULE_EXEC state.highstate || exit 1
+
+# Display the output from the Salt execution
+cat /var/log/salt-deployment.log
 
 chmod +x ${FILE_ROOT}/highstate.sh

--- a/salt/highstate.sh
+++ b/salt/highstate.sh
@@ -12,4 +12,4 @@ else
     exit 1
 fi
 
-${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info --retcode-passthrough --force-color state.highstate
+${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info --out-file=/var/log/salt-deployment.log --retcode-passthrough --force-color state.highstate

--- a/salt/highstate.sh
+++ b/salt/highstate.sh
@@ -13,3 +13,6 @@ else
 fi
 
 ${SALT_CALL} --local --file-root=$FILE_ROOT/ --log-level=info --out-file=/var/log/salt-deployment.log --retcode-passthrough --force-color state.highstate
+
+# Display the output from the Salt execution
+cat /var/log/salt-deployment.log


### PR DESCRIPTION
## What does this PR change?

Write down the salt deployment output in var log file to more easily debug when salt states are failing without the need of rerunning it.
