### PR TITLE
`salt_testenv`: Enable Tumbleweed deployments and clean up

### DIFF
--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -1,6 +1,6 @@
 #cloud-config
 
-%{ if public_instance == "false" }
+%{ if public_instance == "false" ~}
 #disable_root: false
 disable_root: false
 ssh_pwauth: true
@@ -8,25 +8,25 @@ chpasswd:
   expire: false
   list: |
     root:linux
-%{ endif }
+%{ endif ~}
 
-%{ if image == "opensuse156o" }
+%{ if image == "opensuse156o" ~}
 # WORKAROUND: install latest libzypp to prevent signature verification errors
 runcmd:
   - zypper addrepo -G -e http://download.opensuse.org/update/leap/15.6/oss/ os_update
   - zypper addrepo -G -e http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/ client_tools_tmp
   - zypper ref
   - zypper up --allow-vendor-change --no-confirm libzypp
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - zypper in --allow-vendor-change --no-confirm venv-salt-minion
-%{ else }
+%{ else ~}
   - zypper up --allow-vendor-change --no-confirm salt-minion
-%{ endif }
+%{ endif ~}
   - zypper removerepo --all
 
-%{ endif }
+%{ endif ~}
 
-%{ if image == "sles15" }
+%{ if image == "sles15" ~}
 zypper:
   repos:
     - id: os_pool_repo
@@ -36,9 +36,9 @@ zypper:
       autorefresh: 1
 
 packages: ["salt-minion"]
-%{ endif }
+%{ endif ~}
 
-%{ if image == "sles15sp4o" || image == "sles15sp5o" || image == "sles15sp6o" }
+%{ if image == "sles15sp4o" || image == "sles15sp5o" || image == "sles15sp6o" ~}
 runcmd:
   - zypper addrepo -G -e http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products/SLE_15/ salt_test
   - zypper ref
@@ -47,14 +47,14 @@ runcmd:
 
 packages: ["salt-minion"]
 
-%{ endif }
+%{ endif ~}
 
-%{ if image == "sles15sp5-paygo" || image == "sles12sp5-paygo" || image == "slesforsap15sp5-paygo" || image == "sles15sp6-paygo" }
+%{ if image == "sles15sp5-paygo" || image == "sles12sp5-paygo" || image == "slesforsap15sp5-paygo" || image == "sles15sp6-paygo" ~}
 packages: ["salt-minion"]
 
-%{ endif }
+%{ endif ~}
 
-%{ if image == "sles12sp5" }
+%{ if image == "sles12sp5" ~}
 zypper:
   repos:
     - id: tools_pool_repo
@@ -64,9 +64,9 @@ zypper:
       name: tools_pool_repo
 
 packages: ["venv-salt-minion"]
-%{ endif }
+%{ endif ~}
 
-%{ if image == "rhel9" }
+%{ if image == "rhel9" ~}
 yum_repos:
   # repo for salt
   temp_tools_pool_repo:
@@ -82,8 +82,8 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
 
-%{ endif }
-%{ if image == "rhel8" }
+%{ endif ~}
+%{ if image == "rhel8" ~}
 yum_repos:
   # repo for salt
   temp_tools_pool_repo:
@@ -94,9 +94,9 @@ yum_repos:
     name: temp_tools_pool_repo
 
 packages: ["venv-salt-minion", "dbus-tools"]
-%{ endif }
+%{ endif ~}
 
-%{ if image == "rocky8" }
+%{ if image == "rocky8" ~}
 runcmd:
   - |
     cat <<EOF > /etc/yum.repos.d/temp_tools_pool_repo.repo
@@ -110,9 +110,9 @@ runcmd:
   - yum clean all
   - yum repolist
   - dnf -y install venv-salt-minion
-%{ endif }
+%{ endif ~}
 
-%{ if image == "centos7" || image == "rhel7" }
+%{ if image == "centos7" || image == "rhel7" ~}
 yum_repos:
   # repo for salt
   temp_tools_pool_repo:
@@ -123,9 +123,9 @@ yum_repos:
     name: temp_tools_pool_repo
 
 packages: ["venv-salt-minion"]
-%{ endif }
+%{ endif ~}
 
-%{ if image == "ubuntu2404" }
+%{ if image == "ubuntu2404" ~}
 apt:
   sources:
     tools_pool_repo:
@@ -162,9 +162,9 @@ runcmd:
   - systemctl restart ssh
 
 packages: ["venv-salt-minion"]
-%{ endif }
+%{ endif ~}
 
-%{ if image == "ubuntu2204" }
+%{ if image == "ubuntu2204" ~}
 apt:
   sources:
     tools_pool_repo:
@@ -201,9 +201,9 @@ runcmd:
 
 
 packages: ["venv-salt-minion"]
-%{ endif }
+%{ endif ~}
 
-%{ if image == "ubuntu2004" }
+%{ if image == "ubuntu2004" ~}
 apt:
   sources:
     tools_pool_repo:
@@ -239,5 +239,5 @@ runcmd:
   - systemctl restart sshd
 
 packages: ["venv-salt-minion"]
-%{ endif }
+%{ endif ~}
 

--- a/backend_modules/azure/host/user_data.yaml
+++ b/backend_modules/azure/host/user_data.yaml
@@ -1,6 +1,6 @@
 #cloud-config
 
-%{ if public_instance == "false" }
+%{ if public_instance == "false" ~}
 #disable_root: false
 disable_root: false
 ssh_pwauth: true
@@ -8,54 +8,54 @@ chpasswd:
   expire: false
   list: |
     root:linux
-%{ endif }
+%{ endif ~}
 
