### PR TITLE
Ignore return code when checking if eth1 exists

### DIFF
--- a/salt/default/network.sls
+++ b/salt/default/network.sls
@@ -74,7 +74,7 @@ ipv6_disable_all:
 {% endif %}
 
 {% if grains['osfullname'] in ['SLE Micro', 'openSUSE Leap Micro'] and (grains['osrelease'] != '5.1' and grains['osrelease'] != '5.2') %}
-{% set conname2 = salt.cmd.run_stdout('nmcli -g GENERAL.CONNECTION device show eth1') %}
+{% set conname2 = salt.cmd.run_stdout('nmcli -g GENERAL.CONNECTION device show eth1', ignore_retcode=true) %}
 {% if conname2 != '' %}
 enable_dhcp_on_eth1:
   cmd.run:


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with the check of `eth1` . Currently the code uses a `cmd.run_stdout` call which fails if the command returns an error code which translates in a failure of the salt script.  This PR ignores the error code and allows to apply the state correctly when the interface is not present.