### PR TITLE
Create sshd config file if absent

### DIFF
--- a/salt/default/sshd.sls
+++ b/salt/default/sshd.sls
@@ -1,5 +1,7 @@
 {% if 'client' in grains.get('roles') or 'minion' in grains.get('roles') or 'sshminion' in grains.get('roles') %}
 
+# Recent distributions use drop-in configuration files
+# in /etc/ssh/sshd_config.d/ instead of modifying the main file
 {% set sshd_config = "/etc/ssh/sshd_config" %}
 {% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
   {% set sshd_config = "/etc/ssh/sshd_config.d/root.conf" %}
@@ -8,14 +10,23 @@
     {% set sshd_config = "/etc/ssh/sshd_config.d/root.conf" %}
   {% endif %}
 {% elif grains['osfullname'] == 'SL-Micro' %}
-  {% if grains['osrelease'] == '6.0' or grains['osrelease'] == '6.1' or grains['osrelease'] == '6.2' %}
+  {% if grains['osrelease'] in ['6.0', '6.1', '6.2'] %}
     {% set sshd_config = "/etc/ssh/sshd_config.d/root.conf" %}
   {% endif %}
 {% endif %}
 
+ensure_sshd_config_exists:
+  file.managed:
+    - name: {{ sshd_config }}
+    - replace: False
+    - user: root
+    - group: root
+    - mode: '0600'
+    - makedirs: True
+
 sshd_change_challengeresponseauthentication:
   file.replace:
-    - name: {{sshd_config}}
+    - name: {{ sshd_config }}
     - pattern: "^ChallengeResponseAuthentication.*"
     - repl: "ChallengeResponseAuthentication yes"
     - append_if_not_found: True


### PR DESCRIPTION
## What does this PR change?

Create sshd config file if absent

It's for the Tumbleweed case, but it's done in a generic manner