### PR TITLE
Add additional repositories only if server or proxy.

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -118,15 +118,19 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs"}/SUSE/P
   %{ endif }
 %{ endif } # end of image == "slmicro61o" block
 
-for i in ${additional_repos}; do
-  name=$(echo $i | cut -d= -f1)
-  url=$(echo $i | cut -d= -f2)
-  %{ if product_version == "uyuni-pr" }
-    zypper ar --no-gpgcheck $url $name
-  %{ else }
-    zypper ar $url $name
-  %{ endif }
-done
+# Add additional repository for host only if server or proxy
+%{ if container_server || container_proxy }
+  for i in ${additional_repos}; do
+    name=$(echo $i | cut -d= -f1)
+    url=$(echo $i | cut -d= -f2)
+    %{ if product_version == "uyuni-pr" }
+      zypper ar --no-gpgcheck $url $name
+    %{ else }
+      zypper ar $url $name
+    %{ endif }
+  done
+%{ endif }
+
 
 # Install packages
 PACKAGES="qemu-guest-agent avahi ca-certificates"


### PR DESCRIPTION
## What does this PR change?
In combustion, we add the additional repositories without checking if the host is a server or proxy. 
To follow the example of all the other product version (4.3 and 5.0), only add the additional repositories when uyuni tools installation is needed.

For slmicr6X minion, we add those repositories during the testsuite run.

In theory, we really only need server because we also upgrade mgrpxy on proxy in testsuite but we don't upgrade mgrctl.
