### PR TITLE
Update to Ruby 4.0.0

### DIFF
--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -134,7 +134,7 @@ export PRODUCT="SUSE Multi-Linux Manager"
 {% endif %}
 
 # Ruby specific settings
-export GEM_PATH="/usr/lib64/ruby/gems/3.3.0"
+export GEM_PATH="/usr/lib64/ruby/gems/4.0.0"
 
 #### Generate certificates for Google Chrome
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -34,8 +34,8 @@ cucumber_requisites:
       - wget
       - libssh-devel
       - python-devel
-      - ruby3.3
-      - ruby3.3-devel
+      - ruby4.0
+      - ruby4.0-devel
       - autoconf
       - ca-certificates-mozilla
       - automake
@@ -55,34 +55,34 @@ cucumber_requisites:
 
 /usr/bin/ruby:
   file.symlink:
-    - target: /usr/bin/ruby.ruby3.3
+    - target: /usr/bin/ruby.ruby4.0
     - force: True
 
 /usr/bin/gem:
   file.symlink:
-    - target: /usr/bin/gem.ruby3.3
+    - target: /usr/bin/gem.ruby4.0
     - force: True
 
 /usr/bin/irb:
   file.symlink:
-    - target: /usr/bin/irb.ruby3.3
+    - target: /usr/bin/irb.ruby4.0
     - force: True
 
 ruby_set_rake_version:
   cmd.run:
-    - name: update-alternatives --set rake /usr/bin/rake.ruby.ruby3.3
+    - name: update-alternatives --set rake /usr/bin/rake.ruby.ruby4.0
 
 ruby_set_bundle_version:
   cmd.run:
-    - name: update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.3
+    - name: update-alternatives --set bundle /usr/bin/bundle.ruby.ruby4.0
 
 ruby_set_rdoc_version:
   cmd.run:
-    - name: update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.3
+    - name: update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby4.0
 
 ruby_set_ri_version:
   cmd.run:
-    - name: update-alternatives --set ri /usr/bin/ri.ruby.ruby3.3
+    - name: update-alternatives --set ri /usr/bin/ri.ruby.ruby4.0
 
 install_chromium:
   pkg.installed:
@@ -104,7 +104,7 @@ install_npm:
 
 install_gems_via_bundle:
   cmd.run:
-    - name: bundle.ruby3.3 install --gemfile Gemfile
+    - name: bundle.ruby4.0 install --gemfile Gemfile
     - cwd: /root/spacewalk/testsuite
     - require:
       - pkg: cucumber_requisites


### PR DESCRIPTION
## What does this PR change?

This bumps Ruby from version 3.3.x to 4.0.0.


## Outcome
The deployment with the changes was successful and the new version is shown.
```bash
dominik-controller:~/spacewalk/testsuite # ruby --version
ruby 4.0.0 (2025-12-25 revision 553f1675f3) +PRISM [x86_64-linux-gnu]
dominik-controller:~/spacewalk/testsuite # gem --version
4.0.3
```


## Links
- https://www.ruby-lang.org/en/news/2025/12/25/ruby-4-0-0-released/
- https://github.com/uyuni-project/uyuni/pull/11349