### PR TITLE
AWS: Remove SLES 15 SP3 BYOS

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -19,27 +19,6 @@ data "aws_ami" "opensuse156o" {
   }
 }
 
-data "aws_ami" "sles15sp3o" {
-  most_recent = true
-  name_regex  = "^suse-sles-15-sp3-byos-v"
-  owners      = ["679593333241"]
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
-  }
-}
-
 data "aws_ami" "sles15sp4o" {
   most_recent = true
   name_regex  = "^suse-sles-15-sp4-byos-v"

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -69,7 +69,6 @@ locals {
     iam_instance_profile = length(aws_iam_instance_profile.metering_full_access_instance_profile) > 0 ? aws_iam_instance_profile.metering_full_access_instance_profile[0].name : null
     ami_info = {
       opensuse156o                    = { ami = data.aws_ami.opensuse156o.image_id },
-      sles15sp3o                      = { ami = data.aws_ami.sles15sp3o.image_id },
       sles15sp4o                      = { ami = data.aws_ami.sles15sp4o.image_id },
       sles15sp5o                      = { ami = data.aws_ami.sles15sp5o.image_id },
       sles15sp6o                      = { ami = data.aws_ami.sles15sp6o.image_id },

--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -38,15 +38,6 @@ zypper:
 packages: ["salt-minion"]
 %{ endif }
 
-%{ if image == "sles15sp3o" }
-runcmd:
-  - zypper addrepo -G -e http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products/SLE_15_SP3/ salt_test
-  - zypper ref
-  - zypper in --allow-vendor-change --no-confirm salt-minion
-  - zypper removerepo --all
-
-%{ endif }
-
 %{ if image == "sles15sp4o" || image == "sles15sp5o" || image == "sles15sp6o" }
 runcmd:
   - zypper addrepo -G -e http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products/SLE_15/ salt_test


### PR DESCRIPTION
## What does this PR change?

```
│ Error: Your query returned no results. Please change your search criteria and try again.
│ 
│   with module.base.module.base_backend.data.aws_ami.sles15sp3o,
│   on /home/jenkins/workspace/manager-5.0-qe-build-validation-paygo-aws/results/sumaform-aws/backend_modules/aws/base/ami.tf line 22, in data "aws_ami" "sles15sp3o":
│   22: data "aws_ami" "sles15sp3o" {
```

I've manually checked and It seems SLES 15 SP3 BYOS images are no longer available in the AWS marketplace, the similar regex for SLES 15 SP4 BYOS does work
This breaks pipelines as the data section for them returns no result now.

Considering we are not using them anyway in our PAYG pipeline, it would still be useful to remove these sections.
