### PR TITLE
QE: Add SUSE internal CA to kubernetes modules

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -98,7 +98,7 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
     zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Products/SUSE-Manager-Tools-For-SL-Micro/6/x86_64/product/ tools_pool_repo
   %{ endif }
 
-  %{ if container_server || container_proxy || server_kubernetes || proxy_kubernetes }
+  %{ if container_server || container_proxy }
     %{ if product_version == "uyuni-master" || product_version == "uyuni-pr" }
       zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/openSUSE_Leap_16.0/ container_utils_repo
     %{ endif }
@@ -127,18 +127,18 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
       %{ endif }
     %{ endif }
     %{ if product_version == "head" }
-      %{ if container_server || server_kubernetes }
+      %{ if container_server }
         zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
       %{ endif }
-      %{ if container_proxy || proxy_kubernetes }
+      %{ if container_proxy }
         zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
       %{ endif }
     %{ endif }
     %{ if product_version == "head-staging" }
-      %{ if container_server || server_kubernetes }
+      %{ if container_server }
         zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
       %{ endif }
-      %{ if container_proxy || proxy_kubernetes }
+      %{ if container_proxy }
         zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Proxy-5.2-x86_64/ container_utils_repo
       %{ endif }
     %{ endif }
@@ -178,7 +178,7 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
 %{ endif } # end of image == "slmicro62o" block
 
 # Add additional repository for host only if server or proxy
-%{ if container_server || container_proxy || server_kubernetes || proxy_kubernetes }
+%{ if container_server || container_proxy }
   for i in ${additional_repos}; do
     name=$(echo $i | cut -d= -f1)
     url=$(echo $i | cut -d= -f2)
@@ -202,7 +202,7 @@ PACKAGES="$PACKAGES podman netavark aardvark-dns"
 PACKAGES="$PACKAGES helm"
 %{ endif }
 
-%{ if container_server || container_proxy || server_kubernetes || proxy_kubernetes }
+%{ if container_server || container_proxy }
 PACKAGES="$PACKAGES bash-completion ca-certificates-suse"
 %{ endif }
 

--- a/modules/proxy_kubernetes/main.tf
+++ b/modules/proxy_kubernetes/main.tf
@@ -1,15 +1,15 @@
 variable "images" {
   default = {
-    "head"           = "ubuntu2404o"
-    "head-staging"   = "ubuntu2404o"
-    "5.0-released"   = "ubuntu2404o"
-    "5.0-nightly"    = "ubuntu2404o"
-    "5.1-released"   = "ubuntu2404o"
-    "5.1-nightly"    = "ubuntu2404o"
-    "5.2-released"   = "ubuntu2404o"
-    "uyuni-master"   = "ubuntu2404o"
-    "uyuni-released" = "ubuntu2404o"
-    "uyuni-pr"       = "ubuntu2404o"
+    "head"           = "sles15sp7o"
+    "head-staging"   = "sles15sp7o"
+    "5.0-released"   = "sles15sp7o"
+    "5.0-nightly"    = "sles15sp7o"
+    "5.1-released"   = "sles15sp7o"
+    "5.1-nightly"    = "sles15sp7o"
+    "5.2-released"   = "sles15sp7o"
+    "uyuni-master"   = "tumbleweedo"
+    "uyuni-released" = "tumbleweedo"
+    "uyuni-pr"       = "tumbleweedo"
   }
 }
 
