### PR TITLE
Fix Head setup as Product got version 5.2 now

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -108,10 +108,10 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs"}/SUSE/P
           %{ endif }
         %{ else }
           %{ if container_server }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs"}/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Server-5.1-x86_64/ container_utils_repo
+            zypper ar http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs"}/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
           %{ endif }
           %{ if container_proxy }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs"}/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Proxy-5.1-x86_64/ container_utils_repo
+            zypper ar http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs"}/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
           %{ endif }
         %{ endif }
     %{ endif }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -303,7 +303,7 @@ zypper:
 %{ if product_version == "head" ~}
     - id: container_utils_repo
       name: container_utils_repo
-      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Server-5.1-x86_64/
+      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Server-5.2-x86_64/
       enabled: 1
       autorefresh: 1
       gpgcheck: false
@@ -336,7 +336,7 @@ zypper:
     - id: container_utils_repo
       name: container_utils_repo
 #      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/SLE-Micro55/
-      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Proxy-5.1-x86_64/
+      baseurl: http://${ use_mirror_images ? mirror : "dist.nue.suse.com/ibs" }/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/
       enabled: 1
       autorefresh: 1
       gpgcheck: false

--- a/salt/repos/proxy_containerizedHead.sls
+++ b/salt/repos/proxy_containerizedHead.sls
@@ -7,9 +7,9 @@
 # Commented out because we already add this repo in cloud-init:
 # proxy_devel_repo:
 #   pkgrepo.managed:
-#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-5.1-POOL-x86_64-Media1/
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-5.2-x86_64/
 #     - refresh: True
-#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-5.1-POOL-x86_64-Media1/repodata/repomd.xml.key
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-5.2-x86_64/repodata/repomd.xml.key
 
 {% endif %}
 {% endif %}

--- a/salt/repos/server_containerizedHead.sls
+++ b/salt/repos/server_containerizedHead.sls
@@ -7,9 +7,9 @@
 # Commented out because we already add this repo in cloud-init:
 # server_devel_repo:
 #   pkgrepo.managed:
-#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-5.1-POOL-x86_64-Media1/
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Server-5.2-x86_64/
 #     - refresh: True
-#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-5.1-POOL-x86_64-Media1/repodata/repomd.xml.key
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/Multi-Linux-Manager-Server-5.2-x86_64/repodata/repomd.xml.key
 
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

The Server and Proxy products in Head were bumped to version 5.2.
Use the new product repositories in sumaform
