### PR TITLE
AWS payg-related updates

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -124,7 +124,7 @@ data "aws_ami" "sles15sp6o" {
   }
 }
 
-// EMEA offer
+// EMEA offers
 data "aws_ami" "suma-server-50-x86_64-ltd-paygo" {
   most_recent = true
   name_regex  = "^suse-manager-server-5-0-v[0-9].*(ltd).*$"
@@ -151,7 +151,6 @@ data "aws_ami" "suma-server-50-x86_64-ltd-paygo" {
   }
 }
 
-// EMEA offer
 data "aws_ami" "suma-server-50-arm64-ltd-paygo" {
   most_recent = true
   name_regex  = "^suse-manager-server-5-0-v[0-9].*(ltd).*$"
@@ -219,6 +218,104 @@ data "aws_ami" "suma-proxy-50-x86_64-byos" {
     values = ["ebs"]
   }
 }
+
+// TODO: remove comment once those images are publicly available
+
+/* data "aws_ami" "smlm-server-51-x86_64-ltd-paygo" {
+  most_recent = true
+  name_regex  = "^suse-mlm-server-5-1-v[0-9].*(ltd).*$"
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "product-code"
+    values = ["8ysfelcfs2dkok3fba4s5uqo4"]
+  }
+}
+
+
+data "aws_ami" "smlm-server-51-arm64-ltd-paygo" {
+  most_recent = true
+  name_regex  = "^suse-mlm-server-5-1-v[0-9].*(ltd).*$"
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "product-code"
+    values = ["umnofojstehgl6jnp9nspg7g"]
+  }
+}
+
+data "aws_ami" "smlm-proxy-51-arm64-byos" {
+  most_recent = true
+  name_regex  = "^suse-mlm-proxy-5-1-byos-v"
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "architecture"
+    values = ["arm64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+
+data "aws_ami" "smlm-proxy-51-x86_64-byos" {
+  most_recent = true
+  name_regex  = "^suse-mlm-proxy-5-1-byos-v"
+  owners      = ["679593333241"]
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+}
+ */
 
 data "aws_ami" "sles12sp5" {
   most_recent = true

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -79,6 +79,12 @@ locals {
       suma-server-50-arm64-ltd-paygo  = { ami = data.aws_ami.suma-server-50-arm64-ltd-paygo.image_id },
       suma-proxy-50-x86_64-byos       = { ami = data.aws_ami.suma-proxy-50-x86_64-byos.image_id },
       suma-proxy-50-arm64-byos        = { ami = data.aws_ami.suma-proxy-50-arm64-byos.image_id },
+//    TODO: remove comment once these images are publicly available
+/*    smlm-server-51-x86_64-ltd-paygo = { ami = data.aws_ami.smlm-server-51-x86_64-ltd-paygo.image_id },
+      smlm-server-51-arm64-ltd-paygo  = { ami = data.aws_ami.smlm-server-51-arm64-ltd-paygo.image_id },
+      smlm-proxy-51-x86_64-byos       = { ami = data.aws_ami.smlm-proxy-51-x86_64-byos.image_id },
+      smlm-proxy-51-arm64-byos        = { ami = data.aws_ami.smlm-proxy-51-arm64-byos.image_id },
+ */
       sles12sp5                       = { ami = data.aws_ami.sles12sp5.image_id },
       sles12sp5-paygo                 = { ami = data.aws_ami.sles12sp5-paygo.image_id },
       rocky8                          = { ami = data.aws_ami.rocky8.image_id, ssh_user = "rocky" },

--- a/backend_modules/aws/host/combustion
+++ b/backend_modules/aws/host/combustion
@@ -39,11 +39,35 @@ nm_config 2 eth1 manual
 # Set linux as password for root
 echo 'root:$6$3aQC9rrDLHiTf1yR$NoKe9tko0kFIpu0rQ2y/OzOOtbVvs0Amr2bx0T4cGf6aq8PG74EmVy8lSDJdbLVVFpOSzwELWyReRCiPHa7DG0' | chpasswd -e
 
+# 5.1 --> SL micro 6.1
+%{ if product_version == "5.1-paygo" }
+echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/root.conf
+echo "ChallengeResponseAuthentication yes" >> /etc/ssh/sshd_config.d/root.conf
+%{ else }
+# 5.0 --> SLE Micro 5.5
 echo "PermitRootLogin yes" > /etc/ssh/sshd_config
 echo "ChallengeResponseAuthentication yes" >> /etc/ssh/sshd_config
 echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config
-echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGEPA8UvZ/6tTiL+MKGUAsHJuPlDpueeDmbuJ+0giOCY root@controller" > /root/.ssh/authorized_keys
+%{ endif }
 
 # Add a public ssh key and enable sshd
+echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGEPA8UvZ/6tTiL+MKGUAsHJuPlDpueeDmbuJ+0giOCY root@controller" > /root/.ssh/authorized_keys
+
 systemctl enable sshd.service
 systemctl restart sshd.service
+
+# Install packages
+PACKAGES=""
+
+%{ if install_salt_bundle }
+PACKAGES="$PACKAGES venv-salt-minion"
+%{ else }
+PACKAGES="$PACKAGES salt-minion"
+%{ endif }
+
+transactional-update --non-interactive --continue pkg in $PACKAGES
+
+# Leave a marker
+echo "Configured with combustion" > /var/lib/combustion.done
+
+reboot

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -50,7 +50,7 @@ locals {
 
   combustion_images  = [
     "suma-proxy-50-x86_64-byos", "suma-proxy-50-arm64-byos", "suma-server-50-arm64-ltd-paygo", "suma-server-50-x86_64-ltd-paygo",
-    "mlm-proxy-51-x86_64-byos", "mlm-proxy-51-arm64-byos", "mlm-server-51-arm64-ltd-paygo", "mlm-server-51-x86_64-ltd-paygo"
+    "smlm-proxy-51-x86_64-byos", "smlm-proxy-51-arm64-byos", "smlm-server-51-arm64-ltd-paygo", "smlm-server-51-x86_64-ltd-paygo"
   ]
   // manually provided AMIs for to-be-released images all start with 'ami-'
   combustion = contains(local.combustion_images, var.image) || substr(var.image, 0, 3) == "ami"
@@ -255,7 +255,7 @@ resource "null_resource" "host_salt_configuration" {
     bastion_host        = aws_instance.instance[count.index].associate_public_ip_address ? null : local.provider_settings["bastion_host"]
     bastion_user        = "ec2-user"
     bastion_private_key = file(local.provider_settings["key_file"])
-    timeout             = "600s"
+    timeout             = "120s"
   }
 
   provisioner "file" {

--- a/salt/server_containerized/install_podman.sls
+++ b/salt/server_containerized/install_podman.sls
@@ -14,9 +14,11 @@ podman_packages:
       {% endif %}
 {% endif %}
 
+{% if 'paygo' not in grains.get('product_version') | default('', true) %}
 podman_login:
   cmd.run:
     - name: podman login -u {{ grains.get('cc_username') }} -p {{ grains.get('cc_password') }} {{ grains.get("container_repository") }}
+{% endif %}
 
 # WORKAROUND: see github:saltstack/salt#10852
 {{ sls }}_nop:


### PR DESCRIPTION
## What does this PR change?

Includes:

- (currently placeholders) AMIs for 5.1 PAYG Server and 5.1 BYOS Proxy images
- combustion template changes:
  - remove all the currently unused variables
  - rely on product_version instead of image to determine  whether we are using combustion for SLE micro 5.5 or SL  micro 6.1. We cannot rely on the image name because when we test new images we'll provide the AMI itself, since they're not released and cannot be found through "normal" marketplace search.
  -  adds a conditional 3 minutes wait if combustion has been used by the instance. This is to address the need to reboot after installing pkgs on transactional systems, which will break other scripts running due to the SSH connection cut (e.g. wait_for_salt.sh).
