### PR TITLE
[Draft] Refactor Controller to run Testsuite in Podman Container

### DIFF
--- a/salt/controller/apache_https.sls
+++ b/salt/controller/apache_https.sls
@@ -1,30 +1,31 @@
 {% set doc_root = '/root/spacewalk/testsuite' %}
 {% set server_name = grains.get('fqdn') or grains.get('ipv4') | first %}
 
-# Ensure Apache is stopped (since Python is taking port 443)
+# Ensure Apache is stopped on host (ports will be used by container)
 apache2_service_stopped:
   service.dead:
     - name: apache2
     - enable: False
 
-# Install Apache SSL package (needed for certificate generation tools)
+# Install Apache SSL package (needed for certificate generation tools on host)
 apache2_ssl_package:
   pkg.installed:
     - name: apache2-mod_nss
 
-# Generate Self-Signed Certificate (used by Python script)
+# Generate Self-Signed Certificate (Mounted into container)
 self_signed_cert:
   cmd.run:
     - name: |
+        mkdir -p /etc/apache2/ssl.key /etc/apache2/ssl.crt
         openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
         -keyout /etc/apache2/ssl.key/selfsigned.key \
         -out /etc/apache2/ssl.crt/selfsigned.crt \
         -subj '/CN={{ server_name }}/O=Controller/OU=Testsuite'
     - unless: test -f /etc/apache2/ssl.crt/selfsigned.crt
     - require:
-      - pkg: apache2_ssl_package
+        - pkg: apache2_ssl_package
 
-# Manage the Python Script file
+# Manage the Python Script file (Mounted into container)
 https_python_script_file:
   file.managed:
     - name: /usr/local/lib/https_server.py
@@ -32,25 +33,3 @@ https_python_script_file:
     - user: root
     - group: root
     - mode: 755
-
-# Manage the systemd service unit file
-https_testsuite_service_file:
-  file.managed:
-    - name: /etc/systemd/system/https_testsuite.service
-    - source: salt://controller/https_testsuite.service
-    - user: root
-    - group: root
-    - mode: 600
-    - require:
-      - file: https_python_script_file
-      - service: apache2_service_stopped
-
-# Run the new HTTPS service
-https_testsuite_service:
-  service.running:
-    - name: https_testsuite
-    - enable: true
-    - require:
-      - file: https_testsuite_service_file
-      - cmd: self_signed_cert
-      - cmd: spacewalk_git_repository

--- a/salt/controller/apache_https.sls
+++ b/salt/controller/apache_https.sls
@@ -16,11 +16,14 @@ apache2_ssl_package:
 self_signed_cert:
   cmd.run:
     - name: |
-        mkdir -p /etc/apache2/ssl.key /etc/apache2/ssl.crt
+        mkdir -p /etc/apache2/ssl.crt
+        install -d -m 700 /etc/apache2/ssl.key
+        umask 077
         openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
         -keyout /etc/apache2/ssl.key/selfsigned.key \
         -out /etc/apache2/ssl.crt/selfsigned.crt \
         -subj '/CN={{ server_name }}/O=Controller/OU=Testsuite'
+        chmod 600 /etc/apache2/ssl.key/selfsigned.key
     - unless: test -f /etc/apache2/ssl.crt/selfsigned.crt
     - require:
         - pkg: apache2_ssl_package

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -77,7 +77,7 @@ testsuite_env_vars:
     - template: jinja
     - user: root
     - group: root
-    - mode: 755
+    - mode: 600
 
 # Deploy the updated run-testsuite script
 cucumber_run_script:

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -146,5 +146,6 @@ configure_container:
 start_https_service_container:
   cmd.run:
     - name: podman exec -d uyuni-controller python3 /usr/local/lib/https_server.py
+    - unless: podman exec uyuni-controller pgrep -f https_server.py >/dev/null 2>&1
     - require:
         - cmd: configure_container

