### PR TITLE
Fix systemd machine id journal not present

### DIFF
--- a/salt/default/ids.sls
+++ b/salt/default/ids.sls
@@ -11,19 +11,36 @@ systemd_machine_id:
   cmd.run:
     - name: >
         bash -c '
-        rm -f /etc/machine-id &&
-        rm -f /var/lib/dbus/machine-id &&
-        mkdir -p /var/lib/dbus &&
-        dbus-uuidgen --ensure &&
-        systemd-machine-id-setup &&
+        set -e
+        echo "Removing existing machine-id files"
+        rm -f /etc/machine-id
+        rm -f /var/lib/dbus/machine-id
+
+        echo "Creating /var/lib/dbus"
+        mkdir -p /var/lib/dbus
+
+        echo "Generating new D-Bus UUID"
+        dbus-uuidgen --ensure
+
+        echo "Running systemd-machine-id-setup"
+        systemd-machine-id-setup
+
+        echo "Checking if /var/log/journal exists and is not empty"
         if [ -d /var/log/journal ] && [ "$(ls -A /var/log/journal)" ]; then
-          mkdir -p /var/log/journal/$(cat /etc/machine-id) &&
-          mv /var/log/journal/* /var/log/journal/$(cat /etc/machine-id)/;
-        fi &&
+          MID=$(cat /etc/machine-id)
+          echo "Moving logs to /var/log/journal/$MID"
+          mkdir -p /var/log/journal/$MID
+          mv /var/log/journal/* /var/log/journal/$MID/
+        else
+          echo "/var/log/journal does not exist or is empty, skipping move"
+        fi
+
+        echo "Marking setup complete"
         touch /etc/machine-id-already-setup
         '
     - creates: /etc/machine-id-already-setup
     - onlyif: test -f /usr/bin/systemd-machine-id-setup -o -f /bin/systemd-machine-id-setup
+
 
 
 dbus_machine_id:

--- a/salt/default/ids.sls
+++ b/salt/default/ids.sls
@@ -9,7 +9,7 @@ install_dbus_uuidgen:
 
 systemd_machine_id:
   cmd.run:
-    - name: >
+    - name: |
         bash -c '
         set -e
         echo "Removing existing machine-id files"
@@ -40,8 +40,6 @@ systemd_machine_id:
         '
     - creates: /etc/machine-id-already-setup
     - onlyif: test -f /usr/bin/systemd-machine-id-setup -o -f /bin/systemd-machine-id-setup
-
-
 
 dbus_machine_id:
   cmd.run:

--- a/salt/default/ids.sls
+++ b/salt/default/ids.sls
@@ -9,9 +9,22 @@ install_dbus_uuidgen:
 
 systemd_machine_id:
   cmd.run:
-    - name: rm -f /etc/machine-id && rm -f /var/lib/dbus/machine-id && mkdir -p /var/lib/dbus && dbus-uuidgen --ensure && systemd-machine-id-setup && mv /var/log/journal/* /var/log/journal/$(cat /etc/machine-id)/ && touch /etc/machine-id-already-setup
+    - name: >
+        bash -c '
+        rm -f /etc/machine-id &&
+        rm -f /var/lib/dbus/machine-id &&
+        mkdir -p /var/lib/dbus &&
+        dbus-uuidgen --ensure &&
+        systemd-machine-id-setup &&
+        if [ -d /var/log/journal ] && [ "$(ls -A /var/log/journal)" ]; then
+          mkdir -p /var/log/journal/$(cat /etc/machine-id) &&
+          mv /var/log/journal/* /var/log/journal/$(cat /etc/machine-id)/;
+        fi &&
+        touch /etc/machine-id-already-setup
+        '
     - creates: /etc/machine-id-already-setup
     - onlyif: test -f /usr/bin/systemd-machine-id-setup -o -f /bin/systemd-machine-id-setup
+
 
 dbus_machine_id:
   cmd.run:

--- a/salt/default/ids.sls
+++ b/salt/default/ids.sls
@@ -11,31 +11,15 @@ systemd_machine_id:
   cmd.run:
     - name: |
         bash -c '
-        set -e
-        echo "Removing existing machine-id files"
         rm -f /etc/machine-id
         rm -f /var/lib/dbus/machine-id
-
-        echo "Creating /var/lib/dbus"
         mkdir -p /var/lib/dbus
-
-        echo "Generating new D-Bus UUID"
         dbus-uuidgen --ensure
-
-        echo "Running systemd-machine-id-setup"
         systemd-machine-id-setup
-
-        echo "Checking if /var/log/journal exists and is not empty"
         if [ -d /var/log/journal ] && [ "$(ls -A /var/log/journal)" ]; then
-          MID=$(cat /etc/machine-id)
-          echo "Moving logs to /var/log/journal/$MID"
-          mkdir -p /var/log/journal/$MID
-          mv /var/log/journal/* /var/log/journal/$MID/
-        else
-          echo "/var/log/journal does not exist or is empty, skipping move"
+          mkdir -p /var/log/journal/$(cat /etc/machine-id)
+          find /var/log/journal -mindepth 1 -maxdepth 1 ! -name "$(cat /etc/machine-id)" -exec mv {} /var/log/journal/$(cat /etc/machine-id)/ \;
         fi
-
-        echo "Marking setup complete"
         touch /etc/machine-id-already-setup
         '
     - creates: /etc/machine-id-already-setup


### PR DESCRIPTION
## What does this PR change?

Copying the journal log into the new journal log folder is failing for rocky8, leap 15.6, server and deblike minion.
There are two causes:
 - folder /var/log/journal doesn't exist
 - cannot copy a folder in itself

```
Moving logs to /var/log/journal/5fb2f6d9f0af9f07dab8756f6806eca3
mv: cannot move '/var/log/journal/5fb2f6d9f0af9f07dab8756f6806eca3' to a subdirectory of itself, '/var/log/journal/5fb2f6d9f0af9f07dab8756f6806eca3/5fb2f6d9f0af9f07dab8756f6806eca3'

```


Fix this issue with checking the folder journal