### PR TITLE
Add optional OVAL data sync setup variables and Salt state

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -73,6 +73,8 @@ locals {
     host_key => lookup(var.host_settings[host_key], "repository_disk_use_cloud_setup", null) if var.host_settings[host_key] != null }
   scc_access_logging        = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "scc_access_logging", false) if var.host_settings[host_key] != null }
+  enable_oval_metadata     = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "enable_oval_metadata", false) if var.host_settings[host_key] != null }
 
   minimal_configuration     = { hostname = contains(local.hosts, "proxy") ? local.proxy_full_name : local.server_full_name }
   server_configuration      = var.container_server ? module.server_containerized[0].configuration : module.server[0].configuration
@@ -163,6 +165,7 @@ module "server_containerized" {
   repository_disk_size          = lookup(local.repository_disk_size, "server_containerized", 0)
   database_disk_size            = lookup(local.database_disk_size, "server_containerized", 0)
   large_deployment              = lookup(local.large_deployment, "server_containerized", true)
+  enable_oval_metadata          = lookup(local.enable_oval_metadata, "server_containerized", false)
 }
 
 module "proxy" {

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -79,6 +79,7 @@ module "server_containerized" {
     large_deployment               = var.large_deployment
     beta_enabled                   = var.beta_enabled
     additional_repos               = var.additional_repos
+    enable_oval_metadata           = var.enable_oval_metadata
   }
 }
 

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -339,3 +339,9 @@ variable "large_deployment" {
   type        = bool
   default     = true
 }
+
+variable "enable_oval_metadata" {
+  description = "synchronize OVAL data"
+  type        = bool
+  default     = false
+}

--- a/salt/server_containerized/init.sls
+++ b/salt/server_containerized/init.sls
@@ -8,3 +8,4 @@ include:
   - server_containerized.rhn
   - server_containerized.large_deployment
   - server_containerized.testsuite
+  - server_containerized.oval_metadata

--- a/salt/server_containerized/oval_metadata.sls
+++ b/salt/server_containerized/oval_metadata.sls
@@ -1,0 +1,15 @@
+# see https://documentation.suse.com/multi-linux-manager/5.1/en/docs/administration/auditing.html#_oval
+
+{% if grains.get('enable_oval_metadata') | default(false, true) %}
+
+oval_metadata_enable_synchronization:
+  cmd.run:
+    - name: mgrctl exec 'echo "java.cve_audit.enable_oval_metadata=true" >> /etc/rhn/rhn.conf'
+
+oval_metadata_server_restart:
+  cmd.run:
+    - name: mgradm restart
+    - watch:
+      - cmd: oval_metadata_enable_synchronization
+
+{% endif %}


### PR DESCRIPTION
Creates a new variable and related Salt state to allow syncing of OVAL data.
The feature is a 5.1 tech preview and disabled by default.

See https://documentation.suse.com/multi-linux-manager/5.1/en/docs/administration/auditing.html#_oval