### PR TITLE
remove aaa_base-extras from packages to be installed due to file conflicts

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -158,6 +158,8 @@ PACKAGES="$PACKAGES salt-minion"
 %{ endif }
 
 zypper --non-interactive install $PACKAGES
+# full update cause a timeout on deployment
+zypper --non-interactive update --no-recommends iptables
 
 # TEST SUITE SETUP ----------------
 
@@ -185,8 +187,6 @@ TEST_PACKAGES="$TEST_PACKAGES expect bind-utils"
 %{ endif }
 TEST_PACKAGES="$TEST_PACKAGES andromeda-dummy milkyway-dummy virgo-dummy timezone wget"
 zypper --non-interactive install $TEST_PACKAGES
-# full update cause a timeout on deployment
-zypper --non-interactive update --no-recommends iptables
 
 # WORKAROUND
 # Installing the last version of suse-build-key harcoded until it is solved

--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -183,7 +183,7 @@ TEST_PACKAGES=""
 %{ if container_server || container_proxy }
 TEST_PACKAGES="$TEST_PACKAGES expect bind-utils"
 %{ endif }
-TEST_PACKAGES="$TEST_PACKAGES andromeda-dummy milkyway-dummy virgo-dummy timezone wget aaa_base-extras"
+TEST_PACKAGES="$TEST_PACKAGES andromeda-dummy milkyway-dummy virgo-dummy timezone wget"
 zypper --non-interactive install $TEST_PACKAGES
 # full update cause a timeout on deployment
 zypper --non-interactive update --no-recommends iptables

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -413,7 +413,7 @@ runcmd:
   - [ zypper, mr, -a, -g ]
 %{ if testsuite }
   # Packages needed for the testsuite
-  - [ transactional-update, --continue, --non-interactive, pkg, install, wget, timezone, expect, aaa_base-extras, ca-certificates ]
+  - [ transactional-update, --continue, --non-interactive, pkg, install, wget, timezone, expect, ca-certificates ]
 %{ endif }
 %{ if container_server }
   - [ transactional-update, --continue, --non-interactive, pkg, install, mgrctl, mgradm, netavark, aardvark-dns, ca-certificates-suse ]


### PR DESCRIPTION
## What does this PR change?

microos-tools vs. aaa_base-extras from "Leap_pool" cause a file conflict.
Let's try to not install aaa_base-extras
