### PR TITLE
use gp3 as default type for root block device

### DIFF
--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -86,6 +86,7 @@ resource "aws_instance" "instance" {
 
   root_block_device {
     volume_size = local.provider_settings["volume_size"]
+    volume_type = "gp3"
   }
 
   user_data = data.template_file.user_data[count.index].rendered


### PR DESCRIPTION
## What does this PR change?

use gp3 as default type for root block device.
gp3 may also be cheaper in some conditions
