### PR TITLE
Enable by default the tweaks for server performance

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -928,27 +928,28 @@ module "server" {
 
 ## Large deployments
 
-In the case of the Build Validation test suite, or when trying to reproduce situations with a large number of clients, it is advised to use `large_deployment` option. This option is inspired by the documentation at https://documentation.suse.com/suma/4.3/en/suse-manager/specialized-guides/large-deployments/tuning.html, and it will apply the following settings on the server:
+By default to support the load in our test suites, when trying to reproduce situations with a large number of clients, it is advised to use `large_deployment` option.
+This option is inspired by the documentation at https://documentation.suse.com/suma/4.3/en/suse-manager/specialized-guides/large-deployments/tuning.html, and it will apply the following settings on the server:
 
 ```
 ### /etc/rhn/rhn.conf
 taskomatic.com.redhat.rhn.taskomatic.task.MinionActionExecutor.parallel_threads = 3
-hibernate.c3p0.max_size = 50
+hibernate.c3p0.max_size = 100
 
 ### /etc/tomcat/server.xml
 changed `maxThreads` to 256
 
 ### /var/lib/pgsql/data/postgresql.conf
-max_connections = 450
-work_mem = 10MB
+max_connections = 400
+work_mem = 20MB
 ```
 
-An example follows:
+An example to disable it follows:
 
 ```hcl
-module "server" {
+module "server_containerized" {
    ...
-   large_deployment = true
+   large_deployment = false
    ...
 }
 ```

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -119,7 +119,7 @@ module "server" {
   main_disk_size                  = lookup(local.main_disk_size, "server", 200)
   repository_disk_size            = lookup(local.repository_disk_size, "server", 0)
   database_disk_size              = lookup(local.database_disk_size, "server", 0)
-  large_deployment                = lookup(local.large_deployment, "server", false)
+  large_deployment                = lookup(local.large_deployment, "server", true)
   repository_disk_use_cloud_setup = lookup(local.repository_disk_use_cloud_setup, "server", false)
 }
 
@@ -162,7 +162,7 @@ module "server_containerized" {
   main_disk_size                = lookup(local.main_disk_size, "server_containerized", 200)
   repository_disk_size          = lookup(local.repository_disk_size, "server_containerized", 0)
   database_disk_size            = lookup(local.database_disk_size, "server_containerized", 0)
-  large_deployment              = lookup(local.large_deployment, "server_containerized", false)
+  large_deployment              = lookup(local.large_deployment, "server_containerized", true)
 }
 
 module "proxy" {

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -331,7 +331,7 @@ variable "c3p0_connection_debug" {
 variable "large_deployment" {
   description = "set up for a deployment with a great number of clients"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "quantity" {

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -322,5 +322,5 @@ variable "server_mounted_mirror" {
 variable "large_deployment" {
   description = "set up for a deployment with a great number of clients"
   type        = bool
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
## What does this PR change?

Enable by default the tweaks for server performance.
If we don't want this change in some particular deployment, we can manually disable it.
