### PR TITLE
Fix problem propagating the "product_version" attribute

### DIFF
--- a/modules/build_host/main.tf
+++ b/modules/build_host/main.tf
@@ -17,6 +17,7 @@ module "build_host" {
   connect_to_additional_network = true
   roles                         = ["build_host"]
   disable_firewall              = var.disable_firewall
+  product_version               = var.product_version
   grains = {
     mirror                 = var.base_configuration["mirror"]
     server                 = var.server_configuration["hostname"]

--- a/modules/host/main.tf
+++ b/modules/host/main.tf
@@ -25,6 +25,7 @@ module "host" {
   additional_disk_size          = var.additional_disk_size
   second_additional_disk_size   = var.second_additional_disk_size
   volume_provider_settings      = var.volume_provider_settings
+  product_version               = var.product_version
 
   grains = merge({ disable_firewall = var.disable_firewall },
   var.grains)

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -45,6 +45,7 @@ module "server" {
   additional_disk_size          = var.repository_disk_size
   second_additional_disk_size   = var.database_disk_size
   volume_provider_settings      = var.volume_provider_settings
+  product_version               = var.product_version
 
   grains = {
     cc_username            = var.base_configuration["cc_username"]

--- a/modules/sshminion/main.tf
+++ b/modules/sshminion/main.tf
@@ -17,6 +17,7 @@ module "sshminion" {
   connect_to_additional_network = false
   roles                         = ["sshminion"]
   disable_firewall              = var.disable_firewall
+  product_version               = var.product_version
   grains = {
     mirror                 = var.base_configuration["mirror"]
     auto_connect_to_master = var.auto_connect_to_master


### PR DESCRIPTION
## What does this PR change?

I've noticed there was a problem where the `product_version` was not set properly on the deployed nodes when not having a `product_version` definition in the "base" module but instead inside each different nodes.

Like in this example:

```
module "base" {
[... no product_version defined here ...]
}

module "suma-43-srv" {
  source = "./modules/server"
  base_configuration = module.base.configuration

  name = "suma-43-srv"
  product_version = "4.3-nightly"
}

module "suma-43-min-build" {
  source = "./modules/build_host"
  base_configuration = module.base.configuration

  name = "suma-43-min-build"
  product_version = "4.3-released"
  server_configuration = module.suma-43-srv.configuration
  image = "sles15sp4o"
}

module "suma-43-min-host" {
  source = "./modules/host"
  base_configuration = module.base.configuration

  name = "suma-43-min-host"
  image = "sles15sp4o"
}
```

Before this PR, i.a. the `suma-43-srv` node was not deploying correctly, as it got `product_version = ""` and therefore not installing the SERVER stack.

This PR should fix this problem and use the `product_version` from the node if defined, if note take the one from "base" module.