### PR TITLE
Enable sumaform for Debian 13

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -31,6 +31,7 @@ locals {
     ubuntu2204o              = "${var.use_mirror_images ? "http://${var.mirror}" : "http://cloud-images.ubuntu.com"}/jammy/current/jammy-server-cloudimg-amd64.img"
     ubuntu2404o              = "${var.use_mirror_images ? "http://${var.mirror}" : "http://cloud-images.ubuntu.com"}/noble/current/noble-server-cloudimg-amd64.img"
     debian12o                = "${var.use_mirror_images ? "http://${var.mirror}" : "http://cloud.debian.org"}/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
+    debian13o                = "${var.use_mirror_images ? "http://${var.mirror}" : "http://cloud.debian.org"}/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2"
     slemicro52-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_52/SUSE-MicroOS.x86_64-sumaform.qcow2"
     slemicro53-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_53/SLE-Micro.x86_64-sumaform.qcow2"
     slemicro54-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_54/SLE-Micro.x86_64-sumaform.qcow2"

--- a/backend_modules/libvirt/host/network_config.yaml
+++ b/backend_modules/libvirt/host/network_config.yaml
@@ -1,4 +1,4 @@
-%{ if image == "debian12o" || image == "amazonlinux2023o" }
+%{ if image == "debian12o" || image == "debian13o" || image == "amazonlinux2023o" }
 network:
   version: 2
   ethernets:

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -602,13 +602,48 @@ apt:
         =eJaK
         -----END PGP PUBLIC KEY BLOCK-----
 
+%{ endif ~}
+
+%{ if image == "debian13o" ~}
+apt:
+  sources:
+    tools_pool_repo:
+      source: deb http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/Debian13-Uyuni-Client-Tools/Debian_13/ /
+      key: |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v1.4.5 (GNU/Linux)
+
+        mQENBFsnulUBCADNjL4hvhVtSzqVDlMtFFFP28Acq+UNF8WKKMhbBirfOpXwwI1C
+        NR3i0CXPOce5eKShuuWAjD2E36e2XAp3rUAo/aCA7UgtJkMNKzzlTOcqHHxKTx6H
+        gvp0Fb6xTKywZ7VttGhwUynl+CsDuOst3ROXTNdb8XMfm4joH2FW5D3ACN2qNiv0
+        MVcFNKxQ98w8M9xJxdI8DuyngnSeZwAosNzEio3JhTPiTv9ngY2Z3AuYUcwTEt7o
+        feEN+ivAgYnn+a6DBKFBeCW7VUD3V+tH8/fKnkvI4gf2o3N7Ok+/uE+DPUBb+14f
+        +9dhBjd+7+pR3ayEZFjQns5XFShoYu2+CQspABEBAAG0UHN5c3RlbXNtYW5hZ2Vt
+        ZW50OlV5dW5pIE9CUyBQcm9qZWN0IDxzeXN0ZW1zbWFuYWdlbWVudDpVeXVuaUBi
+        dWlsZC5vcGVuc3VzZS5vcmc+iQE+BBMBCAAoBQJnTV1tAhsDBQkQRFMYBgsJCAcD
+        AgYVCAIJCgsEFgIDAQIeAQIXgAAKCRCXLl1sDSCDPqobCACZmP4jvLKA8hixwLbB
+        ws6UpppjKuZ1C29VlfydWW7Zh7YTlQEDweuaP++UTNpG4LFHYEG/h+0m2IiIK8pH
+        37fzKn+xZB+9SA/4hE3RsJhzwCYXxRnnSzahmagskTQp+vPQS571n8rmXbLQVIV8
+        VHOjY6CezItu5OAe4m0DVdS9u4LmikPwxV+irdJ1rMphBKzxccGFOmYFXKWWoEk7
+        VAD02fKgzLdoE6QX9ocIChmDM/fNwEK3us7RWEd2jxqUYdseTsa22clbuR3Dg6SB
+        E/oQa9zikECUNi4T19DnBpquBzBHlmfnGBtHPkq1KF7mNhdLhD28Atn0gpOGZOnd
+        VzV9iEYEExECAAYFAlsnulUACgkQOzARt2udZSO/4QCcDf+j/XRbJn2PudsSoyjw
+        3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
+        =eJaK
+        -----END PGP PUBLIC KEY BLOCK-----
+
+%{ endif ~}
+
+%{ if image == "debian12o" || image == "debian13o" ~}
+
+
 bootcmd:
   # HACK: Make "gnupg" to be installed before configuring repos, so gpg key can be imported
   - DEBIAN_FRONTEND=noninteractive apt-get -yq update
   - DEBIAN_FRONTEND=noninteractive apt-get -yq install gnupg
 
 runcmd:
-  # HACK: cloud-init in Debian 12 does not take care of the following
+  # HACK: cloud-init in Debian 12/13 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
 %{ if install_salt_bundle ~}

--- a/salt/default/locale.sls
+++ b/salt/default/locale.sls
@@ -1,3 +1,8 @@
+{% set use_localectl = true %}
+{% if grains['os_family'] == 'Debian' and grains.get('osmajorrelease', 0)|int() == 13 %}
+{% set use_localectl = false %}
+{% endif %}
+
 {% if grains['os_family'] == 'Suse' %}
 manually_set_locale_rc_lang:
   file.replace:
@@ -30,7 +35,25 @@ langpack_package:
 
 {% endif %}
 
+{% if use_localectl %}
 fix_en_US_UTF8_as_system_locale_with_localectl:
   cmd.run:
     - name: localectl set-locale LANG=en_US.UTF-8
     - onlyif: test -f /usr/bin/localectl
+
+{% else %}
+configure_locale_gen:
+  file.append:
+    - name: /etc/locale.gen
+    - text: en_US.UTF-8 UTF-8
+
+generate_locales:
+  cmd.run:
+    - name: locale-gen
+    - onchanges:
+      - file: configure_locale_gen
+
+fix_en_US_UTF8_as_system_locale_with_update_locale:
+  cmd.run:
+    - name: update-locale LANG=en_US.UTF-8
+{% endif %}

--- a/salt/salt_testenv/salt_bundle_package.sls
+++ b/salt/salt_testenv/salt_bundle_package.sls
@@ -3,6 +3,8 @@
         {% set repo_path = 'Debian_11' %}
     {% elif grains['osrelease'] == '12' %}
         {% set repo_path = 'Debian_12' %}
+    {% elif grains['osrelease'] == '13' %}
+        {% set repo_path = 'Debian_13' %}
     {% endif %}
 {% elif grains['osfullname'] == 'Ubuntu' %}
     {% if grains['osrelease'] == '20.04' %}
@@ -67,6 +69,7 @@ salt_bundle_testsuite_repo:
     - file: /etc/apt/sources.list.d/salt_bundle_testsuite_repo.list
     - name: deb http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/ /
     - key_url: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/Release.key
+    - trusted: True
 {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/
     - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:{{ salt_flavor_path }}:testsuite/{{ repo_path }}/repodata/repomd.xml.key


### PR DESCRIPTION
## What does this PR change?

- Enable Sumaform to create Debian 13 environments.
- Fix Salt Shaker to support Debian 13 environments.
