### PR TITLE
Increase presence ping timeout on testsuite envs

### DIFF
--- a/salt/server_containerized/rhn.sls
+++ b/salt/server_containerized/rhn.sls
@@ -49,7 +49,7 @@ change_product_tree_to_beta:
 {% if grains.get('testsuite') | default(false, true) %}
 increase_presence_ping_timeout:
   cmd.run:
-    - name: mgrctl exec 'echo "presence_ping_timeout = 6" >> /etc/rhn/rhn.conf'
+    - name: mgrctl exec 'echo "java.salt_presence_ping_timeout = 6" >> /etc/rhn/rhn.conf'
 {% endif %}
 
 rhn_conf_present:

--- a/salt/server_containerized/rhn.sls
+++ b/salt/server_containerized/rhn.sls
@@ -46,6 +46,12 @@ change_product_tree_to_beta:
     - name: mgrctl exec 'grep -q "java.product_tree_tag" /etc/rhn/rhn.conf && sed -i "s/java.product_tree_tag = .*/java.product_tree_tag = Beta/" /etc/rhn/rhn.conf || echo "java.product_tree_tag = Beta" >> /etc/rhn/rhn.conf'
 {% endif %}
 
+{% if grains.get('testsuite') | default(false, true) %}
+increase_presence_ping_timeout:
+  cmd.run:
+    - name: mgrctl exec 'echo "presence_ping_timeout = 6" >> /etc/rhn/rhn.conf'
+{% endif %}
+
 rhn_conf_present:
   cmd.run:
     - name: mgrctl exec 'touch /etc/rhn/rhn.conf'


### PR DESCRIPTION
## What does this PR change?

Increase presence ping timeout on testsuite envs.
This will affect all the presence pings made by MLM server to our minions, we are tweaking this to mitigate some flaky issues. In particular, the issues we found are during the registration of a minion, but for now, we don't have a parameter to tweak only the timeout on such case.