### PR TITLE
Attach IAM instance profile to containerized server EC2

### DIFF
--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -98,7 +98,7 @@ resource "aws_instance" "instance" {
   subnet_id              = var.connect_to_base_network ? (local.provider_settings["public_instance"] ? local.public_subnet_id : local.private_subnet_id) : var.connect_to_additional_network ? local.private_additional_subnet_id : local.private_subnet_id
   vpc_security_group_ids = [var.connect_to_base_network ? (local.provider_settings["public_instance"] ? local.public_security_group_id : local.private_security_group_id) : var.connect_to_additional_network ? local.private_additional_security_group_id : local.private_security_group_id]
   private_ip             = local.private_ip
-  iam_instance_profile   = contains(var.roles, "server") ? var.base_configuration["iam_instance_profile"] : null
+  iam_instance_profile   = contains(var.roles, "server") || contains(var.roles, "server_containerized") ? var.base_configuration["iam_instance_profile"] : null
 
   root_block_device {
     volume_size = local.provider_settings["volume_size"]


### PR DESCRIPTION
## What does this PR change?

We probably skipped this check during the last refactors and changes.
Not having an instance profile attached to the EC2 instance does not make the deployment fail or the server unable to start, but results in not being able to send metering data to the AWS markeplace.
This ultimately leads to the instance being identified as not PAYG compliant and all functionalities being blocked.