### PR TITLE
Fix some issues deploying Uyuni released

### DIFF
--- a/modules/build_host/main.tf
+++ b/modules/build_host/main.tf
@@ -1,3 +1,7 @@
+locals {
+  product_version = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
+}
+
 module "build_host" {
   source = "../host"
 
@@ -17,7 +21,7 @@ module "build_host" {
   connect_to_additional_network = true
   roles                         = ["build_host"]
   disable_firewall              = var.disable_firewall
-  product_version               = var.product_version
+  product_version               = local.product_version
   grains = {
     mirror                 = var.base_configuration["mirror"]
     server                 = var.server_configuration["hostname"]

--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -1,3 +1,7 @@
+locals {
+  product_version = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
+}
+
 module "client" {
   source = "../host"
 
@@ -17,11 +21,11 @@ module "client" {
   connect_to_additional_network = false
   roles                         = ["client"]
   disable_firewall              = var.disable_firewall
-  product_version               = var.product_version
+  product_version               = local.product_version
   grains = {
-    mirror          = var.base_configuration["mirror"]
-    server          = var.server_configuration["hostname"]
-    auto_register   = var.auto_register
+    mirror                 = var.base_configuration["mirror"]
+    server                 = var.server_configuration["hostname"]
+    auto_register          = var.auto_register
     sles_registration_code = var.sles_registration_code
   }
 

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -16,6 +16,10 @@ variable "testsuite-branch" {
   }
 }
 
+locals {
+  product_version = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
+}
+
 module "controller" {
   source = "../host"
 
@@ -30,7 +34,7 @@ module "controller" {
   connect_to_base_network       = true
   connect_to_additional_network = false
   roles                         = ["controller"]
-  product_version               = var.product_version
+  product_version               = local.product_version
   grains = {
     cc_username  = var.base_configuration["cc_username"]
     cc_password  = var.base_configuration["cc_password"]
@@ -64,6 +68,7 @@ module "controller" {
     is_using_build_image      = var.is_using_build_image
     is_using_scc_repositories = var.is_using_scc_repositories
     server_instance_id        = var.server_instance_id
+    product_version           = local.product_version
     container_runtime         = lookup(var.server_configuration, "runtime", "")
     catch_timeout_message     = var.catch_timeout_message
     beta_enabled              = var.beta_enabled

--- a/modules/minion/main.tf
+++ b/modules/minion/main.tf
@@ -1,3 +1,7 @@
+locals {
+  product_version = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
+}
+
 module "minion" {
   source = "../host"
 
@@ -17,7 +21,7 @@ module "minion" {
   connect_to_additional_network = false
   roles                         = var.roles
   disable_firewall              = var.disable_firewall
-  product_version               = var.product_version
+  product_version               = local.product_version
   grains = merge({
     mirror                 = var.base_configuration["mirror"]
     server                 = var.auto_connect_to_master ? var.server_configuration["hostname"] : null

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -36,7 +36,7 @@ module "proxy" {
   connect_to_additional_network = true
   roles                         = ["proxy"]
   disable_firewall              = var.disable_firewall
-  product_version               = var.product_version
+  product_version               = local.product_version
   grains = {
     mirror                    = var.base_configuration["mirror"]
     server                    = var.server_configuration["hostname"]

--- a/modules/proxy_containerized/main.tf
+++ b/modules/proxy_containerized/main.tf
@@ -36,6 +36,7 @@ module "proxy_containerized" {
   second_additional_disk_size   = var.database_disk_size
   volume_provider_settings      = var.volume_provider_settings
   provision                     = var.provision
+  product_version               = local.product_version
 
   grains = {
     server                    = var.server_configuration["hostname"]

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -44,7 +44,7 @@ module "server" {
   additional_disk_size          = var.repository_disk_size
   second_additional_disk_size   = var.database_disk_size
   volume_provider_settings      = var.volume_provider_settings
-  product_version               = var.product_version
+  product_version               = local.product_version
   provision                     = var.provision
 
   grains = {
@@ -110,5 +110,6 @@ output "configuration" {
     hostname        = length(module.server.configuration["hostnames"]) > 0 ? module.server.configuration["hostnames"][0] : null
     username        = var.server_username
     password        = var.server_password
+    product_version    = local.product_version
   }
 }

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -43,6 +43,7 @@ module "server_containerized" {
   additional_disk_size          = var.repository_disk_size
   second_additional_disk_size   = var.database_disk_size
   volume_provider_settings      = var.volume_provider_settings
+  product_version               = local.product_version
 
   grains = {
     container_runtime              = var.runtime
@@ -90,6 +91,7 @@ output "configuration" {
     username           = var.server_username
     password           = var.server_password
     runtime            = var.runtime
+    product_version    = local.product_version
     first_user_present = true
   }
 }

--- a/modules/sshminion/main.tf
+++ b/modules/sshminion/main.tf
@@ -1,3 +1,7 @@
+locals {
+  product_version = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
+}
+
 module "sshminion" {
   source = "../host"
 
@@ -17,7 +21,7 @@ module "sshminion" {
   connect_to_additional_network = false
   roles                         = ["sshminion"]
   disable_firewall              = var.disable_firewall
-  product_version               = var.product_version
+  product_version               = local.product_version
   grains = {
     mirror                 = var.base_configuration["mirror"]
     sles_registration_code = var.sles_registration_code

--- a/modules/virthost/main.tf
+++ b/modules/virthost/main.tf
@@ -1,9 +1,13 @@
+locals {
+  product_version = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
+}
+
 module "virthost" {
   source = "../minion"
 
   base_configuration        = var.base_configuration
   name                      = var.name
-  product_version           = var.product_version
+  product_version           = local.product_version
   server_configuration      = var.server_configuration
   activation_key            = var.activation_key
   auto_connect_to_master    = var.auto_connect_to_master

--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -12,6 +12,12 @@ custom_avahi_repo:
     - baseurl: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools:/avahi:/0.6.32/SLE_12_SP5/
     {% elif grains['osrelease'] == '15.3' %}
     - baseurl: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools:/avahi:/0.7/SLE_15_SP3/
+    {% elif grains['osrelease'] == '15.4' %}
+    - baseurl: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools:/avahi:/0.7/SLE_15_SP4/
+    {% elif grains['osrelease'] == '15.5' %}
+    - baseurl: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools:/avahi:/0.8/SLE_15_SP5/
+    {% elif grains['osrelease'] == '15.6' %}
+    - baseurl: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools:/avahi:/0.8/SLE_15_SP6/
     {% endif %}
     - enabled: True
     - refresh: True
@@ -42,7 +48,6 @@ avahi_pkg:
       - nss-mdns
       {% elif grains['os_family'] == 'Suse' %}
       - avahi
-      - avahi-lang
       - libavahi-common3
       {% if grains['osmajorrelease']|int() == 11 %}
       - libavahi-core5

--- a/salt/server_containerized/large_deployment.sls
+++ b/salt/server_containerized/large_deployment.sls
@@ -60,7 +60,7 @@ reload_sshd:
     - watch:
       - file: large_deployment_increase_sshd_maxstartups
 
-{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') or 'head' in grains.get('product_version', '') or '5.1' in grains.get('product_version', '') %}
+{% if 'uyuni' in grains.get('product_version', '') or 'head' in grains.get('product_version', '') or '5.1' in grains.get('product_version', '') %}
 large_deployment_increase_database_max_connections_db_container:
   cmd.run:
     - name: podman exec uyuni-db sed -i "s/max_connections = .*/max_connections = 400/" /var/lib/pgsql/data/postgresql.conf


### PR DESCRIPTION
## What does this PR change?

This PR fixes two issues detected when deploying Uyuni released version:
- Fix state to configure DB in `uyuni-released`
- Fix some issues related to `avahi` (avahi-lang not existing in some cases - not really required for avahi functionality)
- Fix issue propagating `product_version` when defined for single modules [0]

[0] if the `product_version` is not set at `modules/xxxx/main.tf` then it won't be available here: https://github.com/uyuni-project/sumaform/blob/master/backend_modules/libvirt/host/main.tf#L18 meaning, it will always fetch the `product_version` defined in "base", not allowing defining it for individual nodes.