### PR TITLE
Adjust the server_containerized module to kubernetes refactoring

### DIFF
--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -97,9 +97,6 @@ module "cucumber_testsuite" {
 
       # Override where to get the containers from
       # container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
-
-      # Override where to get the helm chart from
-      # helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/charts/uyuni/server-helm"
     }
     proxy = {
       name = "proxy"

--- a/main.tf.libvirt.example
+++ b/main.tf.libvirt.example
@@ -54,9 +54,6 @@ module "server" {
 
   // To define a specific container image tag to install
   // container_tag = 
-
-  // To override the URL to the helm chart to install
-  // helm_chart_url = "oci://registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/charts/uyuni/server"
 }
 
 module "minion" {

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -136,7 +136,6 @@ module "server_containerized" {
   runtime                        = lookup(local.runtimes, "server_containerized", "podman")
   container_repository           = lookup(local.container_repositories, "server_containerized", "")
   container_tag                  = lookup(local.container_tags, "server_containerized", "")
-  helm_chart_url                 = lookup(local.helm_chart_urls, "server_containerized", "")
   auto_accept                    = false
   download_private_ssl_key       = false
   disable_firewall               = false

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -46,7 +46,6 @@ module "server_containerized" {
     container_runtime              = var.runtime
     container_repository           = var.container_repository
     container_tag                  = var.container_tag
-    helm_chart_url                 = var.helm_chart_url
     cc_username                    = var.base_configuration["cc_username"]
     cc_password                    = var.base_configuration["cc_password"]
     mirror                         = var.base_configuration["mirror"]

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -27,11 +27,6 @@ variable "container_tag" {
   default = ""
 }
 
-variable "helm_chart_url" {
-  description = "Where to get the helm chart from. Uses the released one by default."
-  default = ""
-}
-
 variable "product_version" {
   description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string

--- a/salt/server_containerized/chart-values.yaml
+++ b/salt/server_containerized/chart-values.yaml
@@ -1,1 +1,0 @@
-exposeJavaDebug: {{ grains.get("java_debugging") }}

--- a/salt/server_containerized/install_k3s.sls
+++ b/salt/server_containerized/install_k3s.sls
@@ -23,9 +23,3 @@ helm_install:
     - refresh: True
     - name: helm
 {% endif %}
-
-chart_values_file:
-  file.managed:
-    - name: /root/chart-values.yaml
-    - source: salt://server_containerized/chart-values.yaml
-    - template: jinja

--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -20,12 +20,10 @@ tag: {{ grains.get('container_tag') }}
 {%- set mirror_hostname = grains.get('server_mounted_mirror') if grains.get('server_mounted_mirror') else grains.get('mirror') %}
 {%- if mirror_hostname %}
 mirror: /srv/mirror
-{% endif -%}
-{% set helm_chart_default = 'oci://registry.opensuse.org/uyuni/server-helm' %}
-helm:
+{% endif %}
+kubernetes:
   uyuni:
-    chart: {{ grains.get("helm_chart_url") | default(helm_chart_default, true) }}
-    values: /root/chart-values.yaml
+    namespace: uyuni
 {%- if grains.get("java_debugging") %}
 debug:
   java: true


### PR DESCRIPTION
## What does this PR change?

[Kubernetes refactoring](https://github.com/uyuni-project/uyuni-tools/pull/450) drops the use of the server helm chart and renames the --helm-* parameters to --kubernetes-*.