### PR TITLE
Salt Shaker: Upgrade to latest "python3-M2Crypto" version on 15.3 and 15.4

### DIFF
--- a/salt/salt_testenv/salt_classic_package.sls
+++ b/salt/salt_testenv/salt_classic_package.sls
@@ -150,3 +150,10 @@ update_buggy_pyzmq_version:
   pkg.latest:
     - name: python3-pyzmq
 {% endif %}
+
+
+{% if grains['osfullname'] == 'SLES' and grains['osrelease'] in ["15.3", "15.4"] %}
+update_buggy_m2crypto_version:
+  pkg.latest:
+    - name: python3-M2Crypto
+{% endif %}


### PR DESCRIPTION
## What does this PR change?

This PR prevents an error we see when running Salt Shaker tests for classic Salt package in SLE 15.3 and 15.4 caused by an outdated version of `python3-M2Crypto` package (from 2020):

```
tests/pytests/functional/channel/test_req_channel.py::test_req_channel_v2_invalid_token
[...]
    def public_decrypt(self, data, padding):
        # type: (bytes, int) -> bytes
        assert self.check_key(), 'key is not initialised'
>       return m2.rsa_public_decrypt(self.rsa, data, padding)
E       M2Crypto.RSA.RSAError: invalid header

/usr/lib64/python3.6/site-packages/M2Crypto/RSA.py:72: RSAError
```
Upgrading the `python3-M2Crypto` version fixes this issue, so we take here the same approach we did for `python3-pyzmq` in SLE 15.3.
