### PR TITLE
Add 5.1 to CI

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -12,14 +12,15 @@ Legal values for released software are:
 - `4.3-released` (latest released maintenance update for SUSE Manager 4.3 and Tools)
 - `4.3-VM-released` (latest released maintenance update for SUSE Manager 4.3 virtual machine)
 - `5.0-released` (latest released maintenance update for SUSE Manager 5.0 and Tools)
+- `5.1-released` (latest released maintenance update for Multi Linux Manager 5.1 and Tools)
 - `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
 
 Legal values for work-in-progress software are:
 
 - `4.3-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:4.3)
 - `4.3-VM-nightly` (corresponds to the VM image in the Build Service project Devel:Galaxy:Manager:4.3)
-- `4.3-beta` (corresponds to the Build Service project SUSE:SLE-15-SP4:Update:Products:Manager43)
 - `5.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:5.0)
+- `5.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:5.1)
 - `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Head, uses SL Micro 6.1 as the base image for server)
 - `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap image)
 

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -264,86 +264,12 @@ zypper:
       enabled: true
       gpgcheck: false
       name: tools_pool_repo
-%{ if container_server || container_proxy }
-    - id: ca_suse
-      name: ca_suse
-      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP6/
-      enabled: 1
-      autorefresh: 1
-      gpgcheck: false
-    - id: containers_pool_repo
-      name: containers_pool_repo
-      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SLE-Module-Containers/15-SP6/x86_64/product/
-      enabled: 1
-      autorefresh: 1
-      gpgcheck: false
-    - id: containers_updates_repo
-      name: containers_updates_repo
-      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SLE-Module-Containers/15-SP6/x86_64/update/
-      enabled: 1
-      autorefresh: 1
-      gpgcheck: false
-%{ endif }
-%{ if container_server }
-%{ if product_version == "5.0-nightly" }
-    - id: container_utils_repo
-      name: container_utils_repo
-      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/
-      enabled: 1
-      autorefresh: 1
-      gpgcheck: false
-%{ endif }
-%{ if product_version == "5.0-released" }
-    - id: container_utils_pool_repo
-      name: container_utils_pool_repo
-      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SUSE-Manager-Server/5.0/x86_64/product
-      enabled: 1
-      autorefresh: 1
-      gpgcheck: false
-    - id: container_utils_updates_repo
-      name: container_utils_updates_repo
-      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SUSE-Manager-Server/5.0/x86_64/update
-      enabled: 1
-      autorefresh: 1
-      gpgcheck: false
-%{ endif }
-%{ endif }
-%{ if container_proxy }
-%{ if product_version == "5.0-nightly" }
-    - id: container_utils_repo
-      name: container_utils_repo
-      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/
-      enabled: 1
-      autorefresh: 1
-      gpgcheck: false
-%{ endif }
-%{ if product_version == "5.0-released" }
-    - id: container_utils_pool_repo
-      name: container_utils_pool_repo
-      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SUSE-Manager-Proxy/5.0/x86_64/product
-      enabled: 1
-      autorefresh: 1
-      gpgcheck: false
-    - id: container_utils_updates_repo
-      name: container_utils_updates_repo
-      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SUSE-Manager-Proxy/5.0/x86_64/update
-      enabled: 1
-      autorefresh: 1
-      gpgcheck: false
-%{ endif }
-%{ endif }
 
 runcmd:
 %{ if install_salt_bundle }
   - "zypper -n in venv-salt-minion avahi nss-mdns qemu-guest-agent"
 %{ else }
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
-%{ endif }
-%{ if container_server }
-  - "zypper -n in mgrctl mgradm podman ca-certificates-suse"
-%{ endif }
-%{ if container_proxy }
-  - "zypper -n in mgrpxy podman ca-certificates-suse"
 %{ endif }
 %{ endif }
 

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -84,7 +84,7 @@ variable "is_server_paygo_instance" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-nightly, 4.3-released, 4.3-pr, 4.3-beta, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-nightly, 4.3-released, 4.3-pr, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = ""
 }

