### PR TITLE
Allow to define custom attributes for the database container

### DIFF
--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -49,6 +49,9 @@ module "server_containerized" {
     container_repository           = var.container_repository
     container_image                = var.container_image
     container_tag                  = var.container_tag
+    db_container_repository        = var.db_container_repository
+    db_container_image             = var.db_container_image
+    db_container_tag               = var.db_container_tag
     cc_username                    = var.base_configuration["cc_username"]
     cc_password                    = var.base_configuration["cc_password"]
     channels                       = var.channels

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -32,6 +32,21 @@ variable "container_tag" {
   default = ""
 }
 
+variable "db_container_repository" {
+  description = "Where to find the server database container images. Uses the released ones per default."
+  default = ""
+}
+
+variable "db_container_image" {
+  description = "Server database container images name. Don't setup for default images."
+  default = ""
+}
+
+variable "db_container_tag" {
+  description = "The database container image tag to use."
+  default = ""
+}
+
 variable "product_version" {
   description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string

--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -19,6 +19,18 @@ image: {{ grains.get('container_image') }}
 {%- if grains.get('container_tag') %}
 tag: {{ grains.get('container_tag') }}
 {% endif %}
+{%- if grains.get('db_container_image') or grains.get('db_container_tag') %}
+pgsql:
+  {%- if grains.get('db_container_repository') %}
+  registry: {{ grains.get('db_container_repository') }}
+  {% endif %}
+  {%- if grains.get('db_container_image') %}
+  image: {{ grains.get('db_container_image') }}
+  {% endif %}
+  {%- if grains.get('db_container_tag') %}
+  tag: {{ grains.get('db_container_tag') }}
+  {% endif %}
+{% endif %}
 {%- set mirror_hostname = grains.get('server_mounted_mirror') if grains.get('server_mounted_mirror') else grains.get('mirror') %}
 {%- if runtime == 'podman' %}
 {%- if mirror_hostname %}


### PR DESCRIPTION
## What does this PR change?

This PR adds support to define custom "registry/image/tag" for the database containers, which is particularly helpful for developers when testing devel server and db images.