### PR TITLE
Salt Shaker: Rearrange channels on SLE15 instances to fix issues with "python311-salt"

### DIFF
--- a/salt/repos/os.sls
+++ b/salt/repos/os.sls
@@ -116,11 +116,10 @@ os_update_repo:
     - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com/ibs", true) }}/SUSE/Updates/SLE-Module-Basesystem/15-SP5/x86_64/update/
     - refresh: True
 
-# uncomment when it goes LTSS
-#os_ltss_repo:
-#  pkgrepo.managed:
-#    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP5-LTSS/x86_64/update/
-#    - refresh: True
+os_ltss_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/SUSE/Updates/SLE-Product-SLES/15-SP5-LTSS/x86_64/update/
+    - refresh: True
 
 {% elif '15.6' == grains['osrelease'] %}
 

--- a/salt/salt_testenv/salt_classic_package.sls
+++ b/salt/salt_testenv/salt_classic_package.sls
@@ -12,8 +12,13 @@
 {% for module in ["development_tools", "HPC", "containers" ] -%}
 {{ sle15_module_repos(module, "dist.nue.suse.com/ibs") }}
 {% endfor -%}
+{% if grains["osrelease_info"][1]|int >= 4 -%}
+{% for module in ["python3"] -%}
+{{ sle15_module_repos(module, "dist.nue.suse.com/ibs") }}
+{% endfor -%}
+{% endif -%}
 {% if grains["osrelease_info"][1]|int >= 6 -%}
-{% for module in ["python3", "systems_management"] -%}
+{% for module in ["systems_management"] -%}
 {{ sle15_module_repos(module, "dist.nue.suse.com/ibs") }}
 {% endfor -%}
 {% endif -%}


### PR DESCRIPTION
## What does this PR change?

This PR rearrange the channels assigned to SLE15SP4+ instances in order to fix the issues installing `python311-salt` due missing dependencies:

- Add LTSS channel for SLE15SP5
- Include `SLE-Module-Python3` in SP4 and SP5