### PR TITLE
Add "uyuni-main" as product_version to use "systemsmanagement:Uyuni:Main" environment

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -24,6 +24,7 @@ Legal values for work-in-progress software are:
 - `5.1-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:5.1)
 - `head` (corresponds to the Build Service project Devel:Galaxy:Manager:Main, uses SL Micro 6.1 as the base image for server)
 - `uyuni-master` (corresponds to the Build Service project systemsmanagement:Uyuni:Master, for `server` and `proxy` only works with openSUSE Leap image)
+- `uyuni-main` (corresponds to the Build Service project systemsmanagement:Uyuni:Main)
 
 **Important:** sumaform only supports containerized deployments for SUSE Manager versions 5.0 and later.
 Please use `server_containerized` and `proxy_containerized` modules with product versions `head` and `5.0-X`.

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -84,7 +84,7 @@ variable "is_server_paygo_instance" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-nightly, 4.3-released, 4.3-pr, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-nightly, 4.3-released, 4.3-pr, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = ""
 }

--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -127,7 +127,7 @@ variable "volume_provider_settings" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/build_host/variables.tf
+++ b/modules/build_host/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -15,6 +15,7 @@ variable "testsuite-branch" {
     "head"           = "master"
     "head-staging"   = "master"
     "uyuni-master"   = "master"
+    "uyuni-main"     = "master"
     "uyuni-released" = "master"
     "uyuni-pr"       = "master"
   }

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -820,7 +820,7 @@ variable "server_instance_id" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -84,7 +84,7 @@ variable "host_settings" {
 
 // server
 variable "product_version" {
-  description = "One of: head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -13,7 +13,7 @@ variable "roles" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -8,6 +8,7 @@ variable "images" {
     "4.3-VM-released"= "sles15sp4o"
     # Uyuni non-podman deprecated in September 2024:
     "uyuni-master"   = "opensuse156o"
+    "uyuni-main"     = "opensuse156o"
     "uyuni-released" = "opensuse156o"
     "uyuni-pr"       = "opensuse156o"
   }

--- a/modules/proxy_containerized/main.tf
+++ b/modules/proxy_containerized/main.tf
@@ -8,6 +8,7 @@ variable "images" {
     "5.1-nightly"    = "slmicro61o"
     "5.2-released"   = "slmicro62o"
     "uyuni-master"   = "tumbleweedo"
+    "uyuni-main"     = "tumbleweedo"
     "uyuni-released" = "tumbleweedo"
     "uyuni-pr"       = "tumbleweedo"
   }

--- a/modules/proxy_containerized/variables.tf
+++ b/modules/proxy_containerized/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/proxy_kubernetes/main.tf
+++ b/modules/proxy_kubernetes/main.tf
@@ -8,6 +8,7 @@ variable "images" {
     "5.1-nightly"    = "sles15sp7o"
     "5.2-released"   = "sles15sp7o"
     "uyuni-master"   = "tumbleweedo"
+    "uyuni-main"     = "tumbleweedo"
     "uyuni-released" = "tumbleweedo"
     "uyuni-pr"       = "tumbleweedo"
   }

--- a/modules/proxy_kubernetes/variables.tf
+++ b/modules/proxy_kubernetes/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -9,6 +9,7 @@ variable "images" {
     "4.3-VM-released" = "suma43VM-ign"
     # Uyuni non-podman deprecated in September 2024:
     "uyuni-master"    = "opensuse156o"
+    "uyuni-main"      = "opensuse156o"
     "uyuni-released"  = "opensuse156o"
     "uyuni-pr"        = "opensuse156o"
   }

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -10,6 +10,7 @@ variable "images" {
     "5.1-nightly"    = "slmicro61o"
     "5.2-released"   = "slmicro62o"
     "uyuni-master"   = "tumbleweedo"
+    "uyuni-main"     = "tumbleweedo"
     "uyuni-released" = "tumbleweedo"
     "uyuni-pr"       = "tumbleweedo"
   }

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -48,7 +48,7 @@ variable "db_container_tag" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -10,6 +10,7 @@ variable "images" {
     "5.1-nightly"    = "sles15sp7o"
     "5.2-released"   = "sles15sp7o"
     "uyuni-master"   = "tumbleweedo"
+    "uyuni-main"     = "tumbleweedo"
     "uyuni-released" = "tumbleweedo"
     "uyuni-pr"       = "tumbleweedo"
   }

--- a/modules/server_kubernetes/variables.tf
+++ b/modules/server_kubernetes/variables.tf
@@ -78,7 +78,7 @@ variable "db_container_tag" {
 }
 
 variable "product_version" {
-  description = "One of: head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.0-nightly, 5.0-released, 5.1-nightly, 5.1-released, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
   type        = string
   default     = null
 }

--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -368,9 +368,9 @@ http:
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/EL_9/
     archs: [x86_64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_22.04/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_22.04-debbuild/
     archs: [amd64]
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_24.04/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_24.04-debbuild/
     archs: [amd64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/Debian_12-debbuild/
     archs: [amd64]

--- a/salt/mirror/etc/minima.yaml
+++ b/salt/mirror/etc/minima.yaml
@@ -344,3 +344,35 @@ http:
     archs: [amd64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Tumbleweed-Uyuni-Client-Tools/openSUSE_Tumbleweed/
     archs: [amd64]
+
+  # Uyuni Main
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main/openSUSE_Tumbleweed/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/ContainerUtils/openSUSE_Tumbleweed/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main/images/repo/Uyuni-Server-POOL-x86_64-Media1/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_12/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Leap_15.0/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Leap_16.0/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/CentOS_7/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/EL_8/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/EL_9/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_22.04/
+    archs: [amd64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_24.04/
+    archs: [amd64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/Debian_12-debbuild/
+    archs: [amd64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Tumbleweed/
+    archs: [amd64]

--- a/salt/mirror/etc/minimum_repositories_testsuite.yaml
+++ b/salt/mirror/etc/minimum_repositories_testsuite.yaml
@@ -61,6 +61,9 @@ http:
   - url:  http://downloadcontent.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
     archs: [x86_64]
 
+  - url:  http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Leap_15.0/
+    archs: [x86_64]
+
   - url:  http://dist.suse.de/ibs/SUSE/Products/EL/9-CLIENT-TOOLS/x86_64/product/
     archs: [x86_64]
 

--- a/salt/proxy/init.sls
+++ b/salt/proxy/init.sls
@@ -52,7 +52,11 @@ proxy-packages:
   {% if '-released' in grains.get('product_version') %}
     {% set client_tools_repo =  grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/' %}
   {% else %}
-    {% set client_tools_repo =  grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/' %}
+    {% if '-main' in grains.get('product_version') %}
+        {% set client_tools_repo =  grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Leap_15.0/' %}
+    {% else %}
+        {% set client_tools_repo =  grains.get("mirror") | default("download.opensuse.org", true) ~ '/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/' %}
+    {% endif %}
   {% endif %}
 
 galaxy_key:

--- a/salt/repos/client_tools/client_tools_uyuni.sls
+++ b/salt/repos/client_tools/client_tools_uyuni.sls
@@ -3,7 +3,7 @@
 {% if not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles') and 'server_containerized' not in grains.get('roles') and 'proxy_containerized' not in grains.get('roles') and 'controller' not in grains.get('roles')) %}
 {# no client tools on server, proxy, server_containerized, or proxy_containerized #}
 
-{% set uyuni_version = 'Master' if grains.get('product_version', '') == 'uyuni-master' else 'Stable' if grains.get('product_version', '') == 'uyuni-released' else 'Main' %}
+{% set uyuni_version = 'Master' if grains.get('product_version', '') == 'uyuni-master' else 'Main' if grains.get('product_version', '') == 'uyuni-main' else 'Stable' %}
 
 {% if grains['os'] == 'SUSE' %}
 {% if grains['osfullname'] == 'Leap' %}

--- a/salt/repos/client_tools/client_tools_uyuni.sls
+++ b/salt/repos/client_tools/client_tools_uyuni.sls
@@ -3,17 +3,25 @@
 {% if not grains.get('roles') or ('server' not in grains.get('roles') and 'proxy' not in grains.get('roles') and 'server_containerized' not in grains.get('roles') and 'proxy_containerized' not in grains.get('roles') and 'controller' not in grains.get('roles')) %}
 {# no client tools on server, proxy, server_containerized, or proxy_containerized #}
 
-{% set uyuni_version = 'Master' if grains.get('product_version', '') == 'uyuni-master' else 'Stable' %}
+{% set uyuni_version = 'Master' if grains.get('product_version', '') == 'uyuni-master' else 'Stable' if grains.get('product_version', '') == 'uyuni-released' else 'Main' %}
 
 {% if grains['os'] == 'SUSE' %}
 {% if grains['osfullname'] == 'Leap' %}
 {% set leap_version = grains['osrelease'].split('.')[0] %}
 tools_pool_repo:
   pkgrepo.managed:
+  {% if uyuni_version == "Main" %}
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Leap_{{ leap_version }}.0/
+  {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/{{ uyuni_version }}:/openSUSE_Leap_{{ leap_version }}-Uyuni-Client-Tools/openSUSE_Leap_{{ leap_version }}.0/
+  {% endif %}
     - refresh: True
     - gpgcheck: 1
+  {% if uyuni_version == "Main" %}
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Leap_{{ leap_version }}.0/repodata/repomd.xml.key
+  {% else %}
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/{{ uyuni_version }}:/openSUSE_Leap_{{ leap_version }}-Uyuni-Client-Tools/openSUSE_Leap_{{ leap_version }}.0/repodata/repomd.xml.key
+  {% endif %}
 {% endif %} {# grains['osfullname'] == 'Leap' #}
 {% if grains['osfullname'] == 'SLES' %}
 
@@ -28,6 +36,13 @@ tools_pool_repo:
 tools_update_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/
+    - refresh: True
+    - priority: 98
+{% endif %}
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
+tools_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_12/
     - refresh: True
     - priority: 98
 {% endif %}
@@ -51,6 +66,17 @@ tools_update_repo:
 
 {% endif %}
 
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
+
+tools_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/
+    - refresh: True
+    - gpgcheck: 1
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/repodata/repomd.xml.key
+
+{% endif %}
+
 {% endif %} {# '15' in grains['osrelease'] #}
 
 {% if '16' in grains['osrelease'] %}
@@ -68,6 +94,17 @@ tools_update_repo:
     - refresh: True
     - gpgcheck: 1
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE16-Uyuni-Client-Tools/SLE_16/repodata/repomd.xml.key
+
+{% endif %}
+
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
+
+tools_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_16/
+    - refresh: True
+    - gpgcheck: 1
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_16/repodata/repomd.xml.key
 
 {% endif %}
 
@@ -98,6 +135,16 @@ tools_update_repo:
     - gpgcheck: 1
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/repodata/repomd.xml.key
 {% endif %}
+
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
+
+tools_update_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/
+    - refresh: True
+    - gpgcheck: 1
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/SLE_15/repodata/repomd.xml.key
+{% endif %}
 {% endif %} {# grains['osfullname'] == 'SLE Micro' #}
 {% endif %} {# grains['os'] == 'SUSE' #}
 
@@ -127,10 +174,15 @@ tools_update_repo:
     - gpgcheck: 1
     - gpgkey: http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/bundle:/next:/AlmaLinux10/AlmaLinux_10/repodata/repomd.xml.key
 {% else %}
+  {% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/{{ rhlike_client_tools_prefix }}_{{ release }}/
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/{{ rhlike_client_tools_prefix }}_{{ release }}/repodata/repomd.xml.key
+  {% else %}
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/{{ uyuni_version }}:/{{ rhlike_client_tools_prefix }}{{ release }}-Uyuni-Client-Tools/{{ rhlike_client_tools_prefix }}_{{ release }}/
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/{{ uyuni_version }}:/{{ rhlike_client_tools_prefix }}{{ release }}-Uyuni-Client-Tools/{{ rhlike_client_tools_prefix }}_{{ release }}/repodata/repomd.xml.key
+  {% endif %}
     - refresh: True
     - gpgcheck: 1
-    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/{{ uyuni_version }}:/{{ rhlike_client_tools_prefix }}{{ release }}-Uyuni-Client-Tools/{{ rhlike_client_tools_prefix }}_{{ release }}/repodata/repomd.xml.key
     - require:
       - cmd: uyuni_key
 {% endif %}
@@ -146,7 +198,11 @@ clean_repo_metadata:
 {% set release = grains.get('osrelease', None) %}
 {% set short_release = release | replace('.', '') %}
 
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_' + release %}
+{% else %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/' + uyuni_version + ':/Ubuntu' + short_release + '-Uyuni-Client-Tools/xUbuntu_' + release %}
+{% endif %}
 tools_update_repo:
   pkgrepo.managed:
     - humanname: tools_update_repo
@@ -160,7 +216,11 @@ tools_update_repo_raised_priority:
     - name: /etc/apt/preferences.d/tools_update_repo
     - contents: |
             Package: *
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) -%}
+            Pin: release l=systemsmanagement:Uyuni:Main:UyuniTools
+{% else -%}
             Pin: release l=systemsmanagement:Uyuni:{{ uyuni_version }}:Ubuntu{{ short_release }}-Uyuni-Client-Tools
+{% endif -%}
             Pin-Priority: 800
 
 {% endif %} {# grains['os'] == 'Ubuntu' #}
@@ -168,7 +228,11 @@ tools_update_repo_raised_priority:
 {% if grains['os'] == 'Debian' %}
 
 {% set release = grains.get('osrelease', None) %}
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/Debian_' + release %}
+{% else %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/' + uyuni_version + ':/Debian' + release + '-Uyuni-Client-Tools/Debian_' + release %}
+{% endif %}
 tools_update_repo:
   pkgrepo.managed:
     - humanname: tools_update_repo
@@ -183,7 +247,11 @@ tools_update_repo_raised_priority:
     - name: /etc/apt/preferences.d/tools_update_repo
     - contents: |
         Package: *
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) -%}
+        Pin: release l=systemsmanagement:Uyuni:Main:UyuniTools
+{% else -%}
         Pin: release l=systemsmanagement:Uyuni:{{ uyuni_version }}:Debian{{ release }}-Uyuni-Client-Tools
+{% endif -%}
         Pin-Priority: 800
 
 {% endif %} {# grains['os'] == 'Debian' #}

--- a/salt/repos/client_tools/client_tools_uyuni.sls
+++ b/salt/repos/client_tools/client_tools_uyuni.sls
@@ -199,7 +199,7 @@ clean_repo_metadata:
 {% set short_release = release | replace('.', '') %}
 
 {% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_' + release %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/xUbuntu_' + release + '-debbuild' %}
 {% else %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/' + uyuni_version + ':/Ubuntu' + short_release + '-Uyuni-Client-Tools/xUbuntu_' + release %}
 {% endif %}
@@ -229,7 +229,7 @@ tools_update_repo_raised_priority:
 
 {% set release = grains.get('osrelease', None) %}
 {% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
-{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/Debian_' + release %}
+{% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/Debian_' + release + '-debbuild' %}
 {% else %}
 {% set tools_repo_url = 'http://' + grains.get("mirror") | default("download.opensuse.org", true) + '/repositories/systemsmanagement:/Uyuni:/' + uyuni_version + ':/Debian' + release + '-Uyuni-Client-Tools/Debian_' + release %}
 {% endif %}

--- a/salt/repos/default_settings.sls
+++ b/salt/repos/default_settings.sls
@@ -98,7 +98,7 @@ suse_res7_key:
       - file: suse_res7_key
 {% endif %}
 
-{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-released' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') %}
+{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-main' in grains.get('product_version', '') or 'uyuni-released' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') %}
 
 uyuni_key:
   file.managed:

--- a/salt/repos/proxyUyuni.sls
+++ b/salt/repos/proxyUyuni.sls
@@ -23,6 +23,21 @@ testing_overlay_devel_repo:
 
 {% endif %}
 
+{% if 'uyuni-main' in grains.get('product_version') %}
+proxy_devel_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main/images/repo/Uyuni-Proxy-POOL-{{ grains.get("cpuarch") }}-Media1/
+    - refresh: True
+    - priority: 96
+
+testing_overlay_devel_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main/images/repo/Testing-Overlay-POOL-{{ grains.get("cpuarch") }}-Media1/
+    - refresh: True
+    - priority: 96
+
+{% endif %}
+
 {% endif %}
 
 # WORKAROUND: see github:saltstack/salt#10852

--- a/salt/repos/proxy_containerized/proxy_containerizedUyuni.sls
+++ b/salt/repos/proxy_containerized/proxy_containerizedUyuni.sls
@@ -19,6 +19,14 @@ containerutils_uyuni_master:
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
 {% endif %}
 
+{% if 'uyuni-main' == grains.get('product_version') %}
+containerutils_uyuni_main:
+    pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/ContainerUtils/{{ repo }}/
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+{% endif %}
+
 {% endif %}
 {% endif %}
 

--- a/salt/repos/serverUyuni.sls
+++ b/salt/repos/serverUyuni.sls
@@ -23,6 +23,21 @@ testing_overlay_devel_repo:
 
 {% endif %}
 
+{% if 'uyuni-main' in grains.get('product_version') %}
+server_devel_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main/images/repo/Uyuni-Server-POOL-{{ grains.get("cpuarch") }}-Media1/
+    - refresh: True
+    - priority: 96
+
+testing_overlay_devel_repo:
+  pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main/images/repo/Testing-Overlay-POOL-{{ grains.get("cpuarch") }}-Media1/
+    - refresh: True
+    - priority: 96
+
+{% endif %}
+
 {% endif %}
 
 # WORKAROUND: see github:saltstack/salt#10852

--- a/salt/repos/server_containerized/server_containerizedUyuni.sls
+++ b/salt/repos/server_containerized/server_containerizedUyuni.sls
@@ -20,7 +20,7 @@ containerutils_uyuni_master:
 {% endif %}
 
 {% if 'uyuni-main' == grains.get('product_version') %}
-containerutils_uyuni_master:
+containerutils_uyuni_main:
     pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/ContainerUtils/{{ repo }}/
     - refresh: True

--- a/salt/repos/server_containerized/server_containerizedUyuni.sls
+++ b/salt/repos/server_containerized/server_containerizedUyuni.sls
@@ -19,6 +19,14 @@ containerutils_uyuni_master:
     - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
 {% endif %}
 
+{% if 'uyuni-main' == grains.get('product_version') %}
+containerutils_uyuni_master:
+    pkgrepo.managed:
+    - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/ContainerUtils/{{ repo }}/
+    - refresh: True
+    - gpgkey: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Main:/ContainerUtils/{{ repo }}/repodata/repomd.xml.key
+{% endif %}
+
 {% endif %}
 {% endif %}
 

--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -55,7 +55,7 @@ test_repo_debian_updates:
 {% endif %}
 
 # modify Cobbler to be executed from remote-machines..
-{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-released", "uyuni-pr", "head", "head-staging", "4.3-released", "4.3-nightly", "4.3-pr", "4.3-VM-nightly", "4.3-VM-released" ] %}
+{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr", "head", "head-staging", "4.3-released", "4.3-nightly", "4.3-pr", "4.3-VM-nightly", "4.3-VM-released" ] %}
 {% set cobbler_use_settings_yaml = grains.get('product_version') | default('', true) in products_using_new_cobbler_version %}
 {% if 'build_image' not in grains.get('product_version', '') and 'paygo' not in grains.get('product_version', '') %}
 cobbler_configuration:
@@ -102,14 +102,14 @@ testsuite_salt_packages:
   pkg.installed:
     - pkgs:
       - salt-ssh
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'nightly' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') or '4.3-pr' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'uyuni-main' in grains.get('product_version') or 'nightly' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') or '4.3-pr' in grains.get('product_version') %}
     - fromrepo: testing_overlay_devel_repo
 {% endif %}
     - require:
       - sls: repos
 {% endif %}
 
-{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "4.3-nightly", "4.3-released", "4.3-pr", "4.3-VM-nightly", "4.3-VM-released"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-main", "uyuni-pr", "4.3-nightly", "4.3-released", "4.3-pr", "4.3-VM-nightly", "4.3-VM-released"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,

--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -69,7 +69,7 @@ authorized_keys_buildhost:
     - source: salt://build_host/keys/id_ed25519.pub
     - makedirs: True
 
-{%- if grains.get('product_version') | default('', true) in ['uyuni-master', 'uyuni-pr', 'uyuni-released'] %}
+{%- if grains.get('product_version') | default('', true) in ['uyuni-master', 'uyuni-main', 'uyuni-pr', 'uyuni-released'] %}
 uyuni_key_copy_host:
   file.managed:
     - name: /tmp/uyuni.key
@@ -108,7 +108,7 @@ suse_staging_key_import:
 
 {% endif %}
 
-{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-pr", "head", "head-staging", "5.0-nightly", "5.0-released", "5.1-nightly", "5.1-released", "5.2-released"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-main", "uyuni-pr", "head", "head-staging", "5.0-nightly", "5.0-released", "5.1-nightly", "5.1-released", "5.2-released"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,

--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -222,7 +222,11 @@ cloudinit-user-data-{{ os_type }}:
         # on the server to be able to onboard the nested VM
         - zypper --non-interactive ar "http://download.opensuse.org/tumbleweed/repo/oss/" os_pool_repo
         - zypper --non-interactive ar "http://download.opensuse.org/update/tumbleweed/" os_update_repo
+        {% if 'uyuni-main' == grains.get('product_version') -%}
+        - zypper --non-interactive ar -p 98 "http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Main:/UyuniTools/openSUSE_Tumbleweed/" tools_pool_repo
+        {% else -%}
         - zypper --non-interactive ar -p 98 "http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Tumbleweed-Uyuni-Client-Tools/openSUSE_Tumbleweed/" tools_pool_repo
+        {% endif -%}
         - zypper --non-interactive --gpg-auto-import-keys ref
         - zypper --non-interactive install venv-salt-minion
         - rm /etc/venv-salt-minion/minion


### PR DESCRIPTION
## What does this PR change?

We want to run acceptance tests for `Uyuni:Master` in parallel with the new git-based project `Uyuni:Main`.

This PR enables `uyuni-main` as possible `product_version` so we can trigger deployments using this new OBS environment.

Related PR to `susemanager-ci`: https://github.com/SUSE/susemanager-ci/pull/1979