### PR TITLE
Fix: correct health check pkg name

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -239,6 +239,6 @@ health_check_repo:
 
 install_health_check:
     pkg.installed:
-    - name: mgr-health-check
+    - name: python311-mgr-health-check
     - require:
       - pkgrepo: health_check_repo


### PR DESCRIPTION
## What does this PR change?

```
> zypper se -s mgr-health
Loading repository data...
Reading installed packages...

S  | Name                       | Type       | Version          | Arch   | Repository
---+----------------------------+------------+------------------+--------+------------------
   | mgr-health-check           | srcpackage | 0.1.4-150600.1.1 | noarch | health_check_repo
   | python311-mgr-health-check | package    | 0.1.4-150600.1.1 | noarch | health_check_rep
   
   ```
