### PR TITLE
setenforce 0 for centos7 to support auto connect to master.

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -30,6 +30,7 @@ bootcmd:
   - sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
   - sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
   - sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+  - setenforce 0
 
 yum_repos:
   # repo for salt


### PR DESCRIPTION
## What does this PR change?

Related to this issue : https://github.com/SUSE/spacewalk/issues/25325

Starting the (venv-)salt-minion service is not supported when selinux is in enforcing mode.
I open a PR to not start the minion service when not needed but this PR is still needed for the case where we want to auto connect centos7 to master.
