### PR TITLE
Update images list in example main.tf for libvirt

### DIFF
--- a/main.tf.libvirt.example
+++ b/main.tf.libvirt.example
@@ -33,7 +33,7 @@ module "base" {
   //   pool = "default"
   // }
 
-  images = ["opensuse155o"]
+  images = ["opensuse155o", "leapmicro55o"]
 }
 
 module "server" {


### PR DESCRIPTION
## What does this PR change?

Updates the base example using a libvirt backend.
When using Uyuni, the default OS for a containerized server is Leap micro 5.5 and that should be available as VM image.
