### PR TITLE
Install mgradm before configuring the additional_disks

### DIFF
--- a/salt/server_containerized/init.sls
+++ b/salt/server_containerized/init.sls
@@ -2,6 +2,7 @@ include:
   {% if 'build_image' not in grains.get('product_version') | default('', true) %}
   - repos
   {% endif %}
+  - server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
   - server_containerized.additional_disks
   - server_containerized.install_mgradm
   - server_containerized.initial_content

--- a/salt/server_containerized/install_mgradm.sls
+++ b/salt/server_containerized/install_mgradm.sls
@@ -1,6 +1,3 @@
-include:
-  - server_containerized.install_{{ grains.get('container_runtime') | default('podman', true) }}
-
 mgradm_config:
   file.managed:
     - name: /root/mgradm.yaml


### PR DESCRIPTION
## What does this PR change?

For MLM 5.1 on sles15sp7, the salt state `server_containerized.additional_disks` is failing because `mgr-storage-server` is not yet installed (done during combustion for slmicro61).
Move the uyuni tools installation outside mgradm installation state and call it before configuring the additional storages.