-%{ if image == "opensuse154o" }
+%{ if image == "opensuse154o" ~}
 runcmd:
   # WORKAROUND: this package should not be in any image, as it is internal to OBS. To be removed when new images ship without it
   - zypper rm -y gettext-runtime-mini
   # WORKAROUND: instance might already have some repos that end up conflicting with the ones we want to install.
   # Possible bug in zypper's Salt module
   - zypper removerepo --all
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - zypper in --allow-vendor-change --no-confirm venv-salt-minion
-%{ else }
+%{ else ~}
   - zypper up --allow-vendor-change --no-confirm salt-minion
-%{ endif }
+%{ endif ~}
 
-%{ endif }
+%{ endif ~}
 
-%{ if image == "opensuse155o" }
+%{ if image == "opensuse155o" ~}
 runcmd:
   # WORKAROUND: this package should not be in any image, as it is internal to OBS. To be removed when new images ship without it
   - zypper rm -y gettext-runtime-mini
   # WORKAROUND: instance might already have some repos that end up conflicting with the ones we want to install.
   # Possible bug in zypper's Salt module
   - zypper removerepo --all
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - zypper in --allow-vendor-change --no-confirm venv-salt-minion
-%{ else }
+%{ else ~}
   - zypper up --allow-vendor-change --no-confirm salt-minion
-%{ endif }
+%{ endif ~}
 
-%{ endif }
+%{ endif ~}
 
-%{ if image == "opensuse156o" }
+%{ if image == "opensuse156o" ~}
 runcmd:
   # WORKAROUND: this package should not be in any image, as it is internal to OBS. To be removed when new images ship without it
   - zypper rm -y gettext-runtime-mini
   # WORKAROUND: instance might already have some repos that end up conflicting with the ones we want to install.
   # Possible bug in zypper's Salt module
   - zypper removerepo --all
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - zypper in --allow-vendor-change --no-confirm venv-salt-minion
-%{ else }
+%{ else ~}
   - zypper up --allow-vendor-change --no-confirm salt-minion
-%{ endif }
+%{ endif ~}
 
-%{ endif }
+%{ endif ~}
 
-%{ if image == "sles15sp2o" }
+%{ if image == "sles15sp2o" ~}
 zypper:
   repos:
     - id: salt_qubes_build
@@ -66,9 +66,9 @@ zypper:
 
 packages: ["salt-minion"]
 
-%{ endif }
+%{ endif ~}
 
-%{ if image == "sles15sp3o" }
+%{ if image == "sles15sp3o" ~}
 zypper:
   repos:
     - id: salt_qubes_build
@@ -79,9 +79,9 @@ zypper:
 
 packages: ["salt-minion"]
 
-%{ endif }
+%{ endif ~}
 
-%{ if image == "sles15sp4o" }
+%{ if image == "sles15sp4o" ~}
 zypper:
   repos:
     - id: salt_qubes_build
@@ -92,9 +92,9 @@ zypper:
 
 packages: ["salt-minion"]
 
-%{ endif }
+%{ endif ~}
 
-%{ if image == "sles15sp5o" }
+%{ if image == "sles15sp5o" ~}
 zypper:
   repos:
     - id: salt_qubes_build
@@ -105,9 +105,9 @@ zypper:
 
 packages: ["salt-minion"]
 
-%{ endif }
+%{ endif ~}
   
-%{ if image == "sles15sp6o" }
+%{ if image == "sles15sp6o" ~}
 zypper:
   repos:
     - id: salt_qubes_build
@@ -118,9 +118,9 @@ zypper:
 
 packages: ["salt-minion"]
 
-%{ endif }
+%{ endif ~}
   
-%{ if image == "rhel9" }
+%{ if image == "rhel9" ~}
 yum_repos:
   # repo for salt
   temp_tools_pool_repo:
@@ -132,8 +132,8 @@ yum_repos:
     priority: 98
 
 packages: ["salt-minion"]
-%{ endif }
-%{ if image == "rhel8" }
+%{ endif ~}
+%{ if image == "rhel8" ~}
 yum_repos:
   # repo for salt
   temp_tools_pool_repo:
@@ -145,8 +145,8 @@ yum_repos:
     priority: 98
 
 packages: ["salt-minion"]
-%{ endif }
-%{ if image == "centos7" || image == "rhel7" }
+%{ endif ~}
+%{ if image == "centos7" || image == "rhel7" ~}
 yum_repos:
   # repo for salt
   temp_tools_pool_repo:
@@ -158,9 +158,9 @@ yum_repos:
     priority: 98
 
 packages: ["salt-minion"]
-%{ endif }
+%{ endif ~}
 
-%{ if image == "ubuntu2004" }
+%{ if image == "ubuntu2004" ~}
 
 apt:
   sources:
@@ -195,9 +195,9 @@ runcmd:
   - systemctl restart sshd
 
 packages: ["salt-minion"]
-%{ endif }
+%{ endif ~}
 
-%{ if image == "ubuntu2204" }
+%{ if image == "ubuntu2204" ~}
 
 apt:
   sources:
@@ -232,9 +232,9 @@ runcmd:
   - systemctl restart sshd
 
 packages: ["salt-minion"]
-%{ endif }
+%{ endif ~}
 
-%{ if image == "ubuntu2404" }
+%{ if image == "ubuntu2404" ~}
 
 apt:
   sources:
@@ -269,4 +269,4 @@ runcmd:
   - systemctl restart sshd
 
 packages: ["salt-minion"]
-%{ endif }
+%{ endif ~}

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -17,11 +17,11 @@ zypper:
       name: tools_pool_repo
 
 runcmd:
