### PR TITLE
Explicitly configure salt-test for Salt Shaker

### DIFF
--- a/salt/salt_testenv/postinstallation.sls
+++ b/salt/salt_testenv/postinstallation.sls
@@ -1,3 +1,13 @@
+{% if "-bundle" in grains['fqdn'] %}
+set_bundle_salt_test:
+  cmd.run:
+    - name: alternatives --set salt-test /usr/lib/venv-salt-minion/bin/salt-test
+{% else %}
+set_non_bundle_salt_test:
+  cmd.run:
+    - name: alternatives --set salt-test /usr/bin/salt-test-3.{{ grains["pythonversion"][1] }}
+{% endif %}
+
 {% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
 copy_salt_classic_testsuite:
   cmd.run:


### PR DESCRIPTION
## What does this PR change?

On Salt Shaker, we install both non-bundled and bundled Salt test. The bundled salt-test binary has higher priority in `alternatives`. Consequently, non-bundled Salt Shaker pipelines use bundled salt-test, and experience various test fails.

In this PR, we don't rely on the `alternatives` priority, but configure the `salt-test` binary location explicitly.    
