### PR TITLE
Salt Shaker: Upgrade python3-pyzmq to latest version on SLE15SP3 LTSS

### DIFF
--- a/salt/salt_testenv/salt_classic_package.sls
+++ b/salt/salt_testenv/salt_classic_package.sls
@@ -137,3 +137,9 @@ start_docker_service:
 
 {% endif %}
 
+
+{% if grains['osfullname'] == 'SLES' and '15.3' == grains['osrelease'] %}
+update_buggy_pyzmq_version:
+  pkg.latest:
+    - name: python3-pyzmq
+{% endif %}


### PR DESCRIPTION
## What does this PR change?

The JeOS image we use in sumaform for deploying `SLE-15-SP3` instances contains a very old version of `python3-pyzmq`.  

This version is making the Salt Shaker integration tests for classic Salt package to hang when running on SLE15SP3 instances (see https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-products-testing-sles15sp3/214/).

There are newer versions of `python3-pyzmq` in the Update and LTSS channels for SLE15SP3 that fixes this issue, so this PR just adds a workaround on Salt Shaker deployments for SLE15SP3 to force the upgrade of `python3-pyzmq` and allow the integration tests to run.