@@ -57,6 +57,7 @@ module "proxy_kubernetes" {
     helm_chart_url                  = var.helm_chart_url
     helm_chart_name                 = var.helm_chart_name
     mirror                          = var.base_configuration["mirror"]
+    use_mirror_images               = var.base_configuration["use_mirror_images"]
     avahi_reflector                 = var.avahi_reflector
     main_disk_size                  = var.main_disk_size
     repository_disk_size            = var.repository_disk_size

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -2,16 +2,16 @@
 
 variable "images" {
   default = {
-    "head"           = "ubuntu2404o"
-    "head-staging"   = "ubuntu2404o"
-    "5.0-released"   = "ubuntu2404o"
-    "5.0-nightly"    = "ubuntu2404o"
-    "5.1-released"   = "ubuntu2404o"
-    "5.1-nightly"    = "ubuntu2404o"
-    "5.2-released"   = "ubuntu2404o"
-    "uyuni-master"   = "ubuntu2404o"
-    "uyuni-released" = "ubuntu2404o"
-    "uyuni-pr"       = "ubuntu2404o"
+    "head"           = "sles15sp7o"
+    "head-staging"   = "sles15sp7o"
+    "5.0-released"   = "sles15sp7o"
+    "5.0-nightly"    = "sles15sp7o"
+    "5.1-released"   = "sles15sp7o"
+    "5.1-nightly"    = "sles15sp7o"
+    "5.2-released"   = "sles15sp7o"
+    "uyuni-master"   = "tumbleweedo"
+    "uyuni-released" = "tumbleweedo"
+    "uyuni-pr"       = "tumbleweedo"
   }
 }
 
@@ -61,6 +61,7 @@ module "server_kubernetes" {
     cc_password                    = var.base_configuration["cc_password"]
     channels                       = var.channels
     mirror                         = var.base_configuration["mirror"]
+    use_mirror_images              = var.base_configuration["use_mirror_images"]
     server_mounted_mirror          = var.server_mounted_mirror
     server_username                = var.server_username
     server_password                = var.server_password

--- a/salt/proxy_kubernetes/init.sls
+++ b/salt/proxy_kubernetes/init.sls
@@ -1,4 +1,5 @@
 include:
+  - repos
   - kubernetes_common.install_rke2
   - kubernetes_common.install_helm
   - proxy_kubernetes.config_node

--- a/salt/repos/proxy_kubernetes.sls
+++ b/salt/repos/proxy_kubernetes.sls
@@ -1,3 +1,49 @@
+{% if 'proxy_kubernetes' in grains.get('roles') %}
+{% set osfullname = grains['osfullname'] %}
+{% set osrelease = grains['osrelease'] %}
+{% set is_sles_15_7 = osfullname == 'SLES' and osrelease == '15.7' %}
+{% set is_tumbleweed = osfullname == 'openSUSE Tumbleweed' %}
+{% set is_supported_os = is_sles_15_7 or is_tumbleweed %}
+
+{% if is_supported_os %}
+{% set use_mirror_images = grains.get('use_mirror_images', False) %}
+{% set mirror = grains.get('mirror', '') %}
+{% set repo_host = mirror if use_mirror_images and mirror else 'dist.nue.suse.com' %}
+
+{% if is_sles_15_7 %}
+add_repo_ca_sles_proxy:
+  pkgrepo.managed:
+    - humanname: ca_suse
+    - name: ca_suse
+    - baseurl: http://{{ repo_host }}/ibs/SUSE:/CA/SLE_15_SP7/
+    - enabled: 1
+    - refresh: True
+{% elif is_tumbleweed %}
+add_repo_ca_tw_proxy:
+  pkgrepo.managed:
+    - humanname: ca_suse
+    - name: ca_suse
+    - baseurl: http://{{ repo_host }}/ibs/SUSE:/CA/openSUSE_Tumbleweed/
+    - enabled: 1
+    - refresh: True
+{% endif %}
+
+ca_suse_rke2_proxy:
+  pkg.installed:
+    - pkgs:
+      - ca-certificates-suse
+{% if is_sles_15_7 %}
+    - require:
+      - pkgrepo: add_repo_ca_sles_proxy
+{% elif is_tumbleweed %}
+    - require:
+      - pkgrepo: add_repo_ca_tw_proxy
+{% endif %}
+
+{% endif %}
+
+{% endif %}
+
 # WORKAROUND: see github:saltstack/salt#10852
 {{ sls }}_nop:
   test.nop: []

--- a/salt/repos/server_kubernetes.sls
+++ b/salt/repos/server_kubernetes.sls
@@ -1,3 +1,50 @@
+{% if 'server_kubernetes' in grains.get('roles') %}
+{% set osfullname = grains['osfullname'] %}
+{% set osrelease = grains['osrelease'] %}
+{% set is_sles_15_7 = osfullname == 'SLES' and osrelease == '15.7' %}
+{% set is_tumbleweed = osfullname == 'openSUSE Tumbleweed' %}
+{% set is_supported_os = is_sles_15_7 or is_tumbleweed %}
+
+{% if is_supported_os %}
+{% set use_mirror_images = grains.get('use_mirror_images', False) %}
+{% set mirror = grains.get('mirror', '') %}
+{% set repo_host = mirror if use_mirror_images and mirror else 'dist.nue.suse.com' %}
+
+{% if is_sles_15_7 %}
+add_repo_ca_sles_server:
+  pkgrepo.managed:
+    - humanname: ca_suse
+    - name: ca_suse
+    - baseurl: http://{{ repo_host }}/ibs/SUSE:/CA/SLE_15_SP7/
+    - enabled: 1
+    - refresh: True
+{% elif is_tumbleweed %}
+add_repo_ca_tw_server:
+  pkgrepo.managed:
+    - humanname: ca_suse
+    - name: ca_suse
+    - baseurl: http://{{ repo_host }}/ibs/SUSE:/CA/openSUSE_Tumbleweed/
+    - enabled: 1
+    - refresh: True
+{% endif %}
+
+
+ca_suse_rke2_server:
+  pkg.installed:
+    - pkgs:
+      - ca-certificates-suse
+{% if is_sles_15_7 %}
+    - require:
+      - pkgrepo: add_repo_ca_sles_server
+{% elif is_tumbleweed %}
+    - require:
+      - pkgrepo: add_repo_ca_tw_server
+{% endif %}
+
+{% endif %}
+
+{% endif %}
+
 # WORKAROUND: see github:saltstack/salt#10852
 {{ sls }}_nop:
   test.nop: []

--- a/salt/server_kubernetes/init.sls
+++ b/salt/server_kubernetes/init.sls
@@ -1,5 +1,5 @@
-
 include:
+  - repos
   - kubernetes_common.install_rke2
   - kubernetes_common.install_helm
   - server_kubernetes.set-persistent-volumes


### PR DESCRIPTION
## What does this PR change?

Configuring the internal CA of SUSE to reach the private registry in the kubernetes modules and deleting them from combustion. These modules are going to be deleted from combustion because we are using TW and SLES15 SP7 in RKE2, images that are not included in combustion and we don't want to add them.