### PR TITLE
change controller default image to Leap 15.6

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -146,7 +146,7 @@ module "controller" {
     salt_migration_minion = length(var.salt_migration_minion_configuration["hostnames"]) > 0 ? var.salt_migration_minion_configuration["hostnames"][0] : null
   }
 
-  image   = "opensuse155o"
+  image   = "opensuse156o"
   provider_settings = var.provider_settings
 }
 

--- a/salt/repos/ruby.sls
+++ b/salt/repos/ruby.sls
@@ -3,7 +3,7 @@
 ruby_add_devel_repository:
     pkgrepo.managed:
       - name: ruby_devel
-      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby/15.5/
+      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby/15.6/
       - refresh: True
       - gpgautoimport: True
 


### PR DESCRIPTION
## What does this PR change?

Leap 15.5 is EOL and the ruby repo was already removed

