### PR TITLE
Refactor how we require mgrctl and mgradm packages

### DIFF
--- a/salt/default/network.sls
+++ b/salt/default/network.sls
@@ -19,7 +19,7 @@ ipv6_accept_ra_{{ iface }}:
 {% endif %}
 {% endfor %}
 
-{% if grains['osfullname'] in ['SLE Micro', 'openSUSE Leap Micro'] and (grains['osrelease'] != '5.1' and grains['osrelease'] != '5.2') %}
+{% if grains['osfullname'] in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] and (grains['osrelease'] != '5.1' and grains['osrelease'] != '5.2') %}
 {% set conname = salt.cmd.run_stdout('nmcli -g GENERAL.CONNECTION device show eth0') %}
 avoid_network_manager_messing_up:
   cmd.run:
@@ -73,7 +73,7 @@ ipv6_disable_all:
 
 {% endif %}
 
-{% if grains['osfullname'] in ['SLE Micro', 'openSUSE Leap Micro'] and (grains['osrelease'] != '5.1' and grains['osrelease'] != '5.2') %}
+{% if grains['osfullname'] in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] and (grains['osrelease'] != '5.1' and grains['osrelease'] != '5.2') %}
 {% set conname2 = salt.cmd.run_stdout('nmcli -g GENERAL.CONNECTION device show eth1', ignore_retcode=true) %}
 {% if conname2 != '' %}
 enable_dhcp_on_eth1:

--- a/salt/server_containerized/init.sls
+++ b/salt/server_containerized/init.sls
@@ -5,6 +5,6 @@ include:
   - server_containerized.additional_disks
   - server_containerized.install_mgradm
   - server_containerized.initial_content
-  - server_containerized.testsuite
-  - server_containerized.large_deployment
   - server_containerized.rhn
+  - server_containerized.large_deployment
+  - server_containerized.testsuite

--- a/salt/server_containerized/initial_content.sls
+++ b/salt/server_containerized/initial_content.sls
@@ -13,9 +13,6 @@ first_user_set_password:
     - name: mgrctl exec 'echo -e "{{ server_password }}\\n{{ server_password }}" | satpasswd -s {{ server_username }}'
     - require:
       - cmd: mgradm_install
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
 {% endif %}
 
 {% if grains.get('mgr_sync_autologin') %}

--- a/salt/server_containerized/install_common.sls
+++ b/salt/server_containerized/install_common.sls
@@ -1,13 +1,25 @@
 {%- set mirror_hostname = grains.get('server_mounted_mirror') if grains.get('server_mounted_mirror') else grains.get('mirror') %}
 
