### PR TITLE
Fix liberty linux9

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -749,6 +749,11 @@ yum_repos:
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
+  ssl_as_updates:
+    baseurl: http://${mirror}/SUSE/Updates/SLL-AS/9/x86_64/update/
+    enabled: true
+    gpgcheck: false
+    name: ssl_as_updates
   # repo for nss-mdns
   epel:
     baseurl: http://download.fedoraproject.org/pub/epel/9/Everything/$basearch

--- a/salt/default/ids.sls
+++ b/salt/default/ids.sls
@@ -1,8 +1,16 @@
+{% if grains['os_family'] == 'RedHat' and grains['osfinger'] == 'Red Hat Enterprise Linux-9' %}
+systemd_machine_id:
+  cmd.run:
+    - name: rm -f /etc/machine-id && rm -f /var/lib/dbus/machine-id && mkdir -p /var/lib/dbus && uuidgen | sudo tee /etc/machine-id && touch /etc/machine-id-already-setup
+    - creates: /etc/machine-id-already-setup
+    - onlyif: test -f /usr/bin/systemd-machine-id-setup -o -f /bin/systemd-machine-id-setup
+{% else %}
 systemd_machine_id:
   cmd.run:
     - name: rm -f /etc/machine-id && rm -f /var/lib/dbus/machine-id && mkdir -p /var/lib/dbus && dbus-uuidgen --ensure && systemd-machine-id-setup && touch /etc/machine-id-already-setup
     - creates: /etc/machine-id-already-setup
     - onlyif: test -f /usr/bin/systemd-machine-id-setup -o -f /bin/systemd-machine-id-setup
+{% endif %}
 
 dbus_machine_id:
   cmd.run:


### PR DESCRIPTION
## What does this PR change?

Fix liberty linux 9 deployment issues.
Add new repository to solve perl and wget package resolution.
Use uuidgen to generate the machine ID ( dbus-uuidgen not installed on Liberty Linux 9 ) 
