### PR TITLE
dnf command not available on centos7

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -50,9 +50,9 @@ yum_repos:
 
 runcmd:
 %{ if install_salt_bundle }
-  - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent"
+  - "yum -y install venv-salt-minion avahi nss-mdns qemu-guest-agent"
 %{ else }
-  - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
+  - "yum -y install salt-minion avahi nss-mdns qemu-guest-agent"
 %{ endif }
 %{ endif }
 


### PR DESCRIPTION
## What does this PR change?

dnf command not available on centos7 : 
```bash
[root@suma-bv-50-centos7-minion log]# dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent
-bash: dnf: command not found
```