### PR TITLE
Switch from Leap 15.5 to 15.6 on AWS hosts

### DIFF
--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -10,10 +10,10 @@ chpasswd:
     root:linux
 %{ endif }
 
-%{ if image == "opensuse155o" }
+%{ if image == "opensuse156o" }
 # WORKAROUND: install latest libzypp to prevent signature verification errors
 runcmd:
-  - zypper addrepo -G -e http://download.opensuse.org/update/leap/15.5/oss/ os_update
+  - zypper addrepo -G -e http://download.opensuse.org/update/leap/15.6/oss/ os_update
   - zypper addrepo -G -e http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/ client_tools_tmp
   - zypper ref
   - zypper up --allow-vendor-change --no-confirm libzypp


### PR DESCRIPTION
## What does this PR change?

Leftover of the switch from Leap 15.5 to 15.6
