### PR TITLE
Changing ruby_devel_extensions to 15.6 repo

### DIFF
--- a/salt/repos/ruby.sls
+++ b/salt/repos/ruby.sls
@@ -10,7 +10,7 @@ ruby_add_devel_repository:
 ruby_gems_add_devel_repository:
     pkgrepo.managed:
       - name: ruby_devel_extensions
-      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/15.5/
+      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/15.6/
       - refresh: True
       - gpgautoimport: True
 


### PR DESCRIPTION
## What does this PR change?

```
Error building the cache:
11:47:40  module.controller.module.controller.module.host.null_resource.provisioning[0] (remote-exec): [ruby_devel_extensions|http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/15.5/] Valid metadata not found at specified URL
[ruby_devel_extensions|http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/15.5/] Repository type can't be determined.
```

15.5 repository is not available anymore, changing to: https://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/15.6/

## Links

- 5.0.3 BV: https://github.com/SUSE/spacewalk/issues/24901