### PR TITLE
Use empty string for "product_version" default value on base

### DIFF
--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -86,5 +86,5 @@ variable "is_server_paygo_instance" {
 variable "product_version" {
   description = "One of: 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
-  default     = null
+  default     = ""
 }


### PR DESCRIPTION
## What does this PR change?

This avoid getting an error when `product_version` is not set:

failed to render : <template_file>:100,9-24: Unknown variable; There is no variable named "product_version".
 on backend_modules/libvirt/host/main.tf line 79, in data "template_file" "combustion":
