### PR TITLE
Extend an existing workaround to SLE 15 SP6

### DIFF
--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -4,7 +4,7 @@ include:
 {% if grains['use_avahi'] and grains.get('osmajorrelease', None) != None %}
 
 # TODO: remove the following state when fix to bsc#1163683 is applied to all the SLES <= SLES15SP4
-{% if grains['osfullname'] == 'SLES' and grains['osrelease'] != '15.5' and grains['osrelease'] != '15.4' %}
+{% if grains['osfullname'] == 'SLES' and grains['osrelease'] != '15.6' and grains['osrelease'] != '15.5' and grains['osrelease'] != '15.4' %}
 custom_avahi_repo:
   pkgrepo.managed:
     - humanname: custom_avahi_repo


### PR DESCRIPTION
## What does this PR change?

This patch is extending an existing workaround (for bsc#1163683) to SLE 15 SP6. Found this as I was running into issues creating SP6 clients while using avahi.