### PR TITLE
Remove Leap 15.5

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -255,10 +255,10 @@ At the time of writing, the upstream `dmacvicar/libvirt` terraform provider does
 1\. Add the sumaform repository
 
 ```
-zypper ar -f https://download.opensuse.org/repositories/systemsmanagement:/sumaform/openSUSE_Leap_15.5 sumaform
+zypper ar -f https://download.opensuse.org/repositories/systemsmanagement:/sumaform/openSUSE_Leap_15.6 sumaform
 ```
 
-Swap out `openSUSE_Leap_15.5` for `openSUSE_Leap_15.4` or `openSUSE_Tumbleweed` if you’re using a different version of openSUSE.
+Swap out `openSUSE_Leap_15.6` for `openSUSE_Leap_15.5` or `openSUSE_Tumbleweed` if you are using a different version of openSUSE.
 
 2\. Install `terraform-provider-libvirt` from sumaform
 

--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -52,7 +52,7 @@ systemctl enable sshd.service
 ${ gpg_keys }
 
 # Add repositories
-zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/15.5/ ca_suse
+zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/15.6/ ca_suse
 
 %{ if image == "leapmicro55o" }
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/ client_tools_repo
@@ -69,12 +69,12 @@ zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repos
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm/ test_repo_rpm_pool
 
 # Leap repos are required to install expect
-zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/distribution/leap/15.5/repo/oss/ leap_pool_repo
-zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/update/leap/15.5/oss/ leap_update_repo
+zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/distribution/leap/15.6/repo/oss/ leap_pool_repo
+zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/update/leap/15.6/oss/ leap_update_repo
 %{ endif }
 
 %{ if container_runtime == "k3s" }
-zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/update/leap/15.5/sle/ sle_update_repo
+zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/update/leap/15.6/sle/ sle_update_repo
 %{ endif }
 %{ endif } # end of image == "leapmicro55o" block
 

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -53,9 +53,9 @@ update_ca_truststore:
 {% endif %}
 {% endif %}
 
-# WORKAROUND for not syncing openSUSE Leap 15.5 in the Uyuni CIs
+# WORKAROUND for not syncing openSUSE Leap 15.6 in the Uyuni CIs
 # We need some dependencies for the package mgr-push, otherwise the installation in the test suite will fail
-{% if grains['osfullname'] == 'Leap' and grains['osrelease'] == '15.5' %}
+{% if grains['osfullname'] == 'Leap' and grains['osrelease'] == '15.6' %}
 suse_minion_mgr_push_requisites:
   pkg.installed:
     - pkgs:

--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -293,24 +293,22 @@ http:
     archs: [amd64]
 
   # openSUSE Leap
-  - url: http://download.opensuse.org/distribution/leap/15.2/repo/oss
+  - url: http://download.opensuse.org/distribution/leap/15.5/repo/oss
     archs: [x86_64]
-  - url: http://download.opensuse.org/update/leap/15.2/oss
+  - url: http://download.opensuse.org/update/leap/15.5/oss
     archs: [x86_64]
-  - url: http://download.opensuse.org/distribution/leap/15.3/repo/oss
-    archs: [x86_64]
-  - url: http://download.opensuse.org/update/leap/15.3/oss
-    archs: [x86_64]
-  - url: http://download.opensuse.org/update/leap/15.3/backports
-    archs: [x86_64]
-  - url: http://download.opensuse.org/update/leap/15.3/sle
-    archs: [x86_64]
-  - url: http://download.opensuse.org/update/leap/15.4/sle
+  - url: http://download.opensuse.org/update/leap/15.5/backports
     archs: [x86_64]
   - url: http://download.opensuse.org/update/leap/15.5/sle
+    archs: [x86_64,aarch64]
+  - url: http://download.opensuse.org/distribution/leap/15.6/repo/oss
+    archs: [x86_64]
+  - url: http://download.opensuse.org/update/leap/15.6/oss
+    archs: [x86_64]
+  - url: http://download.opensuse.org/update/leap/15.6/backports
     archs: [x86_64]
   - url: http://download.opensuse.org/update/leap/15.6/sle
-    archs: [aarch64]
+    archs: [x86_64,aarch64]
 
   # Testsuite dummy packages for testing repo
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Pool/rpm
@@ -319,8 +317,6 @@ http:
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/deb
 
   # Software for sumaformed Virtual Machines
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_15_SP2
-    archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_15_SP3
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_15_SP4
@@ -328,12 +324,6 @@ http:
   - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_15_SP5
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/SLE_15_SP6
-    archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.2
-    archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.3
-    archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.4
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.5
     archs: [x86_64]
@@ -346,9 +336,9 @@ http:
     archs: [x86_64]
 
   # Uyuni Master
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.5/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.6/
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/openSUSE_Leap_15.5/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/openSUSE_Leap_15.6/
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Testing-Overlay-POOL-x86_64-Media1/
     archs: [x86_64]
@@ -380,7 +370,7 @@ http:
     archs: [amd64]
 
   # Uyuni Stable
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_15.4/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_15.6/
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
     archs: [x86_64]

--- a/salt/repos/proxy_containerizedUyuni.sls
+++ b/salt/repos/proxy_containerizedUyuni.sls
@@ -28,7 +28,7 @@
 {% endif %}
 
 {% if grains['osfullname'] == 'Leap' %}
-{% set repo = 'openSUSE_Leap_15.5' %}
+{% set repo = 'openSUSE_Leap_15.6' %}
 
 
 {% if 'uyuni' == grains['product_version'] %}

--- a/salt/repos/server_containerizedUyuni.sls
+++ b/salt/repos/server_containerizedUyuni.sls
@@ -27,7 +27,7 @@
 {% endif %}
 
 {% if grains['osfullname'] == 'Leap' %}
-{% set repo = 'openSUSE_Leap_15.5' %}
+{% set repo = 'openSUSE_Leap_15.6' %}
 
 
 {% if 'uyuni' == grains['product_version'] %}


### PR DESCRIPTION
## What does this PR change?

This PR replaces Leap 15.5 with Leap 15.6 on server, proxy, and minion

controller, dhcp-dns, and monitoring are not affected.
