### PR TITLE
Switch to 5.2-released (currently 5.2 beta 1)

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -13,6 +13,7 @@ Legal values for released software are:
 - `4.3-VM-released` (latest released maintenance update for SUSE Manager 4.3 virtual machine)
 - `5.0-released` (latest released maintenance update for SUSE Manager 5.0 and Tools)
 - `5.1-released` (latest released maintenance update for Multi Linux Manager 5.1 and Tools)
+- `5.2-released` (latest released maintenance update for Multi Linux Manager 5.2 and Tools)
 - `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
 
 Legal values for work-in-progress software are:

--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -101,39 +101,40 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
   %{ if container_server || container_proxy || server_kubernetes || proxy_kubernetes }
     %{ if product_version == "uyuni-master" || product_version == "uyuni-pr" }
       zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/openSUSE_Leap_16.0/ container_utils_repo
-    %{ else }
-      %{ if product_version == "5.1-released" }
-        %{ if container_server }
-          zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Server/5.1/x86_64/product container_utils_repo
-        %{ endif }
-        %{ if container_proxy }
-          zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Proxy/5.1/x86_64/product/ container_utils_repo
-        %{ endif }
-      %{ else }
-        %{ if product_version == "5.1-nightly" }
-          %{ if container_server }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/5.1/images/repo/Multi-Linux-Manager-Server-5.1-x86_64/ container_utils_repo
-          %{ endif }
-          %{ if container_proxy }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/5.1/images/repo/Multi-Linux-Manager-Proxy-5.1-x86_64/ container_utils_repo
-          %{ endif }
-        %{ endif }
-        %{ if product_version == "head" }
-          %{ if container_server || server_kubernetes }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
-          %{ endif }
-          %{ if container_proxy || proxy_kubernetes }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
-          %{ endif }
-        %{ endif }
-        %{ if product_version == "head-staging" }
-          %{ if container_server || server_kubernetes }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
-          %{ endif }
-          %{ if container_proxy || proxy_kubernetes }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
-          %{ endif }
-        %{ endif }
+    %{ elif product_version == "5.1-released" }
+      %{ if container_server }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Server/5.1/x86_64/product container_utils_repo
+      %{ endif }
+      %{ if container_proxy }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Proxy/5.1/x86_64/product/ container_utils_repo
+      %{ endif }
+    %{ elif product_version == "5.1-nightly" }
+      %{ if container_server }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/5.1/images/repo/Multi-Linux-Manager-Server-5.1-x86_64/ container_utils_repo
+      %{ endif }
+      %{ if container_proxy }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/5.1/images/repo/Multi-Linux-Manager-Proxy-5.1-x86_64/ container_utils_repo
+      %{ endif }
+    %{ elif product_version == "5.2-released" }
+      %{ if container_server }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Server/5.2/x86_64/product container_utils_repo
+      %{ endif }
+      %{ if container_proxy }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Proxy/5.2/x86_64/product/ container_utils_repo
+      %{ endif }
+    %{ elif product_version == "head" }
+      %{ if container_server || server_kubernetes }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
+      %{ endif }
+      %{ if container_proxy || proxy_kubernetes }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
+      %{ endif }
+    %{ elif product_version == "head-staging" }
+      %{ if container_server || server_kubernetes }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
+      %{ endif }
+      %{ if container_proxy || proxy_kubernetes }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
       %{ endif }
     %{ endif }
   %{ endif }
@@ -145,28 +146,26 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
   # Still embryonary; only some cases are considered for now
   %{ if container_server || container_proxy }
     %{ if product_version == "5.2-released" }
-          %{ if container_server }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Server/5.2/x86_64/product container_utils_repo
-          %{ endif }
-          %{ if container_proxy }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Proxy/5.2/x86_64/product/ container_utils_repo
-          %{ endif }
-    %{ endif }
-    %{ if product_version == "head" }
-          %{ if container_server }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
-          %{ endif }
-          %{ if container_proxy }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
-          %{ endif }
-    %{ endif }
-    %{ if product_version == "head-staging" }
-          %{ if container_server }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
-          %{ endif }
-          %{ if container_proxy }
-            zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
-          %{ endif }
+      %{ if container_server }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Server/5.2/x86_64/product container_utils_repo
+      %{ endif }
+      %{ if container_proxy }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Proxy/5.2/x86_64/product/ container_utils_repo
+      %{ endif }
+    %{ elif product_version == "head" }
+      %{ if container_server }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
+      %{ endif }
+      %{ if container_proxy }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
+      %{ endif }
+    %{ elif product_version == "head-staging" }
+      %{ if container_server }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
+      %{ endif }
+      %{ if container_proxy }
+        zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
+      %{ endif }
     %{ endif }
   %{ endif }
 %{ endif } # end of image == "slmicro62o" block

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -84,7 +84,7 @@ variable "is_server_paygo_instance" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-nightly, 4.3-released, 4.3-pr, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-nightly, 4.3-released, 4.3-pr, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = ""
 }

--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -127,7 +127,7 @@ variable "volume_provider_settings" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/build_host/variables.tf
+++ b/modules/build_host/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -9,6 +9,9 @@ variable "testsuite-branch" {
     "5.0-nightly"    = "Manager-5.0"
     "5.1-released"   = "Manager-5.1"
     "5.1-nightly"    = "Manager-5.1"
+    #TODO: use final value
+    "5.2-released"   = "master"
+    # "5.2-released"   = "Manager-5.2"
     "head"           = "master"
     "head-staging"   = "master"
     "uyuni-master"   = "master"

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -806,7 +806,7 @@ variable "server_instance_id" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -13,7 +13,7 @@ variable "roles" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/proxy_containerized/variables.tf
+++ b/modules/proxy_containerized/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/proxy_kubernetes/main.tf
+++ b/modules/proxy_kubernetes/main.tf
@@ -6,6 +6,7 @@ variable "images" {
     "5.0-nightly"    = "ubuntu2404o"
     "5.1-released"   = "ubuntu2404o"
     "5.1-nightly"    = "ubuntu2404o"
+    "5.2-released"   = "ubuntu2404o"
     "uyuni-master"   = "ubuntu2404o"
     "uyuni-released" = "ubuntu2404o"
     "uyuni-pr"       = "ubuntu2404o"

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -48,7 +48,7 @@ variable "db_container_tag" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -8,6 +8,7 @@ variable "images" {
     "5.0-nightly"    = "ubuntu2404o"
     "5.1-released"   = "ubuntu2404o"
     "5.1-nightly"    = "ubuntu2404o"
+    "5.2-released"   = "ubuntu2404o"
     "uyuni-master"   = "ubuntu2404o"
     "uyuni-released" = "ubuntu2404o"
     "uyuni-pr"       = "ubuntu2404o"

--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/salt/repos/proxy_containerized.sls
+++ b/salt/repos/proxy_containerized.sls
@@ -5,6 +5,8 @@ include:
   - repos.proxy_containerized50
   {% elif '5.1' in grains.get('product_version') %}
   - repos.proxy_containerized51
+  {% elif '5.2' in grains.get('product_version') %}
+  - repos.proxy_containerized52
   {%- elif 'head' in grains['product_version'] %}
   - repos.proxy_containerizedMain
   {%- else %}

--- a/salt/repos/proxy_containerized52.sls
+++ b/salt/repos/proxy_containerized52.sls
@@ -1,0 +1,54 @@
+{% if 'proxy_containerized' in grains.get('roles') %}
+
+{% if grains.get("os") == 'SUSE' %}
+{% if grains['osfullname'] == 'SL-Micro' %}
+
+{% if '5.2-released' in grains['product_version'] %}
+# Commented out because we already add this repo in cloud-init:
+# container_utils_pool_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Proxy/5.2/{{ grains.get("cpuarch") }}/product
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Proxy/5.2/{{ grains.get("cpuarch") }}/product/repodata/repomd.xml.key
+# container_utils_updates_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Proxy/5.2/{{ grains.get("cpuarch") }}/update
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Proxy/5.2/{{ grains.get("cpuarch") }}/update/repodata/repomd.xml.key
+{% endif %}
+
+{% elif grains['osfullname'] == 'SLES' %}
+ca_suse_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/SUSE:/CA/SLE_15_SP7
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/SUSE:/CA/SLE_15_SP7/repodata/repomd.xml.key
+
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15-SP7/{{ grains.get("cpuarch") }}/product
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15-SP7/{{ grains.get("cpuarch") }}/product/repodata/repomd.xml.key
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15-SP7/{{ grains.get("cpuarch") }}/update
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15-SP7/{{ grains.get("cpuarch") }}/update/repodata/repomd.xml.key
+
+{% if '5.2-released' in grains['product_version'] %}
+container_utils_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Proxy-SLE/5.2/{{ grains.get("cpuarch") }}/product
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Proxy-SLE/5.2/{{ grains.get("cpuarch") }}/product/repodata/repomd.xml.key
+container_utils_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Proxy-SLE/5.2/{{ grains.get("cpuarch") }}/update
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Proxy-SLE/5.2/{{ grains.get("cpuarch") }}/update/repodata/repomd.xml.key
+{% endif %}
+
+# WORKAROUND: see github:saltstack/salt#10852
+{{ sls }}_nop:
+  test.nop: []

--- a/salt/repos/server_containerized.sls
+++ b/salt/repos/server_containerized.sls
@@ -5,6 +5,8 @@ include:
   - repos.server_containerized50
   {% elif '5.1' in grains.get('product_version') %}
   - repos.server_containerized51
+  {% elif '5.2' in grains.get('product_version') %}
+  - repos.server_containerized52
   {%- elif 'head' in grains['product_version'] %}
   - repos.server_containerizedMain
   {%- else %}

--- a/salt/repos/server_containerized52.sls
+++ b/salt/repos/server_containerized52.sls
@@ -1,0 +1,59 @@
+{% if 'server_containerized' in grains.get('roles')  %}
+
+{% if grains.get("os") == 'SUSE' %}
+{% if grains['osfullname'] == 'SL-Micro' %}
+
+{% if '5.2-released' in grains['product_version'] %}
+# Commented out because we already add this repo in cloud-init:
+# container_utils_pool_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Server/5.2/{{ grains.get("cpuarch") }}/product
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Server/5.2/{{ grains.get("cpuarch") }}/product/repodata/repomd.xml.key
+# container_utils_updates_repo:
+#   pkgrepo.managed:
+#     - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Server/5.2/{{ grains.get("cpuarch") }}/update
+#     - refresh: True
+#     - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Server/5.2/{{ grains.get("cpuarch") }}/update/repodata/repomd.xml.key
+{% endif %}
+
+{% elif grains['osfullname'] == 'SLES' %}
+ca_suse_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/SUSE:/CA/SLE_15_SP7
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/SUSE:/CA/SLE_15_SP7/repodata/repomd.xml.key
+
+containers_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15-SP7/{{ grains.get("cpuarch") }}/product
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Containers/15-SP7/{{ grains.get("cpuarch") }}/product/repodata/repomd.xml.key
+
+containers_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15-SP7/{{ grains.get("cpuarch") }}/update
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Containers/15-SP7/{{ grains.get("cpuarch") }}/update/repodata/repomd.xml.key
+
+{% if '5.2-released' in grains['product_version'] %}
+container_utils_pool_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Server-SLE/5.2/{{ grains.get("cpuarch") }}/product
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Products/Multi-Linux-Manager-Server-SLE/5.2/{{ grains.get("cpuarch") }}/product/repodata/repomd.xml.key
+container_utils_updates_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Server-SLE/5.2/{{ grains.get("cpuarch") }}/update
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("dist.suse.de/ibs", true) }}/SUSE/Updates/Multi-Linux-Manager-Server-SLE/5.2/{{ grains.get("cpuarch") }}/update/repodata/repomd.xml.key
+{% endif %}
+
+{% endif %}
+{% endif %}
+{% endif %}
+
+
+# WORKAROUND: see github:saltstack/salt#10852
+{{ sls }}_nop:
+  test.nop: []

--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -108,7 +108,7 @@ suse_staging_key_import:
 
 {% endif %}
 
-{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "head-staging", "5.0-nightly", "5.0-released", "5.1-nightly", "5.1-released"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "head-staging", "5.0-nightly", "5.0-released", "5.1-nightly", "5.1-released", "5.2-released"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,


### PR DESCRIPTION
## What does this PR change?

In 5.2 Build Validation, now we start to have usable 5.2 branches, it's time to drift away from Head.

This PR adds support for 5.2-released product (currently 5.2 beta 1).

Piggyback: use `%{ elif product_version ==` in jinja instead of `%{ else } %{ if product_version ==` .