### PR TITLE
Adjust sshd configuration for slmicro 6.1

### DIFF
--- a/salt/default/sshd.sls
+++ b/salt/default/sshd.sls
@@ -1,6 +1,6 @@
 {% if 'client' in grains.get('roles') or 'minion' in grains.get('roles') or 'sshminion' in grains.get('roles') %}
 # WORKAROUND: Leap 15.6 and SL-Micro 6.0 are using a different sshd_config. To be reviewed.
-{% if not ( grains['osfullname'] in ['Leap', 'SL-Micro'] and grains['osrelease'] in ['15.6', '6.0'] ) %}
+{% if not ( grains['osfullname'] in ['Leap', 'SL-Micro'] and grains['osrelease'] in ['15.6', '6.0', '6.1'] ) %}
 sshd_change_challengeresponseauthentication:
   file.replace:
     - name: /etc/ssh/sshd_config


### PR DESCRIPTION
## What does this PR change?

Solves the SSHD configuration file special case for SL Micro 6.1 BV

```
[INFO    ] Running state [/etc/ssh/sshd_config] at time 13:42:02.564366
[INFO    ] Executing state file.replace for [/etc/ssh/sshd_config]
[ERROR   ] /etc/ssh/sshd_config: file not found
```

## Links

- 5.0.3 BV: https://github.com/SUSE/spacewalk/issues/24901