### PR TITLE
Fix LTSS path in mirror

### DIFF
--- a/salt/repos/os.sls
+++ b/salt/repos/os.sls
@@ -68,7 +68,7 @@ os_update_repo:
 
 os_ltss_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-SP2-LTSS/x86_64/update/
 
 {% elif '15.3' == grains['osrelease'] %}
 
@@ -84,7 +84,7 @@ os_update_repo:
 
 os_ltss_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/{{ grains.get("cpuarch") }}/update/
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Product-SLES/15-SP3-LTSS/{{ grains.get("cpuarch") }}/update/
 
 {% elif '15.4' == grains['osrelease'] %}
 


### PR DESCRIPTION
## What does this PR change?

The path to LTSS repo in mirror is incorrect.
```
minima-mirror-ci-bv:/srv/mirror/SUSE/Updates/SLE-Product-SLES # pwd
/srv/mirror/SUSE/Updates/SLE-Product-SLES
minima-mirror-ci-bv:/srv/mirror/SUSE/Updates/SLE-Product-SLES # ls -lrt
total 0
drwxr-xr-x 4 root root 47 Aug 15  2023 15-SP4
drwxr-xr-x 3 root root 28 Jan  2  2024 15-SP4-LTSS
drwxr-xr-x 4 root root 45 Jan  8  2024 15-SP5
drwxr-xr-x 4 root root 47 Jan  8  2024 15-SP3
drwxr-xr-x 5 root root 64 Jul 10  2024 15-SP6
drwxr-xr-x 4 root root 47 Aug 22  2024 15-SP3-LTSS
drwxr-xr-x 4 root root 45 Mar 19 11:05 15-SP7
drwxr-xr-x 3 root root 28 Mar 22 22:15 15
drwxr-xr-x 3 root root 28 Mar 22 22:26 15-SP1
drwxr-xr-x 3 root root 28 Mar 23 21:39 15-SP2
drwxr-xr-x 3 root root 28 Mar 23 23:36 15-LTSS
drwxr-xr-x 3 root root 28 Mar 24 00:16 15-SP1-LTSS
drwxr-xr-x 3 root root 28 Mar 24 01:02 15-SP2-LTSS
```