### PR TITLE
Fix path ruby devel

### DIFF
--- a/salt/repos/ruby.sls
+++ b/salt/repos/ruby.sls
@@ -3,7 +3,7 @@
 ruby_add_devel_repository:
     pkgrepo.managed:
       - name: ruby_devel
-      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby/15.5/
+      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby/15.6/
       - refresh: True
       - gpgautoimport: True
 


### PR DESCRIPTION
## What does this PR change?
http://download.opensuse.org/repositories/devel:/languages:/ruby/15.5/ has been removed. Bump to 15.6.
