### PR TITLE
Don't trigger repos salt states for a server on a transactional system

### DIFF
--- a/salt/repos/init.sls
+++ b/salt/repos/init.sls
@@ -21,14 +21,10 @@ include:
   {% endif %}
   - repos.additional
 
-{% if grains['os'] == 'SUSE' %}
+{% if grains['os'] == 'SUSE' and grains['osfullname'] not in ['SLE Micro', 'SL-Micro'] %}
 refresh_repos:
   cmd.run:
-{% if grains['osfullname'] in ['SLE Micro', 'SL-Micro'] %}
-    - name: transactional-update -c run zypper --non-interactive --gpg-auto-import-keys refresh --force
-{% else %}
     - name: zypper --non-interactive --gpg-auto-import-keys refresh --force; exit 0
-{% endif %}
 {% endif %}
 
 # WORKAROUND: see github:saltstack/salt#10852

--- a/salt/server/init.sls
+++ b/salt/server/init.sls
@@ -1,6 +1,6 @@
 include:
   - scc.server
-  {% if 'build_image' not in grains.get('product_version', '') and 'paygo' not in grains.get('product_version', '') %}
+  {% if 'build_image' not in grains.get('product_version', '') and 'paygo' not in grains.get('product_version', '') and grains['osfullname'] not in ['SLE Micro', 'SL-Micro'] %}
   - repos
   {% endif %}
   - server.additional_disk
@@ -19,7 +19,6 @@ include:
   - server.large_deployment
   - server.salt_master
   - server.tcpdump
-
 
 {% if 'paygo' not in grains.get('product_version') | default('', true) %}
 {% if 'uyuni' not in grains.get('product_version') %}


### PR DESCRIPTION
## What does this PR change?

This is just an attempt to fix the issue explained here:

https://github.com/SUSE/spacewalk/issues/25575#issuecomment-2426285245

---

```
suma-bv-50-server:~ # snapper list
 # | Type   | Pre # | Date                             | User | Used Space | Cleanup | Description           | Userdata
---+--------+-------+----------------------------------+------+------------+---------+-----------------------+--------------
0  | single |       |                                  | root |            |         | current               |
1  | single |       | Sat 28 Sep 2024 05:41:43 AM CEST | root | 768.00 KiB | number  | first root filesystem | important=yes
2  | single |       | Wed 16 Oct 2024 03:29:26 AM CEST | root | 496.00 KiB | number  | Snapshot Update of #1 |
3  | single |       | Wed 16 Oct 2024 03:29:31 AM CEST | root | 436.00 KiB | number  | Snapshot Update of #2 |
4  | single |       | Wed 16 Oct 2024 03:29:42 AM CEST | root | 600.00 KiB | number  | Snapshot Update of #3 |
5- | single |       | Wed 16 Oct 2024 03:29:51 AM CEST | root | 208.00 KiB |         | Snapshot Update of #4 |
6  | single |       | Wed 16 Oct 2024 03:31:57 AM CEST | root | 144.00 KiB | number  | Snapshot Update of #5 |
7+ | single |       | Wed 16 Oct 2024 03:32:13 AM CEST | root | 176.00 KiB |         | Snapshot Update of #6 |
```

`-` at snapshot 5 means currently running snapshot. `+` at snapshot 7 means what will be active on new boot.

---

I would like the help of Ion Squad to fix it properly.
Handling a reboot on salt states can be quite delicate, and from what I could see, we don't really need the salt states generating snapshots 6 and 7