### PR TITLE
Set auto_connect_to_master to False for sshminion

### DIFF
--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -15,7 +15,7 @@ variable "product_version" {
 
 variable "auto_connect_to_master" {
   description = "whether this minion should automatically connect to the Salt Master upon deployment"
-  default     = true
+  default     = false
 }
 
 variable "use_os_released_updates" {


### PR DESCRIPTION
## What does this PR change?

In our BV testing, for the sshminion, we don't set `auto_connect_to_master` variable to false so all the sshminion are set to auto connect to master.
**BUT** when we do our test, the sshminion are not visible. Indeed the `server_configuration['hostname']` is not **settable** ( no declare in variables.tf ) for sshminion so the minion run without proper configuration and with that we delete venv-salt-minion before bootstrapping. 

**Because** server_configuration is not an available variable for sshminion, we **can't** configure the auto connect to master.

Set the default variable `auto_connect_to_master` to false for now. We may need to either add `server_configuration` to sshminion or remove `auto_connect_to_master`.