### PR TITLE
Use mgr-storage-server on PAYG containerized server

### DIFF
--- a/salt/server_containerized/init.sls
+++ b/salt/server_containerized/init.sls
@@ -2,7 +2,11 @@ include:
   {% if 'build_image' not in grains.get('product_version') | default('', true) %}
   - repos
   {% endif %}
+  {% if 'paygo' in grains.get('product_version', '') %}
+  - server_containerized.payg_additional_disks
+  {% else %}
   - server_containerized.additional_disks
+  {% endif %}
   - server_containerized.install_mgradm
   - server_containerized.initial_content
   - server_containerized.testsuite

--- a/salt/server_containerized/payg_additional_disks.sls
+++ b/salt/server_containerized/payg_additional_disks.sls
@@ -1,0 +1,12 @@
+include:
+  - default
+
+{% set repository_disk_size = grains.get('repository_disk_size') | int %}
+{% set database_disk_size = grains.get('database_disk_size') | int %}
+
+{% set repository_device_name = '/dev/' + grains.get('data_disk_device', '') if repository_disk_size > 0 else '' %}
+{% set db_device_name = '/dev/' + grains.get('second_data_disk_device', '') if database_disk_size > 0 else '' %}
+
+mgr_storage_:
+  cmd.run: 
+    - name: mgr-storage-server {{repository_device_name}} {{db_device_name}}


### PR DESCRIPTION
## What does this PR change?

When deploying PAYG images for SMLM 5.X, a CLI tool is available to take care of formatting devices and setting up the container's volumes.

We may want to use it instead of parted in our setup Salt states as, besides simplifying them quite a lot, it allows us to use what the final customer will use and verify it works.
