### PR TITLE
Changes needed for separate database container

### DIFF
--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -1,8 +1,6 @@
 {% set runtime = grains.get('container_runtime') | default('podman', true) %}
 db:
   password: spacewalk
-reportdb:
-  host: localhost
 ssl:
   password: spacewalk
 {%- if grains.get('cc_username') %}


### PR DESCRIPTION
## What does this PR change?

* postgresql container uses `reportdb` hostname which is also default so do not set it in the mgradm.yaml
