### PR TITLE
fix: skip scc_data_refresh if cc_username is not set

### DIFF
--- a/salt/server_containerized/initial_content.sls
+++ b/salt/server_containerized/initial_content.sls
@@ -29,6 +29,7 @@ scc_data_refresh:
     - args: "{{ server_username }} {{ server_password }}"
     - require:
       - cmd: mgradm_install
+    - unless: test -z "{{ grains.get('cc_username') or '' }}"
 
 {% if grains.get('channels') %}
 add_channels:

--- a/salt/server_containerized/initial_content.sls
+++ b/salt/server_containerized/initial_content.sls
@@ -22,6 +22,7 @@ mgr_sync_automatic_authentication:
 
 {% endif %}
 
+{% if grains.get('cc_username') %}
 scc_data_refresh:
   cmd.script:
     - name: salt://server_containerized/wait_for_mgr_sync.sh
@@ -29,7 +30,7 @@ scc_data_refresh:
     - args: "{{ server_username }} {{ server_password }}"
     - require:
       - cmd: mgradm_install
-    - unless: test -z "{{ grains.get('cc_username') or '' }}"
+{% endif %}
 
 {% if grains.get('channels') %}
 add_channels:


### PR DESCRIPTION
## What does this PR change?

Fixes the issue #2091 tofu apply hangs indefinitely when deploying a containerized Uyuni server without SCC credentials.

## Problem

The `scc_data_refresh` state runs `wait_for_mgr_sync.sh` unconditionally. This script polls `mgr-sync` in a loop waiting for channel and product synchronization to complete. Without SCC credentials (which is the normal case for Uyuni deployments), the sync always fails with

```
Error: <Fault 10104: 'redstone.xmlrpc.XmlRpcFault: No SCC organization credentials found.'>
```

causing the loop to never exit and `tofu apply` to hang forever until manually killed.