### PR TITLE
Always wait for SCC data refresh

### DIFF
--- a/salt/server/initial_content.sls
+++ b/salt/server/initial_content.sls
@@ -64,7 +64,6 @@ mgr_sync_automatic_authentication:
 
 {% endif %}
 
-{% if grains.get('channels') %}
 wait_for_mgr_sync:
   cmd.script:
     - name: salt://server/wait_for_mgr_sync.py
@@ -73,6 +72,7 @@ wait_for_mgr_sync:
     - require:
       - http: create_first_user
 
+{% if grains.get('channels') %}
 scc_data_refresh:
   cmd.run:
     - name: mgr-sync refresh

--- a/salt/server_containerized/initial_content.sls
+++ b/salt/server_containerized/initial_content.sls
@@ -22,7 +22,6 @@ mgr_sync_automatic_authentication:
 
 {% endif %}
 
-{% if grains.get('channels') %}
 scc_data_refresh:
   cmd.script:
     - name: salt://server_containerized/wait_for_mgr_sync.sh
@@ -31,6 +30,7 @@ scc_data_refresh:
     - require:
       - cmd: mgradm_install
 
+{% if grains.get('channels') %}
 add_channels:
   cmd.run:
     - name: mgrctl exec mgr-sync add channels {{ ' '.join(grains['channels']) }}


### PR DESCRIPTION
## What does this PR change?

Lately, we've noticed failures in 5.0 BV-like pipelines when waiting  to retrieve the initial product list.
That seems connected to our setup for large deployments - specifically the fact that we restart PostgreSQL to apply changes to its configuration, the values themselves do not matter.

Making so that we always wait for the initial, automated, product refresh to complete before applying such changes seems to solve this issue.
