### PR TITLE
Remove AWS AMI for Leap 15.5

### DIFF
--- a/backend_modules/aws/README.md
+++ b/backend_modules/aws/README.md
@@ -51,7 +51,7 @@ Available provider settings for the base module:
 | server_registration_code | string | `null`          | SUMA SCC server registration code to use SCC repositories and disable internal repositories                             |
 | proxy_registration_code  | string | `null`          | SUMA SCC proxy registration code to use SCC repositories and disable internal repositories                              |
 | sles_registration_code   | string | `null`          | SLE registration code to use SCC repositories and disable internal repositories ( use for minion, sshminion and client) |
-| bastion_image            | string | `opensuse155o`  | Image name to be used when deploying the bastion host                                                                   |
+| bastion_image            | string | `opensuse156o`  | Image name to be used when deploying the bastion host                                                                   |
 
 An example follows:
 

--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -1,24 +1,3 @@
-data "aws_ami" "opensuse155o" {
-  most_recent = true
-  name_regex  = "^openSUSE-Leap-15.5-HVM"
-  owners      = ["679593333241"]
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
 data "aws_ami" "opensuse156o" {
   most_recent = true
   name_regex  = "^openSUSE-Leap-15-6-"

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -68,7 +68,6 @@ locals {
     key_file = local.key_file
     iam_instance_profile = length(aws_iam_instance_profile.metering_full_access_instance_profile) > 0 ? aws_iam_instance_profile.metering_full_access_instance_profile[0].name : null
     ami_info = {
-      opensuse155o                    = { ami = data.aws_ami.opensuse155o.image_id },
       opensuse156o                    = { ami = data.aws_ami.opensuse156o.image_id },
       sles15sp3o                      = { ami = data.aws_ami.sles15sp3o.image_id },
       sles15sp4o                      = { ami = data.aws_ami.sles15sp4o.image_id },
@@ -114,7 +113,7 @@ module "bastion" {
   source                        = "../host"
   quantity                      = local.create_network ? 1 : 0
   base_configuration            = local.configuration_output
-  image                         = lookup(var.provider_settings, "bastion_image", "opensuse155o")
+  image                         = lookup(var.provider_settings, "bastion_image", "opensuse156o")
   name                          = "bastion"
   provider_settings = {
     instance_type   = "t3a.micro"

--- a/main.tf.aws-testsuite.example
+++ b/main.tf.aws-testsuite.example
@@ -20,7 +20,7 @@ module "cucumber_testsuite" {
   cc_username = ...
   cc_password = ...
 
-  images = ["opensuse154", "opensuse155"]
+  images = ["opensuse156o"]
 
   name_prefix  = ...
   git_repo     = "https://github.com/uyuni-project/uyuni.git"
@@ -32,16 +32,16 @@ module "cucumber_testsuite" {
     server = {}
     proxy = {}
     suse_client = {
-      image = "opensuse154"
-      name = "cli-opensuse154"
+      image = "opensuse156o"
+      name = "cli-opensuse156"
     }
     suse_minion = {
-      image = "opensuse154"
-      name = "min-opensuse154"
+      image = "opensuse156o"
+      name = "min-opensuse156"
     }
     suse_sshminion = {
-      image = "opensuse154"
-      name = "minssh-opensuse154"
+      image = "opensuse156o"
+      name = "minssh-opensuse156"
     }
   }
 


### PR DESCRIPTION
## What does this PR change?

AWS AMIs for Leap 15.5 are no longer available and will cause our pipeline to fail when attempting to compute a value for the most recent of them.

![Screenshot From 2025-06-18 16-00-58](https://github.com/user-attachments/assets/f0349018-3a41-483e-99b4-4d54b16f4ee2)

```
15:44:27  │ Error: Your query returned no results. Please change your search criteria and try again.
15:44:27  │ 
15:44:27  │   with cucumber_testsuite.base.aws_ami.opensuse155o,
15:44:27  │   on /home/jenkins/workspace/uyuni-master-dev-acceptance-tests-AWS/results/sumaform/backend_modules/aws/base/ami.tf line 1, in data "aws_ami" "opensuse155o":
15:44:27  │    1: data "aws_ami" "opensuse155o" {
15:44:27  │ 
15:44:27  ╵
```

We already switched to Leap 15.6 on our AWS CI , so it should be safe to just remove the entry.
