### PR TITLE
Add forward_registration variable

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -21,7 +21,7 @@ data "aws_ami" "tumbleweedo" {
 
 data "aws_ami" "opensuse156o" {
   most_recent = true
-  name_regex  = "^openSUSE-Leap-15-6-"
+  name_regex  = "^openSUSE-Leap-15.6-"
   owners      = ["679593333241"]
 
   filter {

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -70,6 +70,7 @@ module "server_containerized" {
     database_disk_size             = var.database_disk_size
     skip_changelog_import          = var.skip_changelog_import
     create_first_user              = true
+    forward_registration           = var.forward_registration
     mgr_sync_autologin             = var.mgr_sync_autologin
     create_sample_channel          = var.create_sample_channel
     create_sample_activation_key   = var.create_sample_activation_key

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -341,6 +341,7 @@ variable "server_mounted_mirror" {
 
 variable "forward_registration" {
   description = "Forward client registrations to SCC"
+  type        = bool
   default     = false
 }
 

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -339,6 +339,11 @@ variable "server_mounted_mirror" {
   default     = null
 }
 
+variable "forward_registration" {
+  description = "Forward client registrations to SCC"
+  default     = false
+}
+
 variable "large_deployment" {
   description = "set up for a deployment with a great number of clients"
   type        = bool

--- a/salt/server_containerized/rhn.sls
+++ b/salt/server_containerized/rhn.sls
@@ -43,11 +43,11 @@ write_rhn_conf:
         java.cve_audit.enable_oval_metadata: true
         {% endif %}
 
-{% if grains.get('enable_oval_metadata') | default(false, true) %}
-oval_metadata_services_restart:
+manager_services_restart:
   cmd.run:
     - name: mgrctl exec systemctl restart tomcat taskomatic
-{% endif %}
+    - watch:
+      - manage_config: write_rhn_conf
 
 {% if 'nightly' in grains.get('product_version', '') %}
 change_web_version:


### PR DESCRIPTION
## What does this PR change?

# WIP - DO NOT MERGE 

Related to https://github.com/SUSE/spacewalk/issues/29552

Adds a variable for the server_containerized module, allowing to enable or disable the forward registration of data to SCC.
Without it, he default is to have it disabled in rhn.conf.
For PAYG images, having this option disabled results in the instance being detected as non compliant, blocking most functionalities.
