### PR TITLE
Remove ssl libertylinux 9 workaround.

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -749,11 +749,6 @@ yum_repos:
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
-  ssl_as_updates:
-    baseurl: http://${mirror}/SUSE/Updates/SLL-AS/9/x86_64/update/
-    enabled: true
-    gpgcheck: false
-    name: ssl_as_updates
   # repo for nss-mdns
   epel:
     baseurl: http://download.fedoraproject.org/pub/epel/9/Everything/$basearch


### PR DESCRIPTION
## What does this PR change?

Remove ssl libertylinux 9 workaround.
