### PR TITLE
Even 8 minutes are not enough on SLC 1

### DIFF
--- a/modules/dhcp_dns/main.tf
+++ b/modules/dhcp_dns/main.tf
@@ -31,7 +31,7 @@ resource "null_resource" "standalone_provisioning" {
     host                = "${local.prefix}.53"
     user                = "root"
     password            = "linux"
-    timeout             = "8m"
+    timeout             = "15m"
     bastion_host        = var.hypervisor != null ? var.hypervisor.host : null
     bastion_user        = var.hypervisor != null ? var.hypervisor.user : null
     bastion_private_key = var.hypervisor != null ? var.hypervisor.private_key : null


### PR DESCRIPTION
## What does this PR change?

Even 8 minutes are not enough on SLC 1 for DHCP and DNS VM. Increasing to 15 minutes.