-  - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
-  - systemctl restart sshd
   # For openSUSE Tumbleweed venv-salt-minion is not available.
   # The goal is to be able to run Salt Shaker tests for the classic Salt package in Tumbleweed.
-  - "zypper -n in salt salt-minion avahi avahi-lang"
+  # openssh-server-config-rootlogin is required due to SELinux
+  - "zypper -n in salt salt-minion avahi avahi-lang openssh-server-config-rootlogin"
+  - systemctl restart sshd
 %{endif}
 
 %{ if image == "centos7o" }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -7,7 +7,7 @@ chpasswd:
   list: |
      root:linux
 
-%{ if image == "tumbleweedo" }
+%{ if image == "tumbleweedo" ~}
 zypper:
   repos:
     - id: tools_pool_repo
@@ -24,7 +24,7 @@ runcmd:
   - systemctl restart sshd
 %{endif}
 
-%{ if image == "centos7o" }
+%{ if image == "centos7o" ~}
 bootcmd:
   # HACK: mirrorlist.centos.org doesn't exist anymore
   - sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
@@ -50,14 +50,14 @@ yum_repos:
     name: epel
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "yum -y install venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "yum -y install salt-minion avahi nss-mdns qemu-guest-agent"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "centos8o" }
+%{ if image == "centos8o" ~}
 bootcmd:
   # WORKAROUND: yum_repos state cant replace a repo, so we need to delete it,
   # otherwise the workaround for archived repo doesn't work
@@ -91,14 +91,14 @@ yum_repos:
     name: CentOS-AppStream_backup
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "centos9o" }
+%{ if image == "centos9o" ~}
 bootcmd:
   # WORKAROUND: yum_repos state cant replace a repo, so we need to delete it,
   # otherwise the workaround for archived repo doesn't work
@@ -132,14 +132,14 @@ yum_repos:
     name: CentOS-AppStream_backup
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "opensuse155o" || image == "opensuse156o" || image == "opensuse155-ci-pro" }
+%{ if image == "opensuse155o" || image == "opensuse156o" || image == "opensuse155-ci-pro" ~}
 zypper:
   repos:
     - id: tools_pool_repo
@@ -149,19 +149,19 @@ zypper:
       name: tools_pool_repo
 
 runcmd:
-%{ if container_server && testsuite }
+%{ if container_server && testsuite ~}
   # Packages needed for the testsuite
   - "zypper -n in expect"
-%{ endif }
-%{ if install_salt_bundle }
+%{ endif ~}
+%{ if install_salt_bundle ~}
   - "zypper -n in venv-salt-minion avahi nss-mdns"
-%{ else }
+%{ else ~}
   - "zypper -n in avahi nss-mdns"
-%{ endif }
+%{ endif ~}
   - "zypper removerepo --all"
-%{ endif }
+%{ endif ~}
 
-%{ if image == "sles12sp5o" }
+%{ if image == "sles12sp5o" ~}
 zypper:
   repos:
     - id: os_pool_repo
@@ -176,14 +176,14 @@ zypper:
       name: tools_pool_repo
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "zypper -n in venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "sles15sp3o" }
+%{ if image == "sles15sp3o" ~}
 zypper:
   repos:
     - id: os_pool_repo
@@ -198,16 +198,16 @@ zypper:
       name: tools_pool_repo
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "zypper -n in venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
-%{ endif }
+%{ endif ~}
   # WORKAROUND: cloud-init in SLES 15 SP3 does not take care of the following
   - "systemctl start 'qemu-ga@virtio\\x2dports-org.qemu.guest_agent.0'"
-%{ endif }
+%{ endif ~}
 
-%{ if image == "sles15sp4o" }
+%{ if image == "sles15sp4o" ~}
 zypper:
   repos:
     - id: os_pool_repo
@@ -222,14 +222,14 @@ zypper:
       name: tools_pool_repo
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "zypper -n in venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "sles15sp5o" }
+%{ if image == "sles15sp5o" ~}
 zypper:
   repos:
     - id: os_pool_repo
@@ -244,14 +244,14 @@ zypper:
       name: tools_pool_repo
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "zypper -n in venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "sles15sp6o" }
+%{ if image == "sles15sp6o" ~}
 zypper:
   repos:
     - id: os_pool_repo
@@ -266,14 +266,14 @@ zypper:
       name: tools_pool_repo
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "zypper -n in venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "sles15sp7o" }
+%{ if image == "sles15sp7o" ~}
 zypper:
   repos:
     - id: os_pool_repo
@@ -288,37 +288,37 @@ zypper:
       name: tools_pool_repo
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "zypper -n in venv-salt-minion avahi avahi-lang nss-mdns qemu-guest-agent iptables"
-%{ else }
+%{ else ~}
   - "zypper -n in avahi avahi-lang nss-mdns qemu-guest-agent iptables"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "slemicro55o" }
+%{ if image == "slemicro55o" ~}
 
-write_files: ${ files }
+write_files: ${ files ~}
 
 zypper:
   repos:
-%{ if container_server }
-%{ if product_version == "head" }
+%{ if container_server ~}
+%{ if product_version == "head" ~}
     - id: container_utils_repo
       name: container_utils_repo
       baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Server-5.1-x86_64/
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-%{ endif }
-%{ if product_version == "5.0-nightly" }
+%{ endif ~}
+%{ if product_version == "5.0-nightly" ~}
     - id: container_utils_repo
       name: container_utils_repo
       baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Server-5.0-POOL-x86_64-Media1/
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-%{ endif }
-%{ if product_version == "5.0-released" }
+%{ endif ~}
+%{ if product_version == "5.0-released" ~}
     - id: container_utils_pool_repo
       name: container_utils_pool_repo
       baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SUSE-Manager-Server/5.0/x86_64/product
