### PR TITLE
Bypassing expired build key

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -52,7 +52,7 @@ systemctl enable sshd.service
 ${ gpg_keys }
 
 # Add repositories
-zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/15.6/ ca_suse
+zypper ar -G http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/15.6/ ca_suse
 
 # PRODUCT SETUP ----------------
 

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -496,9 +496,9 @@ runcmd:
   - [ transactional-update, --continue, --non-interactive, pkg, install, mgrpxy, ca-certificates-suse ]
 %{ endif }
 %{ if install_salt_bundle }
-  - [ transactional-update, --continue, --non-interactive, -G, pkg, install, -G, qemu-guest-agent, venv-salt-minion, avahi ]
+  - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, venv-salt-minion, avahi ]
 %{ else }
-  - [ transactional-update, --continue, --non-interactive, -G, pkg, install, -G, qemu-guest-agent, salt-minion, avahi ]
+  - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, salt-minion, avahi ]
 %{ endif }
   - [ reboot ]
 %{ endif }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -496,9 +496,9 @@ runcmd:
   - [ transactional-update, --continue, --non-interactive, pkg, install, mgrpxy, ca-certificates-suse ]
 %{ endif }
 %{ if install_salt_bundle }
-  - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, venv-salt-minion, avahi ]
+  - [ transactional-update, --continue, --non-interactive, -G, pkg, install, -G, qemu-guest-agent, venv-salt-minion, avahi ]
 %{ else }
-  - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, salt-minion, avahi ]
+  - [ transactional-update, --continue, --non-interactive, -G, pkg, install, -G, qemu-guest-agent, salt-minion, avahi ]
 %{ endif }
   - [ reboot ]
 %{ endif }


### PR DESCRIPTION
## What does this PR change?

Bypassing the expired key that requires a prompt. For now disabling temporarily to continue with the deployment. 
