### PR TITLE
Always run test_repo_debian_updates_script_copy salt state

### DIFF
--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -53,8 +53,6 @@ test_repo_debian_updates_script:
 test_repo_debian_updates_script_copy:
   cmd.run:
     - name: "mgrctl cp /root/download_ubuntu_repo.sh server:/root/download_ubuntu_repo.sh"
-    - onchanges:
-      - file: test_repo_debian_updates_script
 
 test_repo_debian_updates:
   cmd.run:


### PR DESCRIPTION
## What does this PR change?

Not only run this cp command when the `download_ubuntu_repo.sh` file change, as sometimes we might have a new container image even if that file did not changed, and so, we will not copy the file inside the container and the next salt state will fail.