### PR TITLE
Adjust mirror handling for k3s

### DIFF
--- a/salt/server_containerized/install_k3s.sls
+++ b/salt/server_containerized/install_k3s.sls
@@ -23,3 +23,19 @@ helm_install:
     - refresh: True
     - name: helm
 {% endif %}
+
+{%- set mirror_hostname = grains.get('server_mounted_mirror', grains.get('mirror')) %}
+{% if mirror_hostname %}
+mirror_pv_file:
+  file.managed:
+    - name: /root/mirror-pv.yaml
+    - source: salt://server_containerized/mirror-pv.yaml
+    - template: jinja
+
+mirror_pv_deploy:
+  cmd.run:
+    - name: kubectl apply -f /root/mirror-pv.yaml
+    - unless: kubectl get pv mirror
+    - require:
+      - file: mirror_pv_file
+{% endif %}

--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -1,3 +1,4 @@
+{% set runtime = grains.get('container_runtime') | default('podman', true) %}
 db:
   password: spacewalk
 reportdb:
@@ -18,12 +19,19 @@ registry: {{ grains.get('container_repository') }}
 tag: {{ grains.get('container_tag') }}
 {% endif %}
 {%- set mirror_hostname = grains.get('server_mounted_mirror') if grains.get('server_mounted_mirror') else grains.get('mirror') %}
+{%- if runtime == 'podman' %}
 {%- if mirror_hostname %}
 mirror: /srv/mirror
-{% endif %}
+{%- endif %}
+{%- else %}
+{%- if mirror_hostname %}
+volumes:
+  mirror: mirror
+{%- endif %}
 kubernetes:
   uyuni:
     namespace: uyuni
+{%- endif %}
 {%- if grains.get("java_debugging") %}
 debug:
   java: true

--- a/salt/server_containerized/mirror-pv.yaml
+++ b/salt/server_containerized/mirror-pv.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mirror
+spec:
+  capacity:
+    storage: 100Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: local-storage
+  local:
+    path: /srv/mirror
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - {{ grains['hostname'] }}
+  claimRef:
+    namespace: uyuni 
+    name: mirror


### PR DESCRIPTION
## What does this PR change?

In kubernetes installations we now require the mirror PV to be created before running mgradm and pass the pv name to --volumes-mirror