### PR TITLE
Upgrade libvirt provider to v0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Terraform version**: 1.0.10
 
-**Libvirt provider version**: 0.6.3
+**Libvirt provider version**: 0.8.1
 
 NOTE: to deploy development versions of SUSE Manager you will have to have [SUSE's internal CA certificates](http://ca.suse.de/) installed on your system.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -237,7 +237,7 @@ Initializing provider plugins...
 ╷
 │ Error: Failed to install provider
 │ 
-│ Error while installing dmacvicar/libvirt v0.6.3: the local package for registry.terraform.io/dmacvicar/libvirt 0.6.3 doesn't match any of the checksums previously recorded in the dependency lock file (this might be because the available checksums are for packages
+│ Error while installing dmacvicar/libvirt v0.6.3: the local package for registry.terraform.io/dmacvicar/libvirt 0.8.1 doesn't match any of the checksums previously recorded in the dependency lock file (this might be because the available checksums are for packages
 │ targeting different platforms)
 ```
 

--- a/backend_modules/libvirt/base/versions.tf
+++ b/backend_modules/libvirt/base/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -154,7 +154,7 @@ resource "libvirt_domain" "domain" {
   qemu_agent = true
 
   // copy host CPU model to guest to get the vmx flag if present
-  cpu = {
+  cpu {
     mode = local.provider_settings["cpu_model"]
   }
 

--- a/backend_modules/libvirt/host/versions.tf
+++ b/backend_modules/libvirt/host/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -3,7 +3,7 @@ terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
-     version = "0.6.3"
+     version = "0.8.1"
    }
  }
 }

--- a/main.tf.libvirt-testsuite.example.Manager-43
+++ b/main.tf.libvirt-testsuite.example.Manager-43
@@ -3,7 +3,7 @@ terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
-     version = "0.6.3"
+     version = "0.8.1"
    }
  }
 }

--- a/main.tf.libvirt.example
+++ b/main.tf.libvirt.example
@@ -3,7 +3,7 @@ terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
-     version = "0.6.3"
+     version = "0.8.1"
    }
  }
 }

--- a/main.tf.libvirt.example.Manager-43
+++ b/main.tf.libvirt.example.Manager-43
@@ -3,7 +3,7 @@ terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
-     version = "0.6.3"
+     version = "0.8.1"
    }
  }
 }


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/25018

Update the libvirt provider to v0.8.1 - the last available version at the time of writing.

Unfortunately, the new version changes cpu definition for  **libvirt_domain** resources from an attribute to a block and breaks backward compatibility with our libvirt module.

# Pre-requisites
 
 - [ ] verify we can build the new provider version at https://build.opensuse.org/package/show/systemsmanagement:sumaform/terraform-provider-libvirt
 - [ ] do a testsuite run on one of our hypervisor using the new provider

# When this PR is merged, we need to:
- Send email to the mailing list
- Adapt CI terraform files to cope with the change: 
- Clean CI environment to cope with the changes
- Remove package from all our CI worker machines.
- Update the `terraform-provider-libvirt`/`terraform` together with that in the OBS if necessary/wanted

# How to upgrade
 - Un-install the provider's package `zypper rm terraform-provider-libvirt`
 - In you main.tf, change the provider version to `0.8.1`
 - If you want to keep the same state file, see `keeping state file`. Otherwise just clan the environment and remove the `terraform.tfstate`, `.terraform.lock.hcl` and `.terraform`
 - Run `terraform init`

## Keeping state file
- Open the`terraform.tfstate`
- Search for all `cpu` keys. The value should now be an array of objects. To change it just surround the existing content with square brackets (`[ {....} ]` )
- Run `terraform init -upgrade`
