### PR TITLE
Support Ubuntu as controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 
 **/.*.sw*
 .*.sw*
+**/.DS_Store
+.DS_Store
 
 .idea
 sumaform.iml

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -155,7 +155,7 @@ module "controller" {
     salt_migration_minion    = length(var.salt_migration_minion_configuration["hostnames"]) > 0 ? var.salt_migration_minion_configuration["hostnames"][0] : null
   }
 
-  image   = "opensuse156o"
+  image             = var.image == null ? "opensuse156o" : var.image
   provider_settings = var.provider_settings
 }
 
@@ -164,5 +164,6 @@ output "configuration" {
     id       = length(module.controller.configuration["ids"]) > 0 ? module.controller.configuration["ids"][0] : null
     hostname = length(module.controller.configuration["hostnames"]) > 0 ? module.controller.configuration["hostnames"][0] : null
     branch   = var.branch == "default" ? var.testsuite-branch[var.server_configuration["product_version"]] : var.branch
+    image    = var.image
   }
 }

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -7,6 +7,12 @@ variable "name" {
   type        = string
 }
 
+variable "image" {
+  description = "An image name, e.g. ubuntu2404o or opensuse156o"
+  type        = string
+  default     = null
+}
+
 variable "cc_ptf_username" {
   description = "username of SCC organization having PTFs available"
   type        = string

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -524,6 +524,7 @@ module "controller" {
   swap_file_size           = null
   beta_enabled             = var.beta_enabled
   web_server_hostname      = var.web_server_hostname
+  image                    = var.playwright_framework == true ? "ubuntu2404o" : "opensuse156o"
 
   additional_repos  = lookup(local.additional_repos, "controller", {})
   additional_repos_only  = lookup(local.additional_repos_only, "controller", false)

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -197,3 +197,8 @@ variable "web_server_hostname" {
   description = "FQDN of the web server or leave the default for no web server"
   default = null
 }
+
+variable "playwright_framework" {
+  description = "Use Playwright Test Framework to run tests"
+  default     = false
+}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -137,8 +137,19 @@ export PRODUCT="SUSE Multi-Linux Manager"
 export GEM_PATH="/usr/lib64/ruby/gems/3.3.0"
 
 #### Generate certificates for Google Chrome
-if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then
-  wget http://$SERVER/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$SERVER.cert
-  update-ca-certificates
-  certutil -d sql:/root/.pki/nssdb -A -t TC -n "susemanager" -i  /etc/pki/trust/anchors/$SERVER.cert
+. /etc/os-release
+if [[ "$ID_LIKE" == *"debian"* ]]; then
+    if [ ! -f /usr/local/share/ca-certificates/$SERVER.cert ]; then
+      (
+        wget http://$SERVER/pub/RHN-ORG-TRUSTED-SSL-CERT -O /usr/local/share/ca-certificates/$SERVER.cert
+        sudo update-ca-certificates
+        certutil -d sql:/root/.pki/nssdb -A -t TC -n "susemanager" -i  /usr/local/share/ca-certificates/$SERVER.cert
+      ) >/dev/null 2>>/tmp/susemanager-cert-setup.err.log
+    fi
+else
+    if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then
+      wget http://$SERVER/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$SERVER.cert
+      update-ca-certificates
+      certutil -d sql:/root/.pki/nssdb -A -t TC -n "susemanager" -i  /etc/pki/trust/anchors/$SERVER.cert
+    fi
 fi

--- a/salt/controller/https_server.py
+++ b/salt/controller/https_server.py
@@ -3,11 +3,39 @@ import ssl
 import socketserver
 import os
 
-# Define the port and the certificate file paths
+is_debian_family = False
+
+# Check for the /etc/os-release file (standard across most modern Linux)
+if os.path.exists("/etc/os-release"):
+    try:
+        # Read the file and parse it into a dictionary
+        os_info = {}
+        with open("/etc/os-release", "r") as f:
+            for line in f:
+                if "=" in line:
+                    key, value = line.strip().split("=", 1)
+                    # Remove quotes from the value
+                    os_info[key] = value.strip('"')
+
+        # Check for Debian or Ubuntu, or if the system is Debian-like
+        system_id = os_info.get("ID", "").lower()
+        id_like = os_info.get("ID_LIKE", "").lower()
+
+        if system_id in ("debian", "ubuntu") or "debian" in id_like:
+            is_debian_family = True
+
+    except Exception as e:
+        print(f"Warning: Could not read /etc/os-release. Falling back to defaults. Error: {e}")
+
 PORT = 443
-CERT_FILE = "/etc/apache2/ssl.crt/selfsigned.crt"
-KEY_FILE = "/etc/apache2/ssl.key/selfsigned.key"
-DIRECTORY = "/root/spacewalk/testsuite" # Use the original working directory
+if is_debian_family:
+    CERT_FILE = "/etc/ssl/certs/selfsigned.crt"
+    KEY_FILE = "/etc/ssl/private/selfsigned.key"
+    DIRECTORY = "/root/spacewalk/"
+else:
+    CERT_FILE = "/etc/apache2/ssl.crt/selfsigned.crt"
+    KEY_FILE = "/etc/apache2/ssl.key/selfsigned.key"
+    DIRECTORY = "/root/spacewalk/testsuite"
 
 # Change the current working directory to the target directory
 os.chdir(DIRECTORY)

--- a/salt/controller/run-testsuite
+++ b/salt/controller/run-testsuite
@@ -9,8 +9,15 @@ if [ "$1" = "-d" -o "$1" = "--dont-fail" ]; then
 fi
 RESULT=0
 
+. /etc/os-release
+OS_FAMILY="${ID_LIKE:-$ID}"
+
 stage() {
-  rake "cucumber:$1"
+  if [[ "$OS_FAMILY" == *"debian"* ]]; then
+    npm run "cucumber:$1"
+  else
+    rake "cucumber:$1"
+  fi
   if [ $? -ne 0 ]; then
     [ $ABORT_ON_ERROR -ne 0 ] && exit -1
     RESULT=1
@@ -18,7 +25,11 @@ stage() {
 }
 
 parallel_stage() {
-  rake "parallel:$1"
+  if [[ "$OS_FAMILY" == *"debian"* ]]; then
+    npm run "cucumber:$1"
+  else
+    rake "parallel:$1"
+  fi
   if [ $? -ne 0 ]; then
     [ $ABORT_ON_ERROR -ne 0 ] && exit -1
     RESULT=1
@@ -71,25 +82,6 @@ fi
 # SLE updates tests
 if [ "$1" = "sle-updates" ]; then
   stage sle-updates
-fi
-
-# QAM
-if [ "$1" = "qam" ]; then
-  stage qam_add_custom_repositories
-  stage qam_add_activation_keys
-  stage qam_init_proxy
-  stage qam_init_clients
-  stage qam_smoke_tests
-  stage qam_finishing
-fi
-
-if [ "$1" = "qam-parallel" ]; then
-  parallel_stage qam_add_custom_repositories
-  parallel_stage qam_add_activation_keys
-  stage qam_init_proxy
-  parallel_stage qam_init_clients
-  parallel_stage qam_smoke_tests
-  stage qam_finishing
 fi
 
 exit $RESULT

--- a/salt/controller/ssh_config
+++ b/salt/controller/ssh_config
@@ -1,0 +1,5 @@
+Host *
+   User root
+   IdentityFile /root/.ssh/id_ed25519
+   StrictHostKeyChecking no
+   UserKnownHostsFile=/root/.ssh/known_hosts


### PR DESCRIPTION
## What does this PR change?

This pull request introduce the support of both openSUSE and Debian-family systems in the controller and test automation setup. The main changes include conditional logic in Salt states, scripts, and configuration files to handle OS-specific differences, especially regarding package installation, SSL certificate paths, and test execution commands.

The result is the possibility to switch between a Cucumber-Selenium Test Runner ( `image = "opensuse156o"`, default) or Cucumber-Playwright Test Runner (`image = "ubuntu2404o"`).
