### PR TITLE
Increase max ssh startups when using large deployment

### DIFF
--- a/salt/server/large_deployment.sls
+++ b/salt/server/large_deployment.sls
@@ -68,4 +68,22 @@ large_deployment_postgresql:
       - file: large_deployment_increase_database_max_connections
       - file: large_deployment_increase_database_work_memory
 
+# Increase MaxStartups for SSH daemon
+large_deployment_increase_sshd_maxstartups:
+  file.managed:
+    - name: /etc/ssh/sshd_config.d/99-maxstartups.conf
+    - contents: |
+        # Increased MaxStartups for large deployment tuning
+        MaxStartups 100:30:200
+    - user: root
+    - group: root
+    - mode: '0644'
+
+large_deployment_sshd_reload:
+  service.running:
+    - name: sshd
+    - reload: True
+    - watch:
+      - file: large_deployment_increase_sshd_maxstartups
+
 {% endif %}

--- a/salt/server_containerized/large_deployment.sls
+++ b/salt/server_containerized/large_deployment.sls
@@ -35,6 +35,24 @@ large_deployment_tomcat_restart:
       - cmd: large_deployment_increase_hibernate_max_connections
       - cmd: large_deployment_tune_tomcat_maxthreads
 
+# Increase MaxStartups for SSH daemon
+large_deployment_increase_sshd_maxstartups:
+  file.managed:
+    - name: /etc/ssh/sshd_config.d/99-maxstartups.conf
+    - contents: |
+        # Increased MaxStartups for large deployment tuning
+        MaxStartups 100:30:200
+    - user: root
+    - group: root
+    - mode: '0644'
+
+large_deployment_sshd_reload:
+  service.running:
+    - name: sshd
+    - reload: True
+    - watch:
+      - file: large_deployment_increase_sshd_maxstartups
+
 {% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') or 'head' in grains.get('product_version', '') or '5.1' in grains.get('product_version', '') %}
 large_deployment_increase_database_max_connections_db_container:
   cmd.run:


### PR DESCRIPTION
## Context

During recent BV runs, we observed a new flaky test failure where SSH connections are unexpectedly reset by the server.
Details and discussion can be found in [#27922](https://github.com/SUSE/spacewalk/issues/27922).

After investigation, it appears that our sshd configuration is missing an explicit MaxStartups setting. In such cases, the default limit is 10 unauthenticated connections, after which incoming connections may be dropped. This could explain why some SSH connections are terminated shortly after authentication begins.

## What does this PR change?

This PR increases the allowed number of unauthenticated SSH connections by configuring sshd with a higher MaxStartups limit. This should improve stability when multiple SSH connections are initiated in parallel (as is common in BVs).

A new config file is added under /etc/ssh/sshd_config.d/ to ensure:
```
MaxStartups 100:30:200
```

This allows:

 - Up to 100 unauthenticated connections,
 - Gradual dropping of connections beyond 30 concurrent attempts,
 - With a hard cap at 200.

## Note

