### PR TITLE
Libvirt provider v0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Terraform version**: 1.0.10
 
-**Libvirt provider version**: 0.6.3
+**Libvirt provider version**: 0.8.1
 
 NOTE: to deploy development versions of SUSE Manager you will have to have [SUSE's internal CA certificates](http://ca.suse.de/) installed on your system.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -232,12 +232,12 @@ Initializing provider plugins...
 - Reusing previous version of hashicorp/null from the dependency lock file
 - Reusing previous version of hashicorp/template from the dependency lock file
 - Using previously-installed hashicorp/template v2.2.0
-- Installing dmacvicar/libvirt v0.6.3...
+- Installing dmacvicar/libvirt v0.8.1...
 - Using previously-installed hashicorp/null v3.1.0
 ╷
 │ Error: Failed to install provider
 │ 
-│ Error while installing dmacvicar/libvirt v0.6.3: the local package for registry.terraform.io/dmacvicar/libvirt 0.6.3 doesn't match any of the checksums previously recorded in the dependency lock file (this might be because the available checksums are for packages
+│ Error while installing dmacvicar/libvirt v0.8.1: the local package for registry.terraform.io/dmacvicar/libvirt 0.8.1 doesn't match any of the checksums previously recorded in the dependency lock file (this might be because the available checksums are for packages
 │ targeting different platforms)
 ```
 

--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -61,6 +61,9 @@ resource "libvirt_network" "additional_network" {
   name      = "${var.name_prefix}private"
   mode      = "none"
   addresses = [local.additional_network]
+  dns {
+    enabled = "false"
+  }
   dhcp {
     enabled = "false"
   }

--- a/backend_modules/libvirt/base/versions.tf
+++ b/backend_modules/libvirt/base/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -154,7 +154,7 @@ resource "libvirt_domain" "domain" {
   qemu_agent = true
 
   // copy host CPU model to guest to get the vmx flag if present
-  cpu = {
+  cpu {
     mode = local.provider_settings["cpu_model"]
   }
 

--- a/backend_modules/libvirt/host/versions.tf
+++ b/backend_modules/libvirt/host/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.3"
+      version = "0.8.1"
     }
   }
 }

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -3,7 +3,7 @@ terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
-     version = "0.6.3"
+     version = "0.8.1"
    }
  }
 }

--- a/main.tf.libvirt-testsuite.example.Manager-43
+++ b/main.tf.libvirt-testsuite.example.Manager-43
@@ -3,7 +3,7 @@ terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
-     version = "0.6.3"
+     version = "0.8.1"
    }
  }
 }

--- a/main.tf.libvirt.example
+++ b/main.tf.libvirt.example
@@ -3,7 +3,7 @@ terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
-     version = "0.6.3"
+     version = "0.8.1"
    }
  }
 }

--- a/main.tf.libvirt.example.Manager-43
+++ b/main.tf.libvirt.example.Manager-43
@@ -3,7 +3,7 @@ terraform {
  required_providers {
    libvirt = {
      source = "dmacvicar/libvirt"
-     version = "0.6.3"
+     version = "0.8.1"
    }
  }
 }

--- a/modules/dhcp_dns/README.md
+++ b/modules/dhcp_dns/README.md
@@ -8,7 +8,3 @@ to repositories, nor the Internet in general. This is why it is prepared
 directly from the hypervisor. As a consequence, the jenkins workers must
 drop the public SSH key of their  "jenkins" user into the authorized hosts
 file of the hypervisor. Or, if you are testing yourself, drop your own key.
-
-If the hypervisor runs SLES 15 SP6 at least, you may also need to
-hack sshd for it to accept RSA keys, since old versions of the
-terraform libvirt provider (like 0.6.3) only work with RSA keys.


### PR DESCRIPTION
## What does this PR change?

Update the terraform-provider-libvirt to the latest available version: 0.8.1
