### PR TITLE
Disabling automatic daily system updates

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -187,5 +187,9 @@ zypper --non-interactive install $PACKAGES
 zypper --non-interactive update --no-recommends iptables
 %{ endif }
 
+# Disabling this timer safely by masking it (systemctl might still not available at Combustion phase)
+echo "Disabling automatic daily system updates"
+ln -sf /dev/null /etc/systemd/system/transactional-update.timer
+
 # Leave a marker
 echo "Configured with combustion" > /etc/issue.d/combustion

--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -187,7 +187,7 @@ zypper --non-interactive install $PACKAGES
 zypper --non-interactive update --no-recommends iptables
 %{ endif }
 
-# Disabling this timer safely by masking it (systemctl might still not available at Combustion phase)
+# Disabling this timer safely by masking it (systemctl might still be unavailable during the Combustion phase)
 echo "Disabling automatic daily system updates"
 ln -sf /dev/null /etc/systemd/system/transactional-update.timer
 


### PR DESCRIPTION
## What does this PR change?

This PR disable the automatic daily system updates and its reboot, in all images initialized with Combustion.

- `ln -sf /dev/null` reliably disables the service even without `systemctl`.
- Compatible with early boot stages of MicroOS / Leap Micro.
- No dependency on D-Bus or systemd being fully available.
