### PR TITLE
Add wiring for custom containers repositories, images and tags

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -51,8 +51,16 @@ locals {
     host_key => lookup(var.host_settings[host_key], "runtime", "podman") if var.host_settings[host_key] != null }
   container_repositories    = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "container_repository", null) if var.host_settings[host_key] != null }
+  container_images    = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "container_image", null) if var.host_settings[host_key] != null }
   container_tags    = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "container_tag", null) if var.host_settings[host_key] != null }
+  db_container_repositories    = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "db_container_repository", null) if var.host_settings[host_key] != null }
+  db_container_images    = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "db_container_image", null) if var.host_settings[host_key] != null }
+  db_container_tags    = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "db_container_tag", null) if var.host_settings[host_key] != null }
   helm_chart_urls           = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "helm_chart_url", null) if var.host_settings[host_key] != null }
   main_disk_size            = { for host_key in local.hosts :
@@ -135,7 +143,11 @@ module "server_containerized" {
   name                           = lookup(local.names, "server_containerized", "server")
   runtime                        = lookup(local.runtimes, "server_containerized", "podman")
   container_repository           = lookup(local.container_repositories, "server_containerized", "")
+  container_image                = lookup(local.container_images, "server_containerized", "")
   container_tag                  = lookup(local.container_tags, "server_containerized", "")
+  db_container_repository        = lookup(local.db_container_repositories, "server_containerized", "")
+  db_container_image             = lookup(local.db_container_images, "server_containerized", "")
+  db_container_tag               = lookup(local.db_container_tags, "server_containerized", "")
   auto_accept                    = false
   download_private_ssl_key       = false
   disable_firewall               = false

--- a/salt/proxy_containerized/init.sls
+++ b/salt/proxy_containerized/init.sls
@@ -64,14 +64,19 @@ config_proxy_containerized:
     - contents: |
         registry: {{ container_repository }}
         httpd:
+          image: proxy-httpd
           tag: {{ container_tag }}
         saltBroker:
+          image: proxy-salt-broker
           tag: {{ container_tag }}
         ssh:
+          image: proxy-ssh
           tag: {{ container_tag }}
         tftpd:
+          image: proxy-tftpd
           tag: {{ container_tag }}
         squid:
+          image: proxy-squid
           tag: {{ container_tag }}
     - makedirs: True
 


### PR DESCRIPTION
## What does this PR change?

We have those option available for the standalone server_containerized module but the cucumber_testsuite one does not properly forwards them when it's used to deploy a containerized server among its hosts.
