### PR TITLE
Salt Shaker: Install all available Python flavors for Salt

### DIFF
--- a/salt/salt_testenv/salt_classic_package.sls
+++ b/salt/salt_testenv/salt_classic_package.sls
@@ -120,15 +120,14 @@ salt_testsuite_installed:
     - transactional_update.call:
       - pkg.install
       - pkgs: {{ to_install }}
-      - resolve_capabilities: true
-      - fromrepo: salt_testing_repo
+      - fromrepo: [salt_testing_repo, salt_testsuite_dependencies_repo]
       - requires:
         - pkgrepo: salt_testing_repo
         - pkgrepo: salt_testsuite_dependencies_repo
 -#}
 salt_testsuite_installed:
   cmd.run:
-    - name: transactional-update --continue --non-interactive --drop-if-no-change pkg install --capability --from salt_testing_repo {{ to_install|join(" ")}}
+    - name: transactional-update --continue --non-interactive --drop-if-no-change pkg install --from salt_testing_repo --from salt_testsuite_dependencies_repo {{ to_install|join(" ")}}
     - requires:
         - pkgrepo: salt_testing_repo
         - pkgrepo: salt_testsuite_dependencies_rep
@@ -137,15 +136,14 @@ salt_testsuite_installed:
 salt_testsuite_installed:
   pkg.installed:
     - pkgs: {{ to_install }}
-    - resolve_capabilities: true
-    - fromrepo: salt_testing_repo
+    - fromrepo: [salt_testing_repo, salt_testsuite_dependencies_repo]
     - require:
       - pkgrepo: salt_testing_repo
       - pkgrepo: salt_testsuite_dependencies_repo
 -#}
 salt_testsuite_installed:
   cmd.run:
-    - name: zypper --non-interactive install --capability --from salt_testing_repo {{ to_install|join(" ") }}
+    - name: zypper --non-interactive install --from salt_testing_repo --from salt_testsuite_dependencies_repo {{ to_install|join(" ") }}
     - require:
       - pkgrepo: salt_testing_repo
       - pkgrepo: salt_testsuite_dependencies_repo

--- a/salt/salt_testenv/salt_classic_package.sls
+++ b/salt/salt_testenv/salt_classic_package.sls
@@ -112,8 +112,7 @@ docker_installed:
     - pkgs: {{ to_install }}
 {% endif %}  
 
-{# TODO: pre-install all Python flavors #}
-{% set to_install = ["python3-salt-testsuite", "python3-salt-test", "python3-salt"] -%}
+{% set to_install = ["python3*-salt-testsuite", "python3*-salt-test", "python3*-salt"] -%}
 {% if grains["transactional"] -%}
 {# FIXME: transactional_update.call currently drops --local
 salt_testsuite_installed:


### PR DESCRIPTION
## What does this PR change?

Since we have an `Obsoletes: python3-salt` set for `python311-salt` in 15SP7, we need to explicitely call for `python311-*` to be installed.