### PR TITLE
Enable java_debugging also in BV

### DIFF
--- a/modules/build_validation/main.tf
+++ b/modules/build_validation/main.tf
@@ -79,7 +79,7 @@ module "server" {
   database_disk_size   = 150
 
   server_mounted_mirror          = var.platform_location_configuration[var.location].mirror
-  java_debugging                 = false
+  java_debugging                 = true
   auto_accept                    = false
   monitored                      = true
   disable_firewall               = false
@@ -124,7 +124,7 @@ module "server_containerized" {
   container_tag                  = "latest"
   beta_enabled                   = false
   server_mounted_mirror          = var.platform_location_configuration[var.location].mirror
-  java_debugging                 = false
+  java_debugging                 = true
   auto_accept                    = false
   disable_firewall               = false
   allow_postgres_connections     = false


### PR DESCRIPTION
## What does this PR change?

Enables java_debugging also in BV 

```
mlm-bv-sandbox-server:~ # ss -ln | grep 800
tcp   LISTEN 0      4096                   0.0.0.0:8002             0.0.0.0:*
tcp   LISTEN 0      4096                   0.0.0.0:8003             0.0.0.0:*
tcp   LISTEN 0      4096                   0.0.0.0:8001             0.0.0.0:*
tcp   LISTEN 0      4096                   0.0.0.0:9800             0.0.0.0:*
```