### PR TITLE
Make server configuration variable optional for minion.

### DIFF
--- a/modules/minion/main.tf
+++ b/modules/minion/main.tf
@@ -20,7 +20,7 @@ module "minion" {
   product_version               = var.product_version
   grains = merge({
     mirror                 = var.base_configuration["mirror"]
-    server                 = var.server_configuration["hostname"]
+    server                 = var.auto_connect_to_master ? var.server_configuration["hostname"] : null
     auto_connect_to_master = var.auto_connect_to_master
     avahi_reflector        = var.avahi_reflector
     susemanager = {

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -20,11 +20,7 @@ variable "product_version" {
 
 variable "server_configuration" {
   description = "use module.<SERVER_NAME>.configuration, see the main.tf example file"
-}
-
-variable "activation_key" {
-  description = "an Activation Key to be used when onboarding this minion"
-  default     = null
+  default     = {}
 }
 
 variable "auto_connect_to_master" {

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -23,6 +23,11 @@ variable "server_configuration" {
   default     = {}
 }
 
+variable "activation_key" {
+  description = "an Activation Key to be used when onboarding this minion"
+  default     = null
+}
+
 variable "auto_connect_to_master" {
   description = "whether this minion should automatically connect to the Salt Master upon deployment"
   default     = true


### PR DESCRIPTION
## What does this PR change?

Make the `server_configuration` variable optional for minions, as it is only required when `auto_connect_to_master` is set to `true`. Removing this mandatory variable will eliminate hundreds of unnecessary lines in BV and CI pipelines, making the configuration cleaner and more efficient. Additionally, it will clarify that this value is not used when auto-connect is disabled.
