### PR TITLE
Oracle 9 defines PermitRootLogin via a drop-in

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -904,7 +904,7 @@ yum_repos:
 
 runcmd:
   # WORKAROUND: cloud-init in Oracle 9 does not take care of the following
-  - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
+  - echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
   - systemctl restart sshd
 %{ if install_salt_bundle ~}
   - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent dbus-tools tar"


### PR DESCRIPTION
## What does this PR change?

Oracle 9 defines `PermitRootLogin` option via a drop-in `/etc/ssh/sshd_config.d/01-permitrootlogin.conf` instead of normal configuration file `/etc/ssh/sshd_config`.