### PR TITLE
fix Multi-Linux-Manager repository URLs after product rename

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -110,10 +110,10 @@ zypper ar http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/SUSE/Pr
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/openSUSE_Leap_16.0/ container_utils
 %{ else }
 %{ if container_server }
-zypper ar http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Multi-Linux-Manager-Server-5.1-x86_64/ container_utils
+zypper ar http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Server-5.1-x86_64/ container_utils
 %{ endif }
 %{ if container_proxy }
-zypper ar http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Multi-Linux-Manager-Proxy-5.1-x86_64/ container_utils
+zypper ar http://${ use_mirror_images ? mirror : "download.suse.de/ibs"}/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Proxy-5.1-x86_64/ container_utils
 %{ endif }
 %{ endif }
 %{ endif }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -376,7 +376,7 @@ zypper:
 %{ if product_version == "head" }
     - id: container_tools_repo
       name: container_tools_repo
-      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Multi-Linux-Manager-Server-5.1-x86_64/
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Server-5.1-x86_64/
       enabled: 1
       autorefresh: 1
       gpgcheck: false
@@ -403,11 +403,11 @@ zypper:
 %{ if product_version == "head" }
     - id: container_tools_repo
       name: container_tools_repo
-      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/SLE-Micro55/
+#      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/SLE-Micro55/
+      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Proxy-5.1-x86_64/
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-#      baseurl: http://${ use_mirror_images ? mirror : "download.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Multi-Linux-Manager-Proxy-5.1-x86_64/
 %{ endif }
 %{ if product_version == "5.0-nightly" }
     - id: container_tools_repo


### PR DESCRIPTION
## What does this PR change?

The products were renamed from "SUSE-Multi-Linux-Manager-*" into "Multi-Linux-Manager-*".
This effect also the repository URLs
