### PR TITLE
Fix beta_enabled variable on cucumber_testsuite module + Refactor rhn.sls on server_containerized

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -290,7 +290,12 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
    * `login_timeout`: define how long the webUI login cookie is valid (in seconds). Set to null by default to leave it up to the application default value.
    * `db_configuration` : pass external database configuration to change `setup_env.sh` file. See more in `Using external database` section
    * `beta_enabled`: enable beta channels in rhn configuration. Set to false by default.
-
+ * `controller` module:
+   * `is_using_paygo_server`: whether to use the paygo server. Set to `false` to use the default server
+   * `is_using_build_image`: whether to use the build image. Set to `false` to use the default image
+   * `is_using_scc_repositories`: whether to use SCC repositories. Set to `false` to use the default repositories
+   * `catch_timeout_message`: whether to catch timeout messages. Set to `false` to use the default timeout message
+   * `beta_enabled`: enable beta channels in rhn configuration. Set to false by default.
 
 ## Adding channels to SUSE Manager Servers
 

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -73,8 +73,6 @@ locals {
     host_key => lookup(var.host_settings[host_key], "repository_disk_use_cloud_setup", null) if var.host_settings[host_key] != null }
   scc_access_logging        = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "scc_access_logging", false) if var.host_settings[host_key] != null }
-  beta_enabled              = { for host_key in local.hosts :
-    host_key => lookup(var.host_settings[host_key], "beta_enabled", false) if var.host_settings[host_key] != null }
 
   minimal_configuration     = { hostname = contains(local.hosts, "proxy") ? local.proxy_full_name : local.server_full_name }
   server_configuration      = var.container_server ? module.server_containerized[0].configuration : module.server[0].configuration
@@ -105,7 +103,7 @@ module "server" {
   forward_registration           = false
   monitored                      = true
   use_os_released_updates        = false
-  beta_enabled                   = lookup(local.beta_enabled, "server", false)
+  beta_enabled                   = var.beta_enabled
   install_salt_bundle            = lookup(local.install_salt_bundle, "server", true)
   ssh_key_path                   = "./salt/controller/id_rsa.pub"
   from_email                     = var.from_email
@@ -149,7 +147,7 @@ module "server_containerized" {
   disable_download_tokens        = false
   //forward_registration           = false
   use_os_released_updates        = false
-  beta_enabled                   = lookup(local.beta_enabled, "server_containerized", false)
+  beta_enabled                   = var.beta_enabled
   install_salt_bundle            = lookup(local.install_salt_bundle, "server_containerized", true)
   ssh_key_path                   = "./salt/controller/id_rsa.pub"
   from_email                     = var.from_email
@@ -492,6 +490,7 @@ module "controller" {
   server_http_proxy        = var.server_http_proxy
   custom_download_endpoint = var.custom_download_endpoint
   swap_file_size           = null
+  beta_enabled             = var.beta_enabled
 
   additional_repos  = lookup(local.additional_repos, "controller", {})
   additional_repos_only  = lookup(local.additional_repos_only, "controller", false)

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -175,3 +175,8 @@ variable "container_proxy" {
   description = "true to run the proxy in containers"
   default = false
 }
+
+variable "beta_enabled" {
+  description = "Enable the mechanism to take into account beta channels"
+  default     = false
+}

--- a/salt/server_containerized/init.sls
+++ b/salt/server_containerized/init.sls
@@ -7,3 +7,4 @@ include:
   - server_containerized.initial_content
   - server_containerized.testsuite
   - server_containerized.large_deployment
+  - server_containerized.rhn


### PR DESCRIPTION
## What does this PR change?

Card: https://github.com/SUSE/spacewalk/issues/26373

Fix `beta_enabled` variable on cucumber_testsuite module.
With those changes, the aim is to provide `beta_enabled` variable at cucumber_testsuite module, so you don't need to define it twice in `controller` and `server_containerized` submodules.

Additionally, we fixed the rhn.sls that was previously NOT triggered, refactoring it so it use mgrctl to run some `sed` commands to modify RHN configuration file.

Note for MLM team:
This PR must be follow up by a PR to adapt our internal terraform files in susemanager-ci repository.
Add this variable at cucumber_testsuite level.