-{% if grains['osfullname'] not in ['SLE Micro', 'openSUSE Leap Micro'] %}
+{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
 uyuni-tools:
   pkg.installed:
     - pkgs:
       - mgradm
       - mgrctl
+{%- else %}
+check_mgrctl_installed:
+  cmd.run:
+    - name: "rpm -q mgrctl"
+    - success_retcodes: [0]
+    - failhard: True
+
+check_mgradm_installed:
+  cmd.run:
+    - name: "rpm -q mgradm"
+    - success_retcodes: [0]
+    - failhard: True
 {% endif %}
-    
+
 {% if mirror_hostname %}
 
 nfs_client:
@@ -30,7 +42,6 @@ mirror_directory:
       - pkg: nfs_client
 
 {% endif %}
-
 
 # WORKAROUND: see github:saltstack/salt#10852
 {{ sls }}_nop:

--- a/salt/server_containerized/install_mgradm.sls
+++ b/salt/server_containerized/install_mgradm.sls
@@ -21,9 +21,6 @@ mgradm_install:
     - unless: helm --kubeconfig /etc/rancher/k3s/k3s.yaml list | grep uyuni
 {%- endif %}
     - require:
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
       - sls: server_containerized.install_common
       - sls: server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
       - file: mgradm_config

--- a/salt/server_containerized/large_deployment.sls
+++ b/salt/server_containerized/large_deployment.sls
@@ -2,24 +2,13 @@
 
 {% if grains.get('large_deployment') | default(false, true) %}
 
-include:
-  - server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
-
 large_deployment_increase_tasko_parallel_threads:
   cmd.run:
     - name: mgrctl exec 'echo "taskomatic.com.redhat.rhn.taskomatic.task.MinionActionExecutor.parallel_threads = 3" >> /etc/rhn/rhn.conf'
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-    - require:
-      - pkg: uyuni-tools
-{% endif %}
 
 large_deployment_increase_hibernate_max_connections:
   cmd.run:
     - name: mgrctl exec 'echo "hibernate.c3p0.max_size = 100" >> /etc/rhn/rhn.conf'
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-    - require:
-      - pkg: uyuni-tools
-{% endif %}
 
 large_deployment_tune_tomcat_stylesheet_host:
   file.managed:
@@ -49,18 +38,10 @@ large_deployment_tomcat_restart:
 large_deployment_increase_database_max_connections:
   cmd.run:
     - name: mgrctl exec 'sed -i "s/max_connections = (.*)/max_connections = 400/" /var/lib/pgsql/data/postgresql.conf'
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-    - require:
-      - pkg: uyuni-tools
-{% endif %}
 
 large_deployment_increase_database_work_memory:
   cmd.run:
     - name: mgrctl exec 'sed -i "s/work_mem = (.*)/work_mem = 20MB/" /var/lib/pgsql/data/postgresql.conf'
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-    - require:
-      - pkg: uyuni-tools
-{% endif %}
 
 large_deployment_postgresql_restart:
   cmd.run:

--- a/salt/server_containerized/rhn.sls
+++ b/salt/server_containerized/rhn.sls
@@ -1,28 +1,19 @@
-include:
-  - server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
-
 {% if grains.get('skip_changelog_import') %}
 
 package_import_skip_changelog_reposync:
   cmd.run:
     - name: mgrctl exec 'echo "package_import_skip_changelog = 1" >> /etc/rhn/rhn.conf'
-    - require:
-        - pkg: uyuni-tools
 
 {% endif %}
 
 limit_changelog_entries:
   cmd.run:
     - name: mgrctl exec 'grep -q "java.max_changelog_entries" /etc/rhn/rhn.conf && sed -i "s/java.max_changelog_entries.*/java.max_changelog_entries = 3/" /etc/rhn/rhn.conf || echo "java.max_changelog_entries = 3" >> /etc/rhn/rhn.conf'
-    - require:
-        - pkg: uyuni-tools
 
 {% if grains.get('disable_download_tokens') %}
 disable_download_tokens:
   cmd.run:
     - name: mgrctl exec 'echo "java.salt_check_download_tokens = false" >> /etc/rhn/rhn.conf'
-    - require:
-        - pkg: uyuni-tools
 {% endif %}
 
 {% if grains.get('monitored') | default(false, true) %}
@@ -30,8 +21,6 @@ disable_download_tokens:
 rhn_conf_prometheus:
   cmd.run:
     - name: mgrctl exec 'echo "prometheus_monitoring_enabled = true" >> /etc/rhn/rhn.conf'
-    - require:
-        - pkg: uyuni-tools
 
 {% endif %}
 
@@ -40,8 +29,6 @@ rhn_conf_prometheus:
 rhn_conf_forward_reg:
   cmd.run:
     - name: mgrctl exec 'echo "server.susemanager.forward_registration = 0" >> /etc/rhn/rhn.conf'
-    - require:
-        - pkg: uyuni-tools
 
 {% endif %}
 
@@ -50,8 +37,6 @@ rhn_conf_forward_reg:
 rhn_conf_disable_auto_generate_bootstrap_repo:
   cmd.run:
     - name: mgrctl exec 'echo "server.susemanager.auto_generate_bootstrap_repo = 0" >> /etc/rhn/rhn.conf'
-    - require:
-        - pkg: uyuni-tools
 
 {% endif %}
 
@@ -59,8 +44,6 @@ rhn_conf_disable_auto_generate_bootstrap_repo:
 change_product_tree_to_beta:
   cmd.run:
     - name: mgrctl exec 'grep -q "java.product_tree_tag" /etc/rhn/rhn.conf && sed -i "s/java.product_tree_tag = .*/java.product_tree_tag = Beta/" /etc/rhn/rhn.conf || echo "java.product_tree_tag = Beta" >> /etc/rhn/rhn.conf'
-    - require:
-        - pkg: uyuni-tools
 {% endif %}
 
 rhn_conf_present:

--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -1,15 +1,8 @@
 {% if grains.get('testsuite') | default(false, true) %}
 
-include:
-  - server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
-
 minima_download:
   cmd.run:
     - name: mgrctl exec 'curl --output-dir /root -OL https://github.com/uyuni-project/minima/releases/download/v0.4/minima-linux-amd64.tar.gz'
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-    - require:
-      - pkg: uyuni-tools
-{% endif %}
 
 minima_unpack:
   cmd.run:
@@ -56,9 +49,6 @@ test_repo_debian_updates:
     - unless: mgrctl exec "ls -d /srv/www/htdocs/pub/TestRepoDebUpdates"
     - require:
       - file: test_repo_debian_updates_script
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
 
 # modify cobbler to be executed from remote-machines..
 cobbler_configuration:
@@ -66,9 +56,6 @@ cobbler_configuration:
     - name: "mgrctl exec 'sed -i \"s/redhat_management_permissive: false/redhat_management_permissive: true/\" /etc/cobbler/settings.yaml'"
     - require:
       - sls: server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
 
 cobbler_restart:
   cmd.run:
@@ -82,7 +69,7 @@ uyuni_key_copy_host:
     - name: /tmp/uyuni.key
     - source: salt://default/gpg_keys/uyuni.key
 
-repo_key_import:
+uyuni_repo_key_import:
   cmd.run:
     - name: "mgradm gpg add -f /tmp/uyuni.key"
     - onchanges:
@@ -94,7 +81,7 @@ galaxy_key_copy_host:
     - name: /tmp/galaxy.key
     - source: salt://default/gpg_keys/galaxy.key
 
-repo_key_import:
+galaxy_repo_key_import:
   cmd.run:
     - name: "mgradm gpg add -f /tmp/galaxy.key"
     - onchanges:
@@ -126,9 +113,6 @@ create_pillar_top_sls_to_assign_salt_bundle_config:
   cmd.run:
     - name: mgrctl exec 'echo -e "base:\n  '"'"'*'"'"':\n    - salt_bundle_config" >/srv/pillar/top.sls'
     - require:
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
       - sls: server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
 
 custom_pillar_to_force_salt_bundle:
@@ -142,27 +126,18 @@ enable_salt_content_staging_window:
   cmd.run:
     - name: mgrctl exec 'sed '"'"'/java.salt_content_staging_window =/{h;s/= .*/= 0.033/};${x;/^$/{s//java.salt_content_staging_window = 0.033/;H};x}'"'"' -i /etc/rhn/rhn.conf'
     - require:
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
       - sls: server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
 
 enable_salt_content_staging_advance:
   cmd.run:
     - name: mgrctl exec 'sed '"'"'/java.salt_content_staging_advance =/{h;s/= .*/= 0.05/};${x;/^$/{s//java.salt_content_staging_advance = 0.05/;H};x}'"'"' -i /etc/rhn/rhn.conf'
     - require:
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
       - sls: server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
 
 enable_kiwi_os_image_building:
   cmd.run:
     - name: mgrctl exec 'sed '"'"'/java.kiwi_os_image_building_enabled =/{h;s/= .*/= true/};${x;/^$/{s//java.kiwi_os_image_building_enabled = true/;H};x}'"'"' -i /etc/rhn/rhn.conf'
     - require:
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
       - sls: server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
 
 tomcat_restart:
@@ -183,9 +158,6 @@ dump_salt_event_log:
     - name: mgrctl cp /root/salt-events.service server:/usr/lib/systemd/system/salt-events.service
     - require:
       - file: salt_event_service_file
-{% if grains['osfullname'] not in ['SLE Micro', 'SL-Micro', 'openSUSE Leap Micro'] %}
-      - pkg: uyuni-tools
-{% endif %}
 
 dump_salt_event_log_start:
   cmd.run:


### PR DESCRIPTION
## What does this PR change?

Some of our salt states in Sumaform requires to have previously installed `mgrctl` or `mgradm`.
But if we are under a transactional-system, we install these packages during the cloud-init/combustion phase.
And if we are under a non transactional-system, we have a salt state called `uyuni-tools` taking care of that installation.
Before this PR, we had an `if` statement and we only required `uyuni-tools` if we were under a non-transactional system, and just don't check it if we are under a transactional-system.
This approach could potentially miss issues, so the PR aims to improve it, by directly check if `mgrctl` and `mgradm` are present when we are on a transactional-system.