### PR TITLE
Missing images/ target is being added by Marina

### DIFF
--- a/salt/repos/client_tools.sls
+++ b/salt/repos/client_tools.sls
@@ -98,7 +98,7 @@ tools_additional_repo:
 
 tools_additional_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/5.0:/SLE12-SUSE-Manager-Tools/SLE_12/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/5.0:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1/
     - refresh: True
     - priority: 98
 


### PR DESCRIPTION
## What does this PR change?

Missing images/ target for SLE 12 devel client tools is being added by Marina, removing the workaround.