@@ -331,10 +331,10 @@ zypper:
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-%{ endif }
-%{ endif }
-%{ if container_proxy }
-%{ if product_version == "head" }
+%{ endif ~}
+%{ endif ~}
+%{ if container_proxy ~}
+%{ if product_version == "head" ~}
     - id: container_utils_repo
       name: container_utils_repo
 #      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/SLE-Micro55/
@@ -342,16 +342,16 @@ zypper:
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-%{ endif }
-%{ if product_version == "5.0-nightly" }
+%{ endif ~}
+%{ if product_version == "5.0-nightly" ~}
     - id: container_utils_repo
       name: container_utils_repo
       baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/5.0/images/repo/SUSE-Manager-Proxy-5.0-POOL-x86_64-Media1/
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-%{ endif }
-%{ if product_version == "5.0-released" }
+%{ endif ~}
+%{ if product_version == "5.0-released" ~}
     - id: container_utils_pool_repo
       name: container_utils_pool_repo
       baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/SUSE/Products/SUSE-Manager-Proxy/5.0/x86_64/product
@@ -364,9 +364,9 @@ zypper:
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-%{ endif }
-%{ endif }
-%{ if testsuite }
+%{ endif ~}
+%{ endif ~}
+%{ if testsuite ~}
     # Required only for wget
     - id: os_pool_repo
       name: os_pool_repo
@@ -374,7 +374,7 @@ zypper:
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-%{ endif }
+%{ endif ~}
     - id: ca_suse
       name: ca_suse
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/SUSE:/CA/SLE_15_SP5/
@@ -399,37 +399,37 @@ zypper:
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-%{ for name, url in jsondecode(additional_repos) }
+%{ for name, url in jsondecode(additional_repos) ~}
     - id: ${name}_repo
       name: ${name}_repo
       baseurl: ${url}
       enabled: 1
       autorefresh: 1
       gpgcheck: false
-%{ endfor }
+%{ endfor ~}
 
 runcmd:
   - [transactional-update, run, sh, -c, "for key in $(ls /etc/gpg_keys); do rpm --import /etc/gpg_keys/$key; done" ]
   - [ zypper, mr, -a, -g ]
-%{ if testsuite }
+%{ if testsuite ~}
   # Packages needed for the testsuite
   - [ transactional-update, --continue, --non-interactive, pkg, install, wget, timezone, expect, ca-certificates ]
-%{ endif }
-%{ if container_server }
+%{ endif ~}
+%{ if container_server ~}
   - [ transactional-update, --continue, --non-interactive, pkg, install, mgrctl, mgradm, netavark, aardvark-dns, ca-certificates-suse ]
-%{ endif }
-%{ if container_proxy }
+%{ endif ~}
+%{ if container_proxy ~}
   - [ transactional-update, --continue, --non-interactive, pkg, install, mgrpxy, ca-certificates-suse ]
-%{ endif }
-%{ if install_salt_bundle }
+%{ endif ~}
+%{ if install_salt_bundle ~}
   - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, venv-salt-minion, avahi ]
-%{ else }
+%{ else ~}
   - [ transactional-update, --continue, --non-interactive, pkg, install, qemu-guest-agent, salt-minion, avahi ]
-%{ endif }
+%{ endif ~}
   - [ reboot ]
-%{ endif }
+%{ endif ~}
 
-%{ if image == "ubuntu2004o" }
+%{ if image == "ubuntu2004o" ~}
 
 apt:
   sources:
@@ -464,18 +464,18 @@ runcmd:
   # WORKAROUND: disable IPv6 until we have it in Provo
   - echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4
   - systemctl restart sshd
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "apt-get -yq update"
   - "apt-get -yq install venv-salt-minion avahi-daemon qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "apt-get -yq update"
   - "apt-get -yq install salt-minion avahi-daemon qemu-guest-agent"
-%{ endif }
+%{ endif ~}
   - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
-%{ endif }
+%{ endif ~}
 
-%{ if image == "ubuntu2204o" }
+%{ if image == "ubuntu2204o" ~}
 
 apt:
   sources:
@@ -510,18 +510,18 @@ runcmd:
   # WORKAROUND: disable IPv6 until we have it in Provo
   - echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4
   - systemctl restart sshd
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "apt-get -yq update"
   - "apt-get -yq install venv-salt-minion avahi-daemon qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "apt-get -yq update"
   - "apt-get -yq install salt-minion avahi-daemon qemu-guest-agent"
-%{ endif }
+%{ endif ~}
   - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
-%{ endif }
+%{ endif ~}
 
-%{ if image == "ubuntu2404o" }
+%{ if image == "ubuntu2404o" ~}
 
 apt:
   sources:
@@ -561,18 +561,18 @@ runcmd:
   # WORKAROUND: disable IPv6 until we have it in Provo
   - echo 'Acquire::ForceIPv4 "true";' > /etc/apt/apt.conf.d/99force-ipv4
   - systemctl restart sshd
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "apt-get -yq update"
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq install venv-salt-minion avahi-daemon qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "apt-get -yq update"
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq install salt-minion avahi-daemon qemu-guest-agent"
-%{ endif }
+%{ endif ~}
   - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
 %{ endif } # end Ubuntu 24.04
 
-%{ if image == "debian12o" }
+%{ if image == "debian12o" ~}
 apt:
   sources:
     tools_pool_repo:
