### PR TITLE
QE: Removing the installation of suse-build-key package from sle microo6.0

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -190,7 +190,7 @@ zypper --non-interactive update --no-recommends iptables
 
 # WORKAROUND
 # Installing the last version of suse-build-key harcoded until it is solved
-%{ if image == "slmicro60o" || image == "slmicro61o" }
+%{ if image == "slmicro61o" }
 zypper install --from os_pool_repo suse-build-key=12.0-slfo.1.1_3.1
 %{ endif }
 


### PR DESCRIPTION

## What does this PR change?

Removing the installation of the suse-build-key package in sle micro 6.0
