### PR TITLE
Only Debian-like minions/clients require wget in our testsuite

### DIFF
--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -10,7 +10,10 @@ client_cucumber_requisites:
       - spacewalk-client-setup
       - spacewalk-check
       - mgr-cfg-actions
+# Debian based systems don't come with curl installed, the test suite handles it with wget instead
+{% if grains['os_family'] == 'Debian' %}
       - wget
+{% endif %}
     - require:
       - sls: default
 

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -11,7 +11,10 @@ minion_cucumber_requisites:
 {% else %}
       - salt-minion
 {% endif %}
+# Debian based systems don't come with curl installed, the test suite handles it with wget instead
+{% if grains['os_family'] == 'Debian' %}
       - wget
+{% endif %}
     - require:
       - sls: default
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

We had issues on Liberty 9, as we couldn't find `wget` installed or available in the pristine image.
In fact, we don't need it, we only need that package in Debian-like systems for our testsuite minions/clients.

See also that:
https://github.com/uyuni-project/uyuni/blob/master/testsuite/features/step_definitions/navigation_steps.rb#L1107-L1112
```
  # debian based systems don't come with curl installed
  if (os_family.include? 'debian') || (os_family.include? 'ubuntu')
    node.run_until_ok("wget --no-check-certificate -qO- #{protocol}://#{system_name}:#{port}#{path} | grep -i '#{text}'")
  else
    node.run_until_ok("curl -s -k #{protocol}://#{system_name}:#{port}#{path} | grep -i '#{text}'")
  end
```