### PR TITLE
Salt packages should come from shared tools in 5.0 for Ubuntu

### DIFF
--- a/salt/repos/clienttools.sls
+++ b/salt/repos/clienttools.sls
@@ -411,7 +411,8 @@ tools_update_repo:
 {% elif '4.3-released' in grains.get('product_version') | default('', true) %}
 {# TODO: remove extra code when Ubuntu 24.04 tools get released #}
 {% if release == '24.04' %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/4.3:/Ubuntu24.04-SUSE-Manager-Tools/xUbuntu_24.04' %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/5.0:/Ubuntu24.04-SUSE-Manager-Tools/xUbuntu_24.04' %}
+{# 5.0 is intentional here (shared tools) #}
 {% else %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.suse.de/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% endif %}
@@ -455,7 +456,8 @@ tools_update_repo_raised_priority:
             Package: *
 {# TODO: remove extra code when Ubuntu 24.04 tools get released #}
 {% if release == '24.04' %}
-            Pin: release l=Devel:Galaxy:Manager:4.3:Ubuntu24.04-SUSE-Manager-Tools
+            Pin: release l=Devel:Galaxy:Manager:5.0:Ubuntu24.04-SUSE-Manager-Tools
+{# 5.0 is intentional here (shared tools) #}
 {% else %}
             Pin: release l=SUSE:Updates:Ubuntu:{{ release }}-CLIENT-TOOLS:x86_64:update
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

On Salt minions, client tools should come from shared tools in 5.0 for Ubuntu in 4.3 branch.

This PR solves only our immediate problem, but does not address 20.04 nor 22.04, nor Debian, nor recent RH and clones, etc - for those ones i have created an issue SUSE/spacewalk#25428 .