### PR TITLE
Remove chromedriver and chromium force version

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -119,14 +119,10 @@ ruby_set_ri_version:
 install_chromium:
   pkg.installed:
   - name: chromium
-  # workaround for https://github.com/SUSE/spacewalk/issues/24883, as soon as we find a version newer than 126 fixing the issue, we should remove this line
-  - version: 125.0.6422.141-bp155.2.91.1
 
 install_chromedriver:
   pkg.installed:
   - name: chromedriver
-  # workaround for https://github.com/SUSE/spacewalk/issues/24883, as soon as we find a version newer than 126 fixing the issue, we should remove this line
-  - version: 125.0.6422.141-bp155.2.91.1
 
 create_syslink_for_chromedriver:
   file.symlink:


### PR DESCRIPTION
## What does this PR change?

New chrome driver and chromium version are available.
I don't reproduce the late issue.
This PR remove the force versions for those two packages.