--- a/salt/controller/run-testsuite
+++ b/salt/controller/run-testsuite
@@ -12,8 +12,9 @@ if ! podman ps | grep -q "$CONTAINER"; then
 fi
 
 run_in_container() {
-    # We source the environment variables before running the rake command
-    podman exec -t "$CONTAINER" /bin/bash -c "source /root/salt_env.sh && cd $WORKDIR && $*"
+    # We source the environment variables before running the command,
+    # and preserve argument boundaries by passing them as positional parameters.
+    podman exec -t "$CONTAINER" /bin/bash -lc 'source /root/salt_env.sh && cd '"$WORKDIR"' && "$@"' bash "$@"
 }
 
 ABORT_ON_ERROR=1

--- a/salt/controller/run-testsuite
+++ b/salt/controller/run-testsuite
@@ -1,6 +1,20 @@
 #! /bin/bash
 
-cd /root/spacewalk/testsuite
+# Define the container name
+CONTAINER="uyuni-controller"
+WORKDIR="/root/spacewalk/testsuite"
+
+# Helper to execute commands inside the container
+# We verify the container is running first
+if ! podman ps | grep -q "$CONTAINER"; then
+    echo "Error: Container $CONTAINER is not running."
+    exit 1
+fi
+
+run_in_container() {
+    # We source the environment variables before running the rake command
+    podman exec -t "$CONTAINER" /bin/bash -c "source /root/salt_env.sh && cd $WORKDIR && $*"
+}
 
 ABORT_ON_ERROR=1
 if [ "$1" = "-d" -o "$1" = "--dont-fail" ]; then
@@ -10,7 +24,7 @@ fi
 RESULT=0
 
 stage() {
-  rake "cucumber:$1"
+  run_in_container rake "cucumber:$1"
   if [ $? -ne 0 ]; then
     [ $ABORT_ON_ERROR -ne 0 ] && exit -1
     RESULT=1
@@ -18,12 +32,14 @@ stage() {
 }
 
 parallel_stage() {
-  rake "parallel:$1"
+  run_in_container rake "parallel:$1"
   if [ $? -ne 0 ]; then
     [ $ABORT_ON_ERROR -ne 0 ] && exit -1
     RESULT=1
   fi
 }
+
+# The rest of the logic remains identical, just calling the wrapper functions
 
 # normal run
 if [ -z "$1" ]; then

--- a/salt/controller/run-testsuite
+++ b/salt/controller/run-testsuite
@@ -6,7 +6,7 @@ WORKDIR="/root/spacewalk/testsuite"
 
 # Helper to execute commands inside the container
 # We verify the container is running first
-if ! podman ps | grep -q "$CONTAINER"; then
+if ! podman inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null | grep -q '^true$'; then
     echo "Error: Container $CONTAINER is not running."
     exit 1
 fi


### PR DESCRIPTION
Note: This code has been developped with the help of Gemini Assistant.

Pending: Refactor Rakefile

## What does this PR change?

This PR refactors the controller deployment logic to containerize the test environment. Instead of installing dependencies (Ruby, Chromium, GCC, etc.) directly on the host VM, the test suite now runs inside the `ghcr.io/uyuni-project/uyuni/ci-test-controller-dev:master` container image using **Podman**.

This change ensures the test environment matches the CI environment exactly and keeps the host system clean.

### Key Changes

**Containerization**:
* Replaced the direct installation of development packages and tools in `controller/init.sls` with the deployment of the `uyuni-controller` container.
* Switched to **Podman** as the container runtime.
* configured volume mounts to share critical host files with the container:
* `spacewalk` git repository
* SSH keys and `.netrc` for git authentication
* SSL certificates
* Environment variables (`salt_env.sh`)

**Salt States Refactoring**:
* `controller/init.sls`: Now handles Podman installation, container lifecycle, and bootstrapping the container environment (e.g., sourcing env vars, installing specific npm packages).
* `controller/apache_https.sls`: Removed the Apache service definition (as the server runs inside the container) but retained certificate generation on the host for mounting.

**Test Execution Wrapper**:
* Updated `controller/run-testsuite` to act as a wrapper script. It now forwards `rake` commands to the running Podman container via `podman exec`, preserving the existing CLI workflow.

**Dependency**: 

We need to merge https://github.com/uyuni-project/uyuni/pull/11450, and publish a new controller container image, so we have installed the Cucumber HTML Reporter, required for test suite execute on-premise.

