### PR TITLE
Fix  the default value for product_version grain

### DIFF
--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -23,7 +23,7 @@ export VIRTHOST_KVM_PASSWORD="linux" {% else %}# no KVM host defined {% endif %}
 {% if grains.get('mirror') | default(false, true) %}
 export BUILD_SOURCES="{{ grains.get('mirror') }}"
 {% else %}
-{% if 'uyuni' in grains.get('product_version') | default(false, true) %}
+{% if 'uyuni' in grains.get('product_version') | default('', true) %}
 export BUILD_SOURCES="downloadcontent.opensuse.org"
 {% else %}
 export BUILD_SOURCES="dist.nue.suse.com"


### PR DESCRIPTION
## What does this PR change?

Fixes the following

```
----------
          ID: testsuite_env_vars
    Function: file.managed
        Name: /root/.bashrc
      Result: False
     Comment: Unable to manage file: Jinja error: argument of type 'bool' is not iterable
              Traceback (most recent call last):
                File "/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/salt/utils/templates.py", line 477, in render_jinja_tmpl
                  output = template.render(**decoded_context)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                File "/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/jinja2/environment.py", line 1301, in render
                  self.environment.handle_exception()
                File "/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/jinja2/environment.py", line 936, in handle_exception
                  raise rewrite_traceback_stack(source=source)
                File "<template>", line 26, in top-level template code
              TypeError: argument of type 'bool' is not iterable
              
              ; line 26
              
              ---
              [...]
              {% if grains.get('additional_network') | default(false, true) %}export PRIVATENET="{{ grains.get('additional_network') }}" {% else %}# no private network defined {% endif %}
              {% if grains.get('mirror') | default(false, true) %}export MIRROR="yes" {% else %}# no mirror used {% endif %}
              {% if grains.get('mirror') | default(false, true) %}
              export BUILD_SOURCES="{{ grains.get('mirror') }}"
              {% else %}
              {% if 'uyuni' in grains.get('product_version') | default(false, true) %}    <======================
              export BUILD_SOURCES="downloadcontent.opensuse.org"
              {% else %}
              export BUILD_SOURCES="dist.nue.suse.com"
              {% endif %}
              {% endif %}
              [...]
              ---
     Started: 10:05:55.982420
    Duration: 102.213 ms
     Changes: 
```
