### PR TITLE
The journal folder has to match the machine-id

### DIFF
--- a/salt/default/ids.sls
+++ b/salt/default/ids.sls
@@ -9,7 +9,7 @@ install_dbus_uuidgen:
 
 systemd_machine_id:
   cmd.run:
-    - name: rm -f /etc/machine-id && rm -f /var/lib/dbus/machine-id && mkdir -p /var/lib/dbus && dbus-uuidgen --ensure && systemd-machine-id-setup && touch /etc/machine-id-already-setup
+    - name: rm -f /etc/machine-id && rm -f /var/lib/dbus/machine-id && mkdir -p /var/lib/dbus && dbus-uuidgen --ensure && systemd-machine-id-setup && mv /var/log/journal/* /var/log/journal/$(cat /etc/machine-id)/ && touch /etc/machine-id-already-setup
     - creates: /etc/machine-id-already-setup
     - onlyif: test -f /usr/bin/systemd-machine-id-setup -o -f /bin/systemd-machine-id-setup
 


### PR DESCRIPTION
## What does this PR change?

If the folder in `/var/log/journal` doesn't match the `/etc/machine-id` `journalctl` cannot log anything... and `podman logs` uses `journald` as its backend so we would also get no container logs.