### PR TITLE
Remove tools_pool_repo.list after bootstrap

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -545,6 +545,7 @@ runcmd:
   - "apt-get -yq update"
   - "apt-get -yq install salt-minion avahi-daemon qemu-guest-agent"
 %{ endif }
+  - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
 %{ endif }
 
@@ -590,6 +591,7 @@ runcmd:
   - "apt-get -yq update"
   - "apt-get -yq install salt-minion avahi-daemon qemu-guest-agent"
 %{ endif }
+  - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
 %{ endif }
 
@@ -640,6 +642,7 @@ runcmd:
   - "apt-get -yq update"
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq install salt-minion avahi-daemon qemu-guest-agent"
 %{ endif }
+  - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
 %{ endif } # end Ubuntu 24.04
 
@@ -687,6 +690,7 @@ runcmd:
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq update"
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq install salt-minion avahi-daemon qemu-guest-agent"
 %{ endif }
+  - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
 %{ endif }
 


### PR DESCRIPTION
## What does this PR change?
During bootstrapping, we create the `tools_pool_repo.list` on deb-based systems. However, we also define the client repo later with https://github.com/uyuni-project/sumaform/commit/5c1b1ad7ca615ee4a7919a1dac5560761d8b172e

This causes two repofiles with the same repo definition:

```
root@salt-shaker-products-testing-ubuntu2004-bundle:~# cat /etc/apt/sources.list.d/tools_pool_repo.list /etc/apt/sources.list.d/tools_update_repo.list 
deb http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/ /
deb http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04 /
```

In this PR, I clean up the bootstrap repository after bootstrap's done. 