### PR TITLE
Add SLES 15 SP6 as base OS for SUSE Manager 5.0

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -293,12 +293,74 @@ zypper:
       enabled: true
       gpgcheck: false
       name: tools_pool_repo
+%{ if container_server || container_proxy }
+    - id: ca_suse
+      name: ca_suse
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP6/
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: false
+    - id: containers_pool_repo
+      name: containers_pool_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/SUSE/Products/SLE-Module-Containers/15-SP6/x86_64/product/
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: false
+    - id: containers_updates_repo
+      name: containers_updates_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/SUSE/Updates/SLE-Module-Containers/15-SP6/x86_64/update/
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: false
+%{ endif }
+%{ if container_server }
+%{ if product_version == "5.0-nightly" }
+    - id: container_tools_repo
+      name: container_tools_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: false
+%{ endif }
+%{ if product_version == "5.0-released" }
+    - id: container_tools_repo
+      name: container_tools_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: false
+%{ endif }
+%{ endif }
+%{ if container_proxy }
+%{ if product_version == "5.0-nightly" }
+    - id: container_tools_repo
+      name: container_tools_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: false
+%{ endif }
+%{ if product_version == "5.0-released" }
+    - id: container_tools_repo
+      name: container_tools_repo
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1
+      enabled: 1
+      autorefresh: 1
+      gpgcheck: false
+%{ endif }
+%{ endif }
 
 runcmd:
 %{ if install_salt_bundle }
   - "zypper -n in venv-salt-minion avahi nss-mdns qemu-guest-agent"
 %{ else }
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
+%{ endif }
+%{ if container_server }
+  - "zypper -n in mgrctl mgradm podman ca-certificates-suse"
+%{ endif }
+%{ if container_proxy }
+  - "zypper -n in mgrpxy podman ca-certificates-suse"
 %{ endif }
 %{ endif }
 


### PR DESCRIPTION
## What does this PR change?

Add SLES 15 SP6 as base OS for SUSE Manager 5.0


## Links

See https://github.com/SUSE/spacewalk/pull/26622