@@ -609,18 +609,18 @@ runcmd:
   # HACK: cloud-init in Debian 12 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq update"
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq install venv-salt-minion avahi-daemon qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq update"
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq install salt-minion avahi-daemon qemu-guest-agent"
-%{ endif }
+%{ endif ~}
   - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
-%{ endif }
+%{ endif ~}
 
-%{ if image == "almalinux8o" }
+%{ if image == "almalinux8o" ~}
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -637,14 +637,14 @@ yum_repos:
     name: epel
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "almalinux9o" }
+%{ if image == "almalinux9o" ~}
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -664,14 +664,14 @@ runcmd:
   # WORKAROUND: cloud-init in Alma 9 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent dbus-tools"
-%{ else }
+%{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent dbus-tools"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "amazonlinux2o" }
+%{ if image == "amazonlinux2o" ~}
 
 yum_repos:
   # repo for salt
@@ -691,14 +691,14 @@ yum_repos:
     name: epel
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "amazonlinux2023o" }
+%{ if image == "amazonlinux2023o" ~}
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -725,15 +725,15 @@ runcmd:
   # WORKAROUND: cloud-init in Amazon Linux 2023 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
-%{ endif }
+%{ endif ~}
   - systemctl start qemu-guest-agent
-%{ endif }
+%{ endif ~}
 
-%{ if image == "libertylinux9o" }
+%{ if image == "libertylinux9o" ~}
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -761,9 +761,9 @@ runcmd:
   - systemctl restart sshd
   - dnf -y install venv-salt-minion
 
-%{ endif }
+%{ endif ~}
 
-%{ if image == "openeuler2403o" }
+%{ if image == "openeuler2403o" ~}
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -783,7 +783,7 @@ runcmd:
   - systemctl start qemu-guest-agent
 %{ endif }
 
-%{ if image == "rocky8o" }
+%{ if image == "rocky8o" ~}
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -801,14 +801,14 @@ yum_repos:
 
 runcmd:
   - "dnf -y check-update"
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns dbus-tools"
-%{ else }
+%{ else ~}
   - "dnf -y install avahi nss-mdns salt-minion dbus-tools"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "rocky9o" }
+%{ if image == "rocky9o" ~}
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -828,14 +828,14 @@ runcmd:
   # WORKAROUND: cloud-init in Rocky 9 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns dbus-tools"
-%{ else }
+%{ else ~}
   - "dnf -y install avahi nss-mdns salt-minion dbus-tools"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "oraclelinux8o" }
+%{ if image == "oraclelinux8o" ~}
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -852,14 +852,14 @@ yum_repos:
     name: epel
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent"
-%{ else }
+%{ else ~}
   - "dnf -y install avahi nss-mdns qemu-guest-agent salt-minion"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "oraclelinux9o" }
+%{ if image == "oraclelinux9o" ~}
 yum_repos:
   # repo for salt
   tools_pool_repo:
@@ -879,14 +879,14 @@ runcmd:
   # WORKAROUND: cloud-init in Oracle 9 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent dbus-tools tar"
