### PR TITLE
Preparations for new terraform and `terraform-provider-libvirt` version

### DIFF
--- a/backend_modules/azure/host/main.tf
+++ b/backend_modules/azure/host/main.tf
@@ -30,17 +30,15 @@ locals {
   public_instance                      = lookup(var.provider_settings, "public_instance", false)
   location                             = var.base_configuration["location"]
   product_version                      = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
-}
 
-data "template_file" "user_data" {
-  count    = var.quantity > 0 ? var.quantity : 0
-  template = file("${path.module}/user_data.yaml")
-  vars = {
-    image           = var.image
-    public_instance = local.public_instance
-    mirror_url      = var.base_configuration["mirror"]
-    install_salt_bundle      = var.install_salt_bundle
-  }
+  user_data = [
+    for i in range(var.quantity) : templatefile("${path.module}/user_data.yaml", {
+      image               = var.image
+      public_instance     = local.public_instance
+      mirror_url          = var.base_configuration["mirror"]
+      install_salt_bundle = var.install_salt_bundle
+    })
+  ]
 }
 
 resource "azurerm_public_ip" "suma-pubIP" {


### PR DESCRIPTION
## What does this PR change?

For Terraform 0.12 and later, the `template_file` data source has been superseded by the `templatefile()` function, which can be used directly in expressions without creating a separate data resource.

## Links
- https://github.com/hashicorp/terraform-provider-template
- https://registry.terraform.io/providers/hashicorp/template/latest/docs#deprecation

