### PR TITLE
Update AWS AMI regex filters for SUMA 5.0 Server

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -213,7 +213,7 @@ data "aws_ami" "suma-server-43-ltd-paygo" {
 // EMEA offer
 data "aws_ami" "suma-server-50-x86_64-ltd-paygo" {
   most_recent = true
-  name_regex  = "^SUSE-Manager-Server-5\\.0.*"
+  name_regex  = "^suse-manager-server-5-0-v[0-9].*(ltd).*$"
   owners      = ["679593333241"]
 
   filter {
@@ -240,7 +240,7 @@ data "aws_ami" "suma-server-50-x86_64-ltd-paygo" {
 // EMEA offer
 data "aws_ami" "suma-server-50-arm64-ltd-paygo" {
   most_recent = true
-  name_regex  = "^SUSE-Manager-Server-5\\.0.*"
+  name_regex  = "^suse-manager-server-5-0-v[0-9].*(ltd).*$"
   owners      = ["679593333241"]
 
   filter {


### PR DESCRIPTION
## What does this PR change?

With the release of new arm64 images, it seems the previous regex is no longer matching any available image

```
17:18:47  │ Error: Your query returned no results. Please change your search criteria and try again.
17:18:47  │ 
17:18:47  │   with cucumber_testsuite.base.aws_ami.suma-server-50-arm64-ltd-paygo,
17:18:47  │   on /home/jenkins/workspace/uyuni-master-dev-acceptance-tests-AWS/results/sumaform/backend_modules/aws/base/ami.tf line 241, in data "aws_ami" "suma-server-50-arm64-ltd-paygo":
17:18:47  │  241: data "aws_ami" "suma-server-50-arm64-ltd-paygo" {
17:18:47  │ 
17:18:47  ╵
```

This PR replaces that regex filter for both x86 and arm64 with a stricter, working, one.