### PR TITLE
Fix: Tomcat context for large deployments

### DIFF
--- a/salt/server_containerized/large_deployment.sls
+++ b/salt/server_containerized/large_deployment.sls
@@ -24,7 +24,7 @@ large_deployment_tune_tomcat_stylesheet_copy:
 
 large_deployment_tune_tomcat_maxthreads:
   cmd.run:
-    - name: mgrctl exec 'xsltproc /tmp/large_deployment_tune_tomcat.xslt /etc/tomcat/server.xml > /tmp/tomcat_server.xml && mv /tmp/tomcat_server.xml /etc/tomcat/server.xml'
+    - name: mgrctl exec 'xsltproc /tmp/large_deployment_tune_tomcat.xslt /etc/tomcat/server.xml > /tmp/tomcat_server.xml && cp /tmp/tomcat_server.xml /etc/tomcat/server.xml'
     - onchanges:
       - cmd: large_deployment_tune_tomcat_stylesheet_copy
 


### PR DESCRIPTION
## What does this PR change?

@aaannz and @mbussolotto made us aware of:

>During debug session with Michele we found out that sumaform is using mgrctl exec 'xsltproc /tmp/large_deployment_tune_tomcat.xslt /etc/tomcat/server.xml > /tmp/tomcat_server.xml && mv /tmp/tomcat_server.xml /etc/tomcat/server.xml' (at https://github.com/uyuni-project/sumaform/blob/master/salt/server_containerized/large_deployment.sls#L27 )
This will prevent server to work after restart. Tuned tomcat.xml is stored at container private location /tmp and adds category to SELinux context. When that file is then moved instead of copied, it takes this context with it and after container restart, when process category is changed, then tomcat will get permission denied

The easiest fix according to Ondrej is to use `cp` instead of `mv`.
