### PR TITLE
Add support container image for server

### DIFF
--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -45,6 +45,7 @@ module "server_containerized" {
   grains = {
     container_runtime              = var.runtime
     container_repository           = var.container_repository
+    container_image                = var.container_image
     container_tag                  = var.container_tag
     cc_username                    = var.base_configuration["cc_username"]
     cc_password                    = var.base_configuration["cc_password"]

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -22,6 +22,11 @@ variable "container_repository" {
   default = ""
 }
 
+variable "container_image" {
+  description = "Server container images name. Don't setup for default images."
+  default = ""
+}
+
 variable "container_tag" {
   description = "The container image tag to use."
   default = ""

--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -15,6 +15,9 @@ emailFrom: {{ grains.get("from_email") | default('galaxy-noise@suse.de', true) }
 {%- if grains.get('container_repository') %}
 registry: {{ grains.get('container_repository') }}
 {% endif %}
+{%- if grains.get('container_image') %}
+image: {{ grains.get('container_image') }}
+{% endif %}
 {%- if grains.get('container_tag') %}
 tag: {{ grains.get('container_tag') }}
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Add the possibility to define an image name if we don't want to use the default image from mgradm. Can be usefull in situation we have an image available for the server but the path is not supported yet.