### PR TITLE
Refactor the usage of packages keyword in cloud-init, to avoid auto upgrade of packages

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -20,7 +20,8 @@ zypper:
       name: tools_pool_repo
 # For openSUSE Tumbleweed venv-salt-minion is not available.
 # The goal is to be able to run Salt Shaker tests for the classic Salt package in Tumbleweed.
-packages: ["salt", "salt-minion", "avahi", "avahi-lang"]
+runcmd:
+  - zypper in salt salt-minion avahi avahi-lang
 %{endif}
 
 %{ if image == "centos7o" }
@@ -48,9 +49,11 @@ yum_repos:
     name: epel
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in salt-minion avahi nss-mdns qemu-guest-agent
 %{ endif }
 %{ endif }
 
@@ -88,9 +91,11 @@ yum_repos:
     name: CentOS-AppStream_backup
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in salt-minion avahi nss-mdns qemu-guest-agent
 %{ endif }
 %{ endif }
 
@@ -128,9 +133,11 @@ yum_repos:
     name: CentOS-AppStream_backup
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in salt-minion avahi nss-mdns qemu-guest-agent
 %{ endif }
 %{ endif }
 
@@ -144,9 +151,11 @@ zypper:
       name: tools_pool_repo
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns
 %{ else }
-packages: ["avahi", "nss-mdns"]
+runcmd:
+  - zypper in avahi nss-mdns
 %{ endif }
 
 runcmd:
@@ -168,9 +177,11 @@ zypper:
       name: tools_pool_repo
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in avahi nss-mdns qemu-guest-agent
 %{ endif }
 %{ endif }
 
@@ -194,9 +205,11 @@ zypper:
       name: tools_pool_repo
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in avahi nss-mdns qemu-guest-agent
 %{ endif }
 
 runcmd:
@@ -219,9 +232,11 @@ zypper:
       name: tools_pool_repo
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in avahi nss-mdns qemu-guest-agent
 %{ endif }
 
 runcmd:
@@ -244,9 +259,11 @@ zypper:
       name: tools_pool_repo
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in avahi nss-mdns qemu-guest-agent
 %{ endif }
 
 runcmd:
@@ -269,9 +286,11 @@ zypper:
       name: tools_pool_repo
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in avahi nss-mdns qemu-guest-agent
 %{ endif }
 
 runcmd:
@@ -295,9 +314,11 @@ zypper:
       name: tools_pool_repo
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in avahi nss-mdns qemu-guest-agent
 %{ endif }
 
 runcmd:
@@ -465,9 +486,11 @@ runcmd:
   - systemctl start qemu-guest-agent
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi-daemon", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi-daemon qemu-guest-agent
 %{ else }
-packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
+runcmd:
+  - zypper in salt-minion avahi-daemon qemu-guest-agent
 %{ endif }
 %{ endif }
 %{ if image == "ubuntu2204o" }
@@ -508,9 +531,11 @@ runcmd:
   - systemctl start qemu-guest-agent
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi-daemon", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi-daemon qemu-guest-agent
 %{ else }
-packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent"]
+runcmd:
+  - zypper in salt-minion avahi-daemon qemu-guest-agent
 %{ endif }
 %{ endif }
 %{ if image == "debian12o" }
@@ -553,9 +578,11 @@ bootcmd:
   - DEBIAN_FRONTEND=noninteractive apt-get -yq install gnupg
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi-daemon", "qemu-guest-agent", "gnupg"]
+runcmd:
+  - zypper in venv-salt-minion avahi-daemon qemu-guest-agent gnupg
 %{ else }
-packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "gnupg"]
+runcmd:
+  - zypper in salt-minion avahi-daemon qemu-guest-agent gnupg
 %{ endif }
 %{ endif }
 %{ if image == "debian11o" }
@@ -600,9 +627,11 @@ bootcmd:
   - DEBIAN_FRONTEND=noninteractive apt-get -yq install gnupg
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi-daemon", "qemu-guest-agent", "gnupg", "python3-apt"]
+runcmd:
+  - zypper in venv-salt-minion avahi-daemon qemu-guest-agent gnupg python3-apt
 %{ else }
-packages: ["salt-minion", "avahi-daemon", "qemu-guest-agent", "gnupg", "python3-apt"]
+runcmd:
+  - zypper in salt-minion avahi-daemon qemu-guest-agent gnupg python3-apt
 %{ endif }
 %{ endif }
 
@@ -626,9 +655,11 @@ yum_repos:
     name: epel
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in salt-minion avahi nss-mdns qemu-guest-agent
 %{ endif }
 
 %{ endif }
@@ -650,9 +681,11 @@ yum_repos:
     name: epel
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
+runcmd:
+  - zypper in avahi nss-mdns qemu-guest-agent salt-minion
 %{ endif }
 
 %{ endif }
@@ -679,9 +712,11 @@ runcmd:
   - systemctl restart sshd
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent", "dbus-tools"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent dbus-tools
 %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion", "dbus-tools"]
+runcmd:
+  - zypper in avahi nss-mdns qemu-guest-agent salt-minion dbus-tools
 %{ endif }
 
 %{ endif }
@@ -727,9 +762,11 @@ yum_repos:
     name: epel
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "dbus-tools"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns dbus-tools
 %{ else }
-packages: ["avahi", "nss-mdns", "salt-minion", "dbus-tools"]
+runcmd:
+  - zypper in avahi nss-mdns salt-minion dbus-tools
 %{ endif }
 
 %{ endif }
@@ -756,9 +793,11 @@ runcmd:
   - systemctl restart sshd
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "dbus-tools"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns dbus-tools
 %{ else }
-packages: ["avahi", "nss-mdns", "salt-minion", "dbus-tools"]
+runcmd:
+  - zypper in avahi nss-mdns salt-minion dbus-tools
 %{ endif }
 %{ endif }
 
@@ -779,9 +818,11 @@ yum_repos:
     name: epel
 
   %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
   %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion"]
+runcmd:
+  - zypper in avahi nss-mdns qemu-guest-agent salt-minion
   %{ endif }
 
   %{ endif }
@@ -808,9 +849,11 @@ runcmd:
   - systemctl restart sshd
 
   %{ if install_salt_bundle }
-packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent", "dbus-tools", "tar"]
+runcmd:
+  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent dbus-tools tar
   %{ else }
-packages: ["avahi", "nss-mdns", "qemu-guest-agent", "salt-minion", "dbus-tools", "tar"]
+runcmd:
+  - zypper in salt-minion avahi nss-mdns qemu-guest-agent dbus-tools tar
   %{ endif }
 
 %{ endif }
@@ -825,9 +868,11 @@ zypper:
       name: tools_pool_repo
 
 %{ if install_salt_bundle }
-packages: ["venv-salt-minion"]
+runcmd:
+  - zypper in venv-salt-minion
 %{ else }
-packages: ["salt-minion"]
+runcmd:
+  - zypper in salt-minion
 %{ endif }
 
 runcmd:


### PR DESCRIPTION
## What does this PR change?

Don't upgrade packages in the systems deployed in a SUMA/Uyuni test environment.

- Related card: https://github.com/SUSE/spacewalk/issues/25189

The cloud team added the module `package-update-upgrade-install` to SUSE cloud-init configuration. This triggers an not-desired update of packages in some of the systems part of our test environment.

This is triggered due to the usage of the keyword `packages` in our [YAML file](https://github.com/uyuni-project/sumaform/blob/master/backend_modules/libvirt/host/user_data.yaml#L91).

---

This PR replace the keyword `packages` by `runcmd zypper in`

Example:
```
packages: ["venv-salt-minion", "avahi", "nss-mdns", "qemu-guest-agent"]
```
```
runcmd:
  - zypper in venv-salt-minion avahi nss-mdns qemu-guest-agent
```
