### PR TITLE
Only call podman login on podman hosts

### DIFF
--- a/salt/server_containerized/install_mgradm.sls
+++ b/salt/server_containerized/install_mgradm.sls
@@ -10,10 +10,6 @@ mgradm_config:
 {% set runtime = grains.get('container_runtime') | default('podman', true) %}
 {% set install_cmd = 'kubernetes' if runtime == 'k3s' else 'podman' %}
 
-podman_login:
-  cmd.run:
-    - name: podman login -u {{ grains.get('cc_username') }} -p {{ grains.get('cc_password') }} {{ grains.get("container_repository") }}
-
 mgradm_install:
   cmd.run:
     - name: mgradm install {{ install_cmd }} --logLevel=debug --config /root/mgradm.yaml {{ grains.get("fqdn") }}

--- a/salt/server_containerized/install_podman.sls
+++ b/salt/server_containerized/install_podman.sls
@@ -14,6 +14,10 @@ podman_packages:
       {% endif %}
 {% endif %}
 
+podman_login:
+  cmd.run:
+    - name: podman login -u {{ grains.get('cc_username') }} -p {{ grains.get('cc_password') }} {{ grains.get("container_repository") }}
+
 # WORKAROUND: see github:saltstack/salt#10852
 {{ sls }}_nop:
   test.nop: []


### PR DESCRIPTION
## What does this PR change?

K3S hosts don't have podman so `podman login` will fail there.