### PR TITLE
Fix mirror grain extraction in k3s setup

### DIFF
--- a/salt/server_containerized/install_k3s.sls
+++ b/salt/server_containerized/install_k3s.sls
@@ -24,7 +24,7 @@ helm_install:
     - name: helm
 {% endif %}
 
-{%- set mirror_hostname = grains.get('server_mounted_mirror', grains.get('mirror')) %}
+{%- set mirror_hostname = grains.get('server_mounted_mirror') if grains.get('server_mounted_mirror') else grains.get('mirror') %}
 {% if mirror_hostname %}
 mirror_pv_file:
   file.managed:


### PR DESCRIPTION
## What does this PR change?

The simplified mirror_hostname value doesn't work because the `server_mounted_mirror` is `{}`.