### PR TITLE
Leap: add dependency for mgr-push

### DIFF
--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -61,6 +61,7 @@ suse_minion_mgr_push_requisites:
     - pkgs:
       - hwdata
       - libgudev-1_0-0
+      - python3-dbus-python
       - python3-dmidecode
       - python3-extras
       - python3-hwdata


### PR DESCRIPTION
## What does this PR change?

Due to killing the Leap 15.5 reposync in the CI, we need those
dependencies already fulfilled.

See SUSE/spacewalk#24979
