### PR TITLE
Add Berlin timezone for container deployment.

### DIFF
--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -38,3 +38,5 @@ admin:
   firstName: Admin
   lastName: Admin
   email: galaxy-noise@suse.de
+tz:
+  Europe/Berlin


### PR DESCRIPTION
## What does this PR change?

Currently, the container have a different timezone than server host or controller.
This differences are created some issues (getting the last log not working with the testsuite, using spacewalk is scheduling the event one hour later, etc)
Force the timezone to Berlin timezone.

Related to: https://github.com/SUSE/spacewalk/issues/25607