-%{ else }
+%{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent dbus-tools tar"
-%{ endif }
-%{ endif }
+%{ endif ~}
+%{ endif ~}
 
-%{ if image == "opensuse155armo" || image == "opensuse156armo" }
+%{ if image == "opensuse155armo" || image == "opensuse156armo" ~}
 zypper:
   repos:
     - id: tools_pool_repo
@@ -896,17 +896,17 @@ zypper:
       name: tools_pool_repo
 
 runcmd:
-%{ if install_salt_bundle }
+%{ if install_salt_bundle ~}
   - "zypper -n in venv-salt-minion"
-%{ else }
+%{ else ~}
   - "zypper -n in salt-minion"
-%{ endif }
+%{ endif ~}
   - "zypper removerepo --all"
-%{ endif }
+%{ endif ~}
 
-%{ if image == "opensuse156armo" }
+%{ if image == "opensuse156armo" ~}
 runcmd:
   # WORKAROUND: cloud-init in opensuse156 does not take care of the following
   - echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/root.conf
   - systemctl restart sshd.service
-%{ endif }
+%{ endif ~}

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -11,16 +11,14 @@ chpasswd:
 zypper:
   repos:
     - id: tools_pool_repo
-      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/saltstack/openSUSE_Tumbleweed/
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/saltstack:/bundle:/openSUSE_Tumbleweed/openSUSE_Tumbleweed/
       enabled: true
       gpgcheck: false
       name: tools_pool_repo
 
 runcmd:
-  # For openSUSE Tumbleweed venv-salt-minion is not available.
-  # The goal is to be able to run Salt Shaker tests for the classic Salt package in Tumbleweed.
-  # openssh-server-config-rootlogin is required due to SELinux
-  - "zypper -n in salt salt-minion avahi avahi-lang openssh-server-config-rootlogin"
+   # openssh-server-config-rootlogin is required to allow ssh root login with SELinux enabled
+  - zypper --non-interactive install venv-salt-minion avahi avahi-lang openssh-server-config-rootlogin
   - systemctl restart sshd
 %{endif}
 

--- a/salt/repos/disable_local.sls
+++ b/salt/repos/disable_local.sls
@@ -1,4 +1,4 @@
-{% if 'paygo' not in grains.get('product_version') | default('', true) %}
+{% if 'paygo' not in grains.get('product_version') | default('', true) and grains.get("osfullname") != "openSUSE Tumbleweed" %}
 disable_all_local_repos:
   cmd.run:
     - name: zypper mr -d --all

--- a/salt/salt_testenv/init.sls
+++ b/salt/salt_testenv/init.sls
@@ -1,42 +1,10 @@
 include:
   - default
-{% if grains['osfullname'] == 'SLES' and grains['osrelease_info'][0] == 15 %}
+{% if grains['osfullname'] != 'openSUSE Tumbleweed' %}
+  - .salt_bundle_package
+{% endif %}
+{% if (grains['osfullname'] in ['SL-Micro', 'Leap', 'openSUSE Tumbleweed']
+       or (grains['osfullname'] == 'SLES' and grains['osrelease_info'][0] == 15)) %}
   - .salt_classic_package
-  - .salt_bundle_package
-{% elif grains['osfullname'] == 'SLES' and grains['osrelease_info'][0] == 12 %}
-  - .salt_bundle_package
-{% elif grains['osfullname'] == 'SL-Micro' %}
-  - .salt_classic_package
-  - .salt_bundle_package
-{% elif grains['osfullname'] == 'Leap' %}
-  - .salt_classic_package
-  - .salt_bundle_package
-{% elif grains['osfullname'] == 'openSUSE Tumbleweed' %}
-  - .salt_classic_package
-{% elif grains['os'] == 'Debian' %}
-  {% if grains['osrelease'] == '10' %}
-  - .salt_classic_package
-  - .salt_bundle_package
-  {% else %}
-  - .salt_bundle_package
-  {% endif %}
-{% elif grains['osfullname'] == 'Ubuntu' %}
-  {% if grains['osrelease'] == '20.04' %}
-  - .salt_classic_package
-  - .salt_bundle_package
-  {% else %}
-  - .salt_bundle_package
-  {% endif %}
-{% elif grains['osfullname'] == 'AlmaLinux' %}
-  {% if grains['osrelease_info'][0] == 8 %}
-  - .salt_classic_package
-  - .salt_bundle_package
-  {% else %}
-  - .salt_bundle_package
-  {% endif %}
-{% elif grains['osfullname'] == 'CentOS Linux' %}
-  - .salt_bundle_package
-{% else %}
-    {{ raise("Salt Shaker unsupported OS") }}
 {% endif %}
   - .postinstallation

--- a/salt/salt_testenv/lib.sls
+++ b/salt/salt_testenv/lib.sls
@@ -1,0 +1,48 @@
+{# Collection of macros to simplify SLS files #}
+
+{# Build repository url for a SLE 15 Module.
+
+Args:
+  module: name of SLE 15 module. If the name consists of multiple words,
+    they should be separated by an underscore. Names in UPPERCASE are kept as they are.
+    Examples: development_tools, containers, HPC
+  default_mirror: mirror to use when no mirror is configured via grains
+  product: boolean to indicate "product" or "updates" repository
+#}
+{% macro sle15_module_repourl(module, default_mirror, product) -%}
+{# REVIEW: why is |default needed? -#}
+{% set mirror = grains.get("mirror")|default(default_mirror, true) -%}
+{% if product -%}
+{% set suse_base_path = "SUSE/" ~ "Products" -%}
+{% else -%}
+{% set suse_base_path = "SUSE/" ~ "Updates" -%}
+{% endif -%}
+{% set sle_version = "15" if grains["osrelease"] == 15 else "15-SP" ~ grains["osrelease_info"][1] -%}
+{% set repo_path = "product" if product else "update" -%}
+{% if module is upper -%}
+{% set sle_module = "SLE-Module-" ~ module -%}
+{% else -%}
+{% set sle_module = "SLE-Module-" ~ module.split("_")|map("capitalize")|join("-") -%}
+{% endif -%}
+http://{{mirror}}/{{suse_base_path}}/{{sle_module}}/{{sle_version}}/x86_64/{{repo_path}}/
+{%- endmacro %}
+
+{# SLE 15 Module repositories block.
+
+Includes two repositories, one for "pool" and one for "updates".
+Args:
+  module: name of SLE 15 module. If the name consists of multiple words,
+    they should be separated by an underscore. Example: development_tools
+  default_mirror: mirror to use when no mirror is configured via grains
+#}
+{% macro sle15_module_repos(module, default_mirror) -%}
+{{module}}_repo_pool:
+  pkgrepo.managed:
+    - baseurl: {{ sle15_module_repourl(module, default_mirror, True) }}
+    - refresh: true
+
+{{module}}_repo_updates:
+  pkgrepo.managed:
+    - baseurl: {{ sle15_module_repourl(module, default_mirror, False) }}
+    - refresh: true
+{% endmacro -%}

--- a/salt/salt_testenv/salt_classic_package.sls
+++ b/salt/salt_testenv/salt_classic_package.sls
@@ -1,138 +1,160 @@
-{% if grains['os'] == 'SUSE' %}
+{% from "salt_testenv/lib.sls" import sle15_module_repos with context -%}
 
-{% if grains['osfullname'] == 'SLES' and grains['osrelease_info'][0] == 15 %}
-{% set repo_path = "15" if grains["osrelease"] == 15 else "15-SP" + grains["osrelease_info"][1]|string %}
-development_tools_repo_pool:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SLE-Module-Development-Tools/{{ repo_path }}/x86_64/product/
-    - refresh: True
+{% if grains["os"] != "SUSE" -%}
+  {{ raise("Incompatible OS, this state only works on openSUSE/SUSE distributions.")}}
+{% endif  -%}
 
-development_tools_repo_updates:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SLE-Module-Development-Tools/{{ repo_path }}/x86_64/update/
-    - refresh: True
+## Repos
 
-# needed for libhttp_parser_2_7_1, dependency of libgit2
-sle_module_hpc_repo_pool:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SLE-Module-HPC/{{ repo_path }}/x86_64/product/
-    - refresh: True
+{# SLE 15 -#}
+{% if grains["osfullname"] == "SLES" -%}
+{# hpc is needed for libhttp_parser_2_7_1, required by libgit2 -#}
+{% for module in ["development_tools", "HPC", "containers" ] -%}
+{{ sle15_module_repos(module, "dist.nue.suse.com/ibs") }}
+{% endfor -%}
+{% if grains["osrelease_info"][1]|int >= 6 -%}
+{% for module in ["python3", "systems_management"] -%}
+{{ sle15_module_repos(module, "dist.nue.suse.com/ibs") }}
+{% endfor -%}
+{% endif -%}
 
-sle_module_hpc_repo_updates:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SLE-Module-HPC/{{ repo_path }}/x86_64/update/
-    - refresh: True
+{% if grains["osrelease"] == 15 -%}
+  {% set repo_path = "15" -%}
+{% else -%}
+  {% if grains["osrelease_info"][1]|int >= 3 -%}
+  {% set repo_path = "15." ~ grains["osrelease_info"][1] -%}
+  {% else -%}
+  {% set repo_path = "15-SP" ~ grains["osrelease_info"][1] -%}
+  {% endif -%}
+{% endif -%}
 
-containers_pool_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SLE-Module-Containers/{{ repo_path }}/x86_64/product/
-    - refresh: True
+{#- Leap -#}
+{%- elif grains["osfullname"] == "Leap"-%}
+{% set repo_path = grains["osrelease"] -%}
 
-containers_updates_repo:
-  pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/{{ repo_path }}/x86_64/update/
-    - refresh: True
-
-{% if grains['osrelease_info'][1] >= 3 %}
-{% set repo_path = grains["osrelease"] %}
-{% else %}
-{% set repo_path = "SLE_15_SP" + grains["osrelease_info"][1]|string %}
-{% endif %}
-
-{% endif %}
-
-remove_old_salt:
-  cmd.run:
-{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
-    - name: transactional-update -c -n pkg remove python3-salt; exit 0
-{% else %}
-    - name: zypper se -i /python3[0-9]*-salt/ | awk -F'|' '/^i/ { gsub(/ /, "", $2); print $2 }' |  xargs zypper --non-interactive remove; exit 0
-{% endif %}
-
-{% if grains['osfullname'] == 'SL-Micro' %}
-{% set repo_path = 'SLMicro' + grains['osrelease_info'][0]|string + grains['osrelease_info'][1]|string %}
+{#- SL Micro -#}
+{%- elif grains["osfullname"] == "SL-Micro" -%}
 os_pool_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SL-Micro/{{ grains['osrelease'] }}/x86_64/product/
+    - baseurl: http://{{ grains.get("mirror")|default("dist.nue.suse.com/ibs", true) }}/SUSE/Products/SL-Micro/{{ grains['osrelease'] }}/x86_64/product/
     - refresh: True
-
+{# REVIEW: Correct repo for 6.1? -#}
 alp_sources_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE:/ALP:/Source:/Standard:/Core:/1.0:/Build/standard/
+    - baseurl: http://{{ grains.get("mirror")|default("dist.nue.suse.com/ibs", true) }}/SUSE:/ALP:/Source:/Standard:/Core:/1.0:/Build/standard/
     - refresh: True
-{% endif %}
+{% set repo_path = 'SLMicro' ~ grains['osrelease_info']|join %}
 
-{% if grains['osfullname'] == 'Leap' %}
-{% set repo_path = grains['osrelease'] %}
-{% endif %}
-
-{% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
-{% set repo_path = 'openSUSE_Tumbleweed' %}
+{#- Tumbleweed -#}
+{%- elif grains["osfullname"] == "openSUSE Tumbleweed"-%}
+{# REVIEW: Do we need to set repo-oss? #}
 repo-oss:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/tumbleweed/repo/oss/
     - refresh: True
     - gpgcheck: False
-{% endif %}
+{% set repo_path = grains["osfullname"]|replace(" ", "_") -%}
+{% endif -%}
 
+{#- Common -#}
 salt_testsuite_dependencies_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:products:test-dependencies/{{ repo_path }}/
     - refresh: True
-    - gpgcheck: 0
-{% if grains['os'] == 'SUSE' %}
+    - gpgcheck: False
     - priority: 1
-{% endif %}
     - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:saltstack:products:test-dependencies/{{ repo_path }}/repodata/repomd.xml.key
 
 salt_testing_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ grains["salt_obs_flavor"] }}/{{ repo_path }}/
     - refresh: True
-    - gpgcheck: 0
-{% if grains['os'] == 'SUSE' %}
+    - gpgcheck: False
     - priority: 1
-{% endif %}
     - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ grains["salt_obs_flavor"] }}/{{ repo_path }}/repodata/repomd.xml.key
 
-{% set salt_minion_is_installed = salt["pkg.info_installed"]("salt-minion").get("salt-minion", False) %}
-install_salt_testsuite:
-{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
-  cmd.run:
-    - name: transactional-update -c -n pkg in --capability python3-salt-testsuite python3-salt-test python3-salt
-{% else %}
-  {# HACK: we call zypper manually to ensure right packages are installed regardless upgrade/downgrade #}
-  cmd.run:
-    {# We install docker first to ensure zypper does not resolve this dependency to podman-docker #}
-    {% if salt_minion_is_installed %}
-    - name: |
-        zypper --non-interactive in --force docker
-        zypper --non-interactive in --capability --from salt_testing_repo python3-salt salt python3-salt-testsuite salt-minion
-    {% else %}
-    - name: |
-        zypper --non-interactive in --force docker
-        zypper --non-interactive in --capability --from salt_testing_repo python3-salt salt python3-salt-testsuite
-    {% endif %}
-    - fromrepo: salt_testing_repo
-{% endif %}
-    - require:
-      - pkgrepo: salt_testsuite_dependencies_repo
-      - pkgrepo: salt_testing_repo
+## Packages
 
-install_salt_tests_executor:
-{% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
+{% set installed_salt_pkgs = salt["pkg.list_pkgs"]().keys()|select("match", "python.*-salt")|list -%}
+{% if grains["transactional"] -%}
+{# FIXME: transactional_update.call currently drops --local
+salt_packages_absent:
+  module.run:
+    - transactional_update.call:
+      - pkg.remove
+      - pkgs: {{ installed_salt_pkgs }}
+-#}
+salt_packages_absent:
   cmd.run:
-    - name: transactional-update -c -n pkg in python3-salt-test
-{% else %}
+    - name: transactional-update --continue --non-interactive --drop-if-no-change pkg remove {{ installed_salt_pkgs|join(" ")}}
+{% else -%}
+salt_packages_absent:
+  pkg.removed:
+    - pkgs: {{ installed_salt_pkgs }}
+{% endif %}
+
+{# Ensure docker is installed, and not podman-docker #}
+{% set to_install = ["docker"] -%}
+{% if grains["transactional"] -%}
+{# FIXME: transactional_update.call currently drops --local
+docker_installed:
+  module.run:
+    - transactional_update.call:
+      - pkg.install
+      - pkgs: {{ to_install }}
+-#}
+docker_installed:
+  cmd.run:
+    - name: transactional-update --continue --non-interactive --drop-if-no-change pkg install {{ to_install|join(" ")}}
+{% else -%}        
+docker_installed:
   pkg.installed:
-    - resolve_capabilities: true
-    - pkgs:
-      - python3-salt-test
-{% endif %}
-    - require:
-      - cmd: install_salt_testsuite
+    - pkgs: {{ to_install }}
+{% endif %}  
 
-start_docker_service:
+{# TODO: pre-install all Python flavors #}
+{% set to_install = ["python3-salt-testsuite", "python3-salt-test", "python3-salt"] -%}
+{% if grains["transactional"] -%}
+{# FIXME: transactional_update.call currently drops --local
+salt_testsuite_installed:
+  module.run:
+    - transactional_update.call:
+      - pkg.install
+      - pkgs: {{ to_install }}
+      - resolve_capabilities: true
+      - fromrepo: salt_testing_repo
+      - requires:
+        - pkgrepo: salt_testing_repo
+        - pkgrepo: salt_testsuite_dependencies_repo
+-#}
+salt_testsuite_installed:
+  cmd.run:
+    - name: transactional-update --continue --non-interactive --drop-if-no-change pkg install --capability --from salt_testing_repo {{ to_install|join(" ")}}
+    - requires:
+        - pkgrepo: salt_testing_repo
+        - pkgrepo: salt_testsuite_dependencies_rep
+{% else -%}
+{# resolve_capabilities and fromrepo conflict, see bsc#1244067
+salt_testsuite_installed:
+  pkg.installed:
+    - pkgs: {{ to_install }}
+    - resolve_capabilities: true
+    - fromrepo: salt_testing_repo
+    - require:
+      - pkgrepo: salt_testing_repo
+      - pkgrepo: salt_testsuite_dependencies_repo
+-#}
+salt_testsuite_installed:
+  cmd.run:
+    - name: zypper --non-interactive install --capability --from salt_testing_repo {{ to_install|join(" ") }}
+    - require:
+      - pkgrepo: salt_testing_repo
+      - pkgrepo: salt_testsuite_dependencies_repo
+{% endif -%}  
+
+## Services for running tests
+
+docker_service_enabled:
 {% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
   cmd.run:
     - name: transactional-update -c run systemctl enable docker
@@ -141,10 +163,7 @@ start_docker_service:
     - name: docker
 {% endif %}
     - requires:
-      - pkg: install_salt_testsuite
-
-{% endif %}
-
+      - pkg: salt_testsuite_installed
 
 {% if grains['osfullname'] == 'SLES' and '15.3' == grains['osrelease'] %}
 update_buggy_pyzmq_version:

--- a/salt/salt_testenv/salt_classic_package.sls
+++ b/salt/salt_testenv/salt_classic_package.sls
@@ -46,7 +46,7 @@ remove_old_salt:
 {% if grains['os_family'] == 'Suse' and grains['osfullname'] == 'SL-Micro' %}
     - name: transactional-update -c -n pkg remove python3-salt; exit 0
 {% else %}
-    - name: zypper --non-interactive remove python3-salt; exit 0
+    - name: zypper se -i /python3[0-9]*-salt/ | awk -F'|' '/^i/ { gsub(/ /, "", $2); print $2 }' |  xargs zypper --non-interactive remove; exit 0
 {% endif %}
 
 {% if grains['osfullname'] == 'SL-Micro' %}
@@ -125,6 +125,7 @@ install_salt_tests_executor:
     - name: transactional-update -c -n pkg in python3-salt-test
 {% else %}
   pkg.installed:
+    - resolve_capabilities: true
     - pkgs:
       - python3-salt-test
 {% endif %}


### PR DESCRIPTION
This pull request enables `salt_testenv` Tumbleweed deployments by fixing the password-based root login over SSH (used by terraform to run `salt` on the target) and using `venv-salt-minion` during provisioning, which allows the removal of Salt packages without interfering with the provisioning itself.

In a secondary step I did a bit of clean-up. I used a bit of Jinja to remove repetition from our salt_classic_package.sls. This serves as an example, we can do the same for more if we like it. 