--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -127,7 +127,7 @@ variable "volume_provider_settings" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/build_host/variables.tf
+++ b/modules/build_host/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -5,11 +5,10 @@ variable "testsuite-branch" {
     "4.3-pr"         = "Manager-4.3"
     "4.3-VM-released"= "Manager-4.3"
     "4.3-VM-nightly" = "Manager-4.3"
-    "4.3-beta"       = "master"
     "5.0-released"   = "Manager-5.0"
     "5.0-nightly"    = "Manager-5.0"
-    "5.1-released"   = "master"
-    "5.1-nightly"    = "master"
+    "5.1-released"   = "master"      # TODO change to "Manager-5.1"
+    "5.1-nightly"    = "master"      # as soon as the branch is created
     "head"           = "master"
     "uyuni-master"   = "master"
     "uyuni-released" = "master"

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -763,7 +763,7 @@ variable "server_instance_id" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -84,7 +84,7 @@ variable "host_settings" {
 
 // server
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -13,7 +13,7 @@ variable "roles" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -3,7 +3,6 @@ variable "images" {
     "4.3-released"   = "sles15sp4o"
     "4.3-nightly"    = "sles15sp4o"
     "4.3-pr"         = "sles15sp4o"
-    "4.3-beta"       = "sles15sp4o"
     "4.3-build_image"= "sles15sp4o"
     "4.3-VM-nightly" = "sles15sp4o"
     "4.3-VM-released"= "sles15sp4o"

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released"
   type        = string
   default     = null
 }

--- a/modules/proxy_containerized/main.tf
+++ b/modules/proxy_containerized/main.tf
@@ -3,11 +3,11 @@ variable "images" {
     "head"           = "slmicro61o"
     "5.0-released"   = "slemicro55o"
     "5.0-nightly"    = "slemicro55o"
+    "5.1-released"   = "slmicro61o"
+    "5.1-nightly"    = "slmicro61o"
     "uyuni-master"   = "leapmicro55o"
     "uyuni-released" = "leapmicro55o"
     "uyuni-pr"       = "leapmicro55o"
-    "5.1-released"   = "slmicro61o"
-    "5.1-nightly"    = "slmicro61o"
   }
 }
 

--- a/modules/proxy_containerized/variables.tf
+++ b/modules/proxy_containerized/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -3,7 +3,6 @@ variable "images" {
     "4.3-released"    = "sles15sp4o"
     "4.3-nightly"     = "sles15sp4o"
     "4.3-pr"          = "sles15sp4o"
-    "4.3-beta"        = "sles15sp4o"
     "4.3-build_image" = "sles15sp4o"
     "4.3-paygo"       = "suma-server-43-paygo"
     "4.3-VM-nightly"  = "suma43VM-ign"

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released"
   type        = string
   default     = null
 }

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -5,11 +5,11 @@ variable "images" {
     "head"           = "slmicro61o"
     "5.0-released"   = "slemicro55o"
     "5.0-nightly"    = "slemicro55o"
+    "5.1-released"   = "slmicro61o"
+    "5.1-nightly"    = "slmicro61o"
     "uyuni-master"   = "leapmicro55o"
     "uyuni-released" = "leapmicro55o"
     "uyuni-pr"       = "leapmicro55o"
-    "5.1-released"   = "slmicro61o"
-    "5.1-nightly"    = "slmicro61o"
   }
 }
 

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -33,7 +33,7 @@ variable "container_tag" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-beta, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/salt/proxy_containerized/init.sls
+++ b/salt/proxy_containerized/init.sls
@@ -43,11 +43,15 @@ ssh_config_proxy_containerized:
     {% set container_repository = 'registry.opensuse.org/systemsmanagement/uyuni/master/containers' %}
     # in Uyuni this would use latest tag
     {% set container_tag = '' %}
-  {% elif '5.0' in grains.get('product_version') and 'released' in grains.get('product_version') %}
+  {% elif '5.0-released' in grains.get('product_version') %}
     {% set container_repository = 'registry.suse.de/suse/sle-15-sp6/update/products/manager50/containerfile' %}
     # in SUMA this would use most recent version as tag
     {% set container_tag = '' %}
-  {% else %} # Head or 5.0-nightly
+  {% elif '5.1-released' in grains.get('product_version') %}
+    {% set container_repository = 'registry.suse.de/suse/sle-15-sp7/update/products/multilinuxmanager51/containerfile' %}
+    # in SUMA this would use most recent version as tag
+    {% set container_tag = '' %}
+  {% else %} # Head or nightly versions
     {% set container_repository = 'registry.suse.de/devel/galaxy/manager/head/containers' %}
     {% set container_tag = 'latest' %}
   {% endif %}

--- a/salt/repos/client_tools.sls
+++ b/salt/repos/client_tools.sls
@@ -111,6 +111,14 @@ tools_additional_repo:
     - refresh: True
     - priority: 98
 
+{% elif '5.1-nightly' in grains.get('product_version') | default('', true) %}
+
+tools_additional_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.1:/MLMTools-SLE12/images/repo/ManagerTools-SLE12-Pool-x86_64-Media1/
+    - refresh: True
+    - priority: 98
+
 {% elif 'head' in grains.get('product_version') | default('', true) %}
 
 tools_additional_repo:
@@ -188,6 +196,14 @@ tools_additional_repo:
 tools_additional_repo:
   pkgrepo.managed:
   - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.0:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
+  - refresh: True
+  - priority: 98
+
+{% elif '5.1-nightly' in grains.get('product_version') | default('', true) %}
+
+tools_additional_repo:
+  pkgrepo.managed:
+  - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.1:/MLMTools-SLE15/images/repo/ManagerTools-SLE15-Pool-x86_64-Media1/
   - refresh: True
   - priority: 98
 
@@ -282,6 +298,14 @@ tools_additional_repo:
 tools_additional_repo:
   pkgrepo.managed:
   - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.0:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/
+  - refresh: True
+  - priority: 98
+
+{% elif '5.1-nightly' in grains.get('product_version') | default('', true) %}
+
+tools_additional_repo:
+  pkgrepo.managed:
+  - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.1:/MLMTools-SLE15/images/repo/ManagerTools-SLE15-Pool-x86_64-Media1/
   - refresh: True
   - priority: 98
 
@@ -421,12 +445,26 @@ tools_update_repo:
       - cmd: suse_res7_key
     {% endif %}
 
-{% elif 'head' in grains.get('product_version') | default('', true) %}
+{% elif '5.1-nightly' in grains.get('product_version') | default('', true) %}
 
-{% set rhlike_client_tools_prefix = 'EL' %}
-{% if release < 9 %}
-{% set rhlike_client_tools_prefix = 'RES' %}
-{% endif %}
+tools_update_repo:
+  pkgrepo.managed:
+    - humanname: tools_update_repo
+{%- if release >= 8 %}
+    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.1:/MLMTools-EL{{release}}/images/repo/MultiLinuxManagerTools-EL-8-x86_64-Media1/
+{%- else %}
+    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.1:/MLMTools-EL{{release}}/images/repo/ManagerTools-EL7-POOL-x86_64-Media/
+{%- endif %}
+    - refresh: True
+    - require:
+      - cmd: galaxy_key
+    {% if release >= 9 %}
+      - cmd: suse_el9_key
+    {% else %}
+      - cmd: suse_res7_key
+    {% endif %}
+
+{% elif 'head' in grains.get('product_version') | default('', true) %}
 
 tools_update_repo:
   pkgrepo.managed:
@@ -534,6 +572,15 @@ tools_update_repo:
 {% else %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% endif %}
+{% elif '5.1-nightly' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com", true) + '/ibs/Devel:/Galaxy:/Manager:/5.1:/Ubuntu' + release + '-SUSE-Manager-Tools/xUbuntu_' + release %}
+{% elif '5.1-released' in grains.get('product_version') | default('', true) %}
+{# TODO: remove extra code when Ubuntu 24.04 tools get released #}
+{% if release == '24.04' %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com", true) + '/ibs/Devel:/Galaxy:/Manager:/5.1:/MLMTools-Ubuntu24.04/xUbuntu_24.04' %}
+{% else %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com/ibs", true) + '/SUSE/Updates/Ubuntu/' + release + '-MultiLinuxManagerTools/x86_64/update/' %}
+{% endif %}
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu' + short_release + '-Uyuni-Client-Tools/xUbuntu_' + release %}
 {% else %}
@@ -587,6 +634,21 @@ tools_update_repo_raised_priority:
             Pin: release l=SUSE:Updates:Ubuntu:{{ release }}-CLIENT-TOOLS:x86_64:update
 {%- endif %}
             Pin-Priority: 800
+{% elif '5.1-nightly' in grains.get('product_version') | default('', true) %}
+    - contents: |
+            Package: *
+            Pin: release l=Devel:Galaxy:Manager:5.1:MLMTools-Ubuntu{{ release }}
+            Pin-Priority: 800
+{% elif '5.1-released' in grains.get('product_version') | default('', true) %}
+{# TODO: remove extra code when Ubuntu 24.04 tools get released #}
+    - contents: |
+            Package: *
+{%- if release == '24.04' %}
+            Pin: release l=Devel:Galaxy:Manager:5.1:MLMTools-Ubuntu24.04
+{%- else %}
+            Pin: release l=SUSE:Updates:MultiLinuxManagerTools:Ubuntu-{{ release }}:x86_64
+{%- endif %}
+            Pin-Priority: 800
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
     - contents: |
             Package: *
@@ -614,6 +676,8 @@ tools_update_repo:
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com", true) + '/ibs/Devel:/Galaxy:/Manager:/5.0:/Debian' + release + '-SUSE-Manager-Tools/Debian_' + release %}
 {% elif '5.0-nightly' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com", true) + '/ibs/Devel:/Galaxy:/Manager:/5.0:/Debian' + release + '-SUSE-Manager-Tools/Debian_' + release %}
+{% elif '5.1-nightly' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com", true) + '/ibs/Devel:/Galaxy:/Manager:/5.1:/MLMTools-Debian' + release + '/Debian_' + release %}
 {% elif 'head' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com", true) + '/ibs/Devel:/Galaxy:/Manager:/Head:/MLMTools-Beta-Debian' + release + '/Debian_' + release %}
 {% elif 'beta' in grains.get('product_version') | default('', true) %}
@@ -624,6 +688,8 @@ tools_update_repo:
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com/ibs", true) + '/SUSE/Updates/Debian/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
 {% elif '5.0-released' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com/ibs", true) + '/SUSE/Updates/Debian/' + release + '-CLIENT-TOOLS/x86_64/update/' %}
+{% elif '5.1-released' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("dist.nue.suse.com/ibs", true) + '/SUSE/Updates/Debian/' + release + '-MultiLinuxManagerTools/x86_64/update/' %}
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Master:/Debian' + release + '-Uyuni-Client-Tools/Debian_' + release %}
 {% else %}
@@ -660,6 +726,11 @@ tools_update_repo_raised_priority:
     - contents: |
         Package: *
         Pin: release l=SUSE:Updates:Debian:{{ release }}-CLIENT-TOOLS:x86_64:update
+        Pin-Priority: 800
+{% elif '5.1-released' in grains.get('product_version') | default('', true) %}
+    - contents: |
+        Package: *
+        Pin: release l=SUSE:Updates:MultiLinuxManagerTools:Debian-{{release}}:x86_64:update
         Pin-Priority: 800
 {% elif 'uyuni-master' in grains.get('product_version') | default('', true) %}
     - contents: |

--- a/salt/repos/proxy43.sls
+++ b/salt/repos/proxy43.sls
@@ -11,12 +11,6 @@ proxy_product_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Proxy/4.3/x86_64/update/
     - refresh: True
 
-{% if 'beta' in grains['product_version'] %}
-proxy_module_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/SUSE:/SLE-15-SP4:/Update:/Products:/Manager43/images/repo/SLE-Module-SUSE-Manager-Proxy-4.3-POOL-x86_64-Media1/
-    - refresh: True
-{% else %}
 proxy_module_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Proxy/4.3/x86_64/product/
@@ -26,8 +20,6 @@ proxy_module_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Proxy/4.3/x86_64/update/
     - refresh: True
-
-{% endif %}
 
 module_server_applications_pool_repo:
   pkgrepo.managed:

--- a/salt/repos/proxy_containerized.sls
+++ b/salt/repos/proxy_containerized.sls
@@ -3,6 +3,8 @@
 include:
   {% if '5.0' in grains.get('product_version') %}
   - repos.proxy_containerized50
+  {% elif '5.1' in grains.get('product_version') %}
+  - repos.proxy_containerized51
   {%- elif 'head' in grains['product_version'] %}
   - repos.proxy_containerizedHead
   {%- else %}

--- a/salt/repos/proxy_containerized50.sls
+++ b/salt/repos/proxy_containerized50.sls
@@ -5,20 +5,66 @@
 
 {% if '5.0-released' in grains['product_version'] %}
 # Commented out because we already add this repo in cloud-init:
-# manager50_repo:
+# container_utils_pool_repo:
 #   pkgrepo.managed:
-#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SUSE-Manager-Proxy/5.0/x86_64/product
 #     - refresh: True
-#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SUSE-Manager-Proxy/5.0/x86_64/product/repodata/repomd.xml.key
+# container_utils_updates_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SUSE-Manager-Proxy/5.0/x86_64/update
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SUSE-Manager-Proxy/5.0/x86_64/update/repodata/repomd.xml.key
 {% endif %}
 
 {% if '5.0-nightly' in grains['product_version'] %}
 # Commented out because we already add this repo in cloud-init:
 # manager50_repo:
 #   pkgrepo.managed:
-#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1
 #     - refresh: True
-#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+{% endif %}
+
+{% elif grains['osfullname'] == 'SLES' %}
+ca_suse_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP6
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP6/repodata/repomd.xml.key
+
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SLE-Module-Containers/15-SP6/x86_64/product
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SLE-Module-Containers/15-SP6/x86_64/product/repodata/repomd.xml.key
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SLE-Module-Containers/15-SP6/x86_64/update
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SLE-Module-Containers/15-SP6/x86_64/update/repodata/repomd.xml.key
+
+{% if '5.0-released' in grains['product_version'] %}
+container_utils_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SUSE-Manager-Proxy/5.0/x86_64/product
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SUSE-Manager-Proxy/5.0/x86_64/product/repodata/repomd.xml.key
+
+container_utils_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SUSE-Manager-Proxy/5.0/x86_64/update
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SUSE-Manager-Proxy/5.0/x86_64/update/repodata/repomd.xml.key
+{% endif %}
+
+{% if '5.0-nightly' in grains['product_version'] %}
+container_utils_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 {% endif %}
 
 {% endif %}

--- a/salt/repos/proxy_containerized51.sls
+++ b/salt/repos/proxy_containerized51.sls
@@ -1,0 +1,75 @@
+{% if 'proxy_containerized' in grains.get('roles') %}
+
+{% if grains.get("os") == 'SUSE' %}
+{% if grains['osfullname'] == 'SL-Micro' %}
+
+{% if '5.1-released' in grains['product_version'] %}
+# Commented out because we already add this repo in cloud-init:
+# container_utils_pool_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Proxy/5.1/x86_64/product
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Proxy/5.1/x86_64/product/repodata/repomd.xml.key
+# container_utils_updates_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Proxy/5.1/x86_64/update
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Proxy/5.1/x86_64/update/repodata/repomd.xml.key
+{% endif %}
+
+{% if '5.1-nightly' in grains['product_version'] %}
+# Commented out because we already add this repo in cloud-init:
+# manager51_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.1/images/repo/Multi-Linux-Manager-Proxy-5.1-x86_64
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.1/images/repo/Multi-Linux-Manager-Proxy-5.1-x86_64/repodata/repomd.xml.key
+{% endif %}
+
+{% elif grains['osfullname'] == 'SLES' %}
+ca_suse_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP7
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP7/repodata/repomd.xml.key
+
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SLE-Module-Containers/15-SP7/x86_64/product
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SLE-Module-Containers/15-SP7/x86_64/product/repodata/repomd.xml.key
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SLE-Module-Containers/15-SP7/x86_64/update
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SLE-Module-Containers/15-SP7/x86_64/update/repodata/repomd.xml.key
+
+{% if '5.1-released' in grains['product_version'] %}
+container_utils_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Proxy-SLE/5.1/x86_64/product
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Proxy-SLE/5.1/x86_64/product/repodata/repomd.xml.key
+container_utils_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Proxy-SLE/5.1/x86_64/update
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Proxy-SLE/5.1/x86_64/update/repodata/repomd.xml.key
+{% endif %}
+
+{% if '5.1-nightly' in grains['product_version'] %}
+manager51_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.1/images-SP7/repo/Multi-Linux-Manager-Proxy-5.1-x86_64
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.1/images-SP7/repo/Multi-Linux-Manager-Proxy-5.1-x86_64/repodata/repomd.xml.key
+{% endif %}
+
+{% endif %}
+{% endif %}
+{% endif %}
+
+# WORKAROUND: see github:saltstack/salt#10852
+{{ sls }}_nop:
+  test.nop: []

--- a/salt/repos/server43.sls
+++ b/salt/repos/server43.sls
@@ -11,12 +11,6 @@ server_product_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SLE-Product-SUSE-Manager-Server/4.3/x86_64/update/
     - refresh: True
 
-{% if 'beta' in grains['product_version'] %}
-server_module_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/SUSE:/SLE-15-SP4:/Update:/Products:/Manager43/images/repo/SLE-Module-SUSE-Manager-Server-4.3-POOL-x86_64-Media1/
-    - refresh: True
-{% else %}
 server_module_pool_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SLE-Module-SUSE-Manager-Server/4.3/x86_64/product/
@@ -26,8 +20,6 @@ server_module_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SLE-Module-SUSE-Manager-Server/4.3/x86_64/update/
     - refresh: True
-
-{% endif %}
 
 module_server_applications_pool_repo:
   pkgrepo.managed:

--- a/salt/repos/server_containerized.sls
+++ b/salt/repos/server_containerized.sls
@@ -3,6 +3,8 @@
 include:
   {% if '5.0' in grains.get('product_version') %}
   - repos.server_containerized50
+  {% elif '5.1' in grains.get('product_version') %}
+  - repos.server_containerized51
   {%- elif 'head' in grains['product_version'] %}
   - repos.server_containerizedHead
   {%- else %}

--- a/salt/repos/server_containerized50.sls
+++ b/salt/repos/server_containerized50.sls
@@ -5,28 +5,72 @@
 
 {% if '5.0-released' in grains['product_version'] %}
 # Commented out because we already add this repo in cloud-init:
-# manager50_repo:
+# container_utils_pool_repo:
 #   pkgrepo.managed:
-#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SUSE-Manager-Server/5.0/x86_64/product
 #     - refresh: True
-#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE:/SLE-15-SP5:/Update:/Products:/Manager50/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SUSE-Manager-Server/5.0/x86_64/product/repodata/repomd.xml.key
+# container_utils_updates_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SUSE-Manager-Server/5.0/x86_64/update
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SUSE-Manager-Server/5.0/x86_64/update/repodata/repomd.xml.key
 {% endif %}
 
 {% if '5.0-nightly' in grains['product_version'] %}
 # Commented out because we already add this repo in cloud-init:
 # manager50_repo:
 #   pkgrepo.managed:
-#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1
 #     - refresh: True
-#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
+{% endif %}
+
+{% elif grains['osfullname'] == 'SLES' %}
+ca_suse_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP6
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP6/repodata/repomd.xml.key
+
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SLE-Module-Containers/15-SP6/x86_64/product
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SLE-Module-Containers/15-SP6/x86_64/product/repodata/repomd.xml.key
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SLE-Module-Containers/15-SP6/x86_64/update
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SLE-Module-Containers/15-SP6/x86_64/update/repodata/repomd.xml.key
+
+{% if '5.0-released' in grains['product_version'] %}
+container_utils_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SUSE-Manager-Server/5.0/x86_64/product
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SUSE-Manager-Server/5.0/x86_64/product/repodata/repomd.xml.key
+
+container_utils_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SUSE-Manager-Server/5.0/x86_64/update
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SUSE-Manager-Server/5.0/x86_64/update/repodata/repomd.xml.key
+{% endif %}
+
+{% if '5.0-nightly' in grains['product_version'] %}
+container_utils_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/repodata/repomd.xml.key
 {% endif %}
 
 {% endif %}
 {% endif %}
 {% endif %}
-
 
 # WORKAROUND: see github:saltstack/salt#10852
 {{ sls }}_nop:
   test.nop: []
-

--- a/salt/repos/server_containerized51.sls
+++ b/salt/repos/server_containerized51.sls
@@ -1,0 +1,76 @@
+{% if 'server_containerized' in grains.get('roles')  %}
+
+{% if grains.get("os") == 'SUSE' %}
+{% if grains['osfullname'] == 'SL-Micro' %}
+
+{% if '5.1-released' in grains['product_version'] %}
+# Commented out because we already add this repo in cloud-init:
+# container_utils_pool_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Server/5.1/x86_64/product
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Server/5.1/x86_64/product/repodata/repomd.xml.key
+# container_utils_updates_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Server/5.1/x86_64/update
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Server/5.1/x86_64/update/repodata/repomd.xml.key
+{% endif %}
+
+{% if '5.1-nightly' in grains['product_version'] %}
+# Commented out because we already add this repo in cloud-init:
+# manager51_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.1/images/repo/Multi-Linux-Manager-Server-5.1-x86_64
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.1/images/repo/Multi-Linux-Manager-Server-5.1-x86_64/repodata/repomd.xml.key
+{% endif %}
+
+{% elif grains['osfullname'] == 'SLES' %}
+ca_suse_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP7
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP7/repodata/repomd.xml.key
+
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SLE-Module-Containers/15-SP7/x86_64/product
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SLE-Module-Containers/15-SP7/x86_64/product/repodata/repomd.xml.key
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SLE-Module-Containers/15-SP7/x86_64/update
+    - refresh: True
+    - gpgkey: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Updates/SLE-Module-Containers/15-SP7/x86_64/update/repodata/repomd.xml.key
+
+{% if '5.1-released' in grains['product_version'] %}
+container_utils_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Server-SLE/5.1/x86_64/product
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Server-SLE/5.1/x86_64/product/repodata/repomd.xml.key
+container_utils_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Server-SLE/5.1/x86_64/update
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Server-SLE/5.1/x86_64/update/repodata/repomd.xml.key
+{% endif %}
+
+{% if '5.1-nightly' in grains['product_version'] %}
+manager51_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.1/images-SP7/repo/Multi-Linux-Manager-Server-5.1-x86_64
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/Devel:/Galaxy:/Manager:/5.1/images-SP7/repo/Multi-Linux-Manager-Server-5.1-x86_64/repodata/repomd.xml.key
+{% endif %}
+
+{% endif %}
+{% endif %}
+{% endif %}
+
+
+# WORKAROUND: see github:saltstack/salt#10852
+{{ sls }}_nop:
+  test.nop: []

--- a/salt/server/postgres.sls
+++ b/salt/server/postgres.sls
@@ -23,7 +23,7 @@ postgresql_hba_configuration:
   file.append:
     - name: /var/lib/pgsql/data/pg_hba.conf
     - text: |
-{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-pr', '4.3-released', '4.3-beta', '4.3-VM-nightly', '4.3-VM-released'] %}
+{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-pr', '4.3-released', '4.3-VM-nightly', '4.3-VM-released'] %}
         host    all     all       0.0.0.0/0      scram-sha-256
         host    all     all       ::/0           scram-sha-256
 {%- else %}


### PR DESCRIPTION
## What does this PR change?

This PR adds 5.1 to CI

Notes:

* the Ubuntu 24.04 workarounds are not ready to be removed yet
* the code for SL Micro 6.1 containerized server and proxy was already done by @maximenoel8 in `backend_modules/libvirt/host/combustion`
* this PR uses by default SL Micro 6.1 for images. We have a separate issue for allowing SLE 15 SP7 as default image.
That being said, SLE 15 SP7 is supported by this PR, you only have to force the image.
For the moment, SLE 15 SP7 as base OS is tested in dedicated "alternate" BV test suite.
* this PR moves back some code from cloud-init to `salt/repos`
* this PR also finally removes `4.3-beta`

This is the second attempt. First attempt is here: https://github.com/uyuni-project/sumaform/pull/1842.