### PR TITLE
Update Liberty Linux 9 cloud init

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -788,6 +788,14 @@ runcmd:
     enabled=1
     gpgcheck=0
     EOF
+  - |
+    cat <<EOF > /etc/yum.repos.d/appstream_updates.repo
+    [liberty-9-appstream]
+    name=Liberty Linux 9 AppStream Updates
+    baseurl=http://${ use_mirror_images ? mirror : "updates.suse.de" }/SUSE/Updates/SLL-AS/9/x86_64/update/
+    enabled=1
+    gpgcheck=0
+    EOF
 
   # WORKAROUND: cloud-init in Liberty9 does not take care of the following
   - echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -572,7 +572,7 @@ runcmd:
 %{ endif ~}
   - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
-%{ endif } # end Ubuntu 24.04
+%{ endif } 
 
 %{ if image == "debian12o" ~}
 apt:
@@ -761,33 +761,44 @@ runcmd:
 %{ endif ~}
 
 %{ if image == "libertylinux9o" ~}
-yum_repos:
-  # repo for salt
-  tools_pool_repo:
-    baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
-    enabled: true
-    gpgcheck: false
-    name: tools_pool_repo
-  # repo for nss-mdns
-  epel:
-    baseurl: http://download.fedoraproject.org/pub/epel/9/Everything/$basearch
-    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-9&arch=$basearch
-    enabled: true
-    gpgcheck: false
-    name: epel
-  # repo for dbus-tools
-  os_update_repo:
-    baseurl: http://${ use_mirror_images ? mirror : "updates.suse.de" }/SUSE/Updates/SLL/9/x86_64/update/
-    enabled: true
-    gpgcheck: false
-    name: os_update_repo
-
 runcmd:
-  # WORKAROUND: cloud-init in Liberty 9 does not take care of the following
-  - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
-  - systemctl restart sshd
-  - dnf -y install venv-salt-minion
+  # Manually create repository files since yum_repos module is disabled in image
+  - |
+    cat <<EOF > /etc/yum.repos.d/tools_pool_repo.repo
+    [tools_pool_repo]
+    name=tools_pool_repo
+    baseurl=http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
+    enabled=1
+    gpgcheck=0
+    EOF
+  - |
+    cat <<EOF > /etc/yum.repos.d/epel.repo
+    [epel]
+    name=epel
+    baseurl=http://download.fedoraproject.org/pub/epel/9/Everything/\$basearch
+    mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-9&arch=\$basearch
+    enabled=1
+    gpgcheck=0
+    EOF
+  - |
+    cat <<EOF > /etc/yum.repos.d/os_update_repo.repo
+    [os_update_repo]
+    name=os_update_repo
+    baseurl=http://${ use_mirror_images ? mirror : "updates.suse.de" }/SUSE/Updates/SLL/9/x86_64/update/
+    enabled=1
+    gpgcheck=0
+    EOF
 
+  # WORKAROUND: cloud-init in Liberty9 does not take care of the following
+  - echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/01-permitrootlogin.conf
+  - systemctl restart sshd
+  - dnf clean all
+%{ if install_salt_bundle ~}
+  - dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent dbus-tools tar
+%{ else ~}
+  - dnf -y install salt-minion avahi nss-mdns qemu-guest-agent dbus-tools tar
+%{ endif ~}
+  - systemctl enable --now qemu-guest-agent
 %{ endif ~}
 
 %{ if image == "openeuler2403o" ~}


### PR DESCRIPTION
## What does this PR change?

- yum-variables
 - yum-add-repo
 
In our Liberty9 image,  these modules are missing in the enabled ones for cloud init.
This results in yum_repos being skipped and only runcmd being run.


