### PR TITLE
Exclude openSUSE Leap Micro from avahi_pkg

### DIFF
--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -29,7 +29,7 @@ dbus_enable_service:
 {% endif %}
 
 # TODO: replace 'pkg.latest' with 'pkg.installed' when fix to bsc#1163683 is applied to all the SLES versions we use
-{% if not (grains['os_family'] == 'Suse' and grains['osfullname'] in ['SLE Micro', 'SL-Micro']) %}
+{% if not (grains['os_family'] == 'Suse' and grains['osfullname'] in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro']) %}
 avahi_pkg:
   pkg.latest:
     - pkgs:


### PR DESCRIPTION
## What does this PR change?

This PR avoid applying the `avahi_pkg` state on openSUSE Leap Micro.
