### PR TITLE
Add sles12sp5 os ltss repo

### DIFF
--- a/salt/repos/os.sls
+++ b/salt/repos/os.sls
@@ -41,10 +41,9 @@ os_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/
     - refresh: True
 
-# uncomment when it goes LTSS
-# os_ltss_repo:
-#   pkgrepo.managed:
-#           - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP5-LTSS/x86_64/update/
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-SERVER/12-SP5-LTSS/x86_64/update/
 
 {% endif %}
 {% endif %} ## End skip if SCC support


### PR DESCRIPTION
## What does this PR change?

sles12sp5 is now LTSS
Add the ltss repo to sumaform.
Depends on: https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/1032
