### PR TITLE
Enable salt service ONLY if auto_connect to master is true.

### DIFF
--- a/salt/minion/init.sls
+++ b/salt/minion/init.sls
@@ -66,6 +66,7 @@ master_configuration:
           - susemanager
 {% endif %}
 
+{% if grains.get('auto_connect_to_master') %}
 minion_service:
   service.running:
 {% if grains['install_salt_bundle'] %}
@@ -75,7 +76,6 @@ minion_service:
     - name: salt-minion
     - enable: True
 {% endif %}
-{% if grains.get('auto_connect_to_master') %}
     - watch:
       - file: master_configuration
 {% endif %}


### PR DESCRIPTION
## What does this PR change?
Don't start venv-salt-minion or salt-minion service when auto_connect_to_master is set to false.
The file master_configuration is only set when auto connect to master is true so it doesn't make sense to start salt minion service when file is not set.

