### PR TITLE
Pin all GitHub actions to a commit

### DIFF
--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -10,10 +10,10 @@ jobs:
     name: Validate Salt states
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 1
-#    - uses: awalsh128/cache-apt-pkgs-action@latest
+#    - uses: awalsh128/cache-apt-pkgs-action@5902b33ae29014e6ca012c5d8025d4346556bd40 #v1.4.3
 #      with:
 #        packages: salt-common
 #        version: 1.0
@@ -45,10 +45,10 @@ jobs:
     name: Validate terraform configuration
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 1
-    - uses: hashicorp/setup-terraform@v3
+    - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd #v3.1.2
       with:
         terraform_version: 1.0.10
     - name: Validate configuration using example files

--- a/.github/workflows/mirror-update-warning.yml
+++ b/.github/workflows/mirror-update-warning.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       with:
         fetch-depth: 2
     - name: Find modified image URLs
@@ -28,7 +28,7 @@ jobs:
 
         echo "EOF" >> $GITHUB_ENV
     - name: Comment on the pull request
-      uses: actions-cool/maintain-one-comment@v3
+      uses: actions-cool/maintain-one-comment@4b2dbf086015f892dcb5e8c1106f5fccd6c1476b # v3.2.0
       with:
         delete: ${{ !env.IMAGE_LIST }}
         body: |


### PR DESCRIPTION
## What does this PR change?

One of the recommendations of the [Good security practices for using GitHub Actions features](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions?learn=getting_started).

For each action I went to the repository and used the last released version for the major version we were using, and specified the exact version with a comment.

If we were using `latest`, I pinned to the latest commit for the most recent version released.
