### PR TITLE
Rearrange Jinja logic to prevent syntax error

### DIFF
--- a/salt/repos/client_tools/client_tools_uyuni.sls
+++ b/salt/repos/client_tools/client_tools_uyuni.sls
@@ -214,14 +214,17 @@ tools_update_repo:
 tools_update_repo_raised_priority:
   file.managed:
     - name: /etc/apt/preferences.d/tools_update_repo
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
     - contents: |
             Package: *
-{% if 'uyuni-main' in grains.get('product_version') | default('', true) -%}
             Pin: release l=systemsmanagement:Uyuni:Main:UyuniTools
-{% else -%}
-            Pin: release l=systemsmanagement:Uyuni:{{ uyuni_version }}:Ubuntu{{ short_release }}-Uyuni-Client-Tools
-{% endif -%}
             Pin-Priority: 800
+{% else %}
+    - contents: |
+            Package: *
+            Pin: release l=systemsmanagement:Uyuni:{{ uyuni_version }}:Ubuntu{{ short_release }}-Uyuni-Client-Tools
+            Pin-Priority: 800
+{% endif %}
 
 {% endif %} {# grains['os'] == 'Ubuntu' #}
 
@@ -245,14 +248,17 @@ tools_update_repo:
 tools_update_repo_raised_priority:
   file.managed:
     - name: /etc/apt/preferences.d/tools_update_repo
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) -%}
     - contents: |
         Package: *
-{% if 'uyuni-main' in grains.get('product_version') | default('', true) -%}
         Pin: release l=systemsmanagement:Uyuni:Main:UyuniTools
-{% else -%}
-        Pin: release l=systemsmanagement:Uyuni:{{ uyuni_version }}:Debian{{ release }}-Uyuni-Client-Tools
-{% endif -%}
         Pin-Priority: 800
+{% else -%}
+    - contents: |
+        Package: *
+        Pin: release l=systemsmanagement:Uyuni:{{ uyuni_version }}:Debian{{ release }}-Uyuni-Client-Tools
+        Pin-Priority: 800
+{% endif -%}
 
 {% endif %} {# grains['os'] == 'Debian' #}
 {% endif %} {# no client tools on server or proxy #}


### PR DESCRIPTION
## What does this PR change?

This PR prevents the following syntax error when deploying `deblike-minion`:

```console
(remote-exec):␛[0m ␛[0m[CRITICAL] Could not render SLS default.minimal. Syntax error detected.
(remote-exec):␛[0m ␛[0m␛[0;1;31mlocal:␛[0;0m
(remote-exec):␛[0m ␛[0m    ␛[0;1;31mData failed to compile:␛[0;0m
(remote-exec):␛[0m ␛[0m␛[0;1;31m----------
(remote-exec):␛[0m ␛[0m    ID Pin in SLS repos.client_tools.client_tools_uyuni is not a dictionary␛[0;0m
(remote-exec):␛[0m ␛[0m␛[0;1;31m----------
(remote-exec):␛[0m ␛[0m    ID Pin-Priority in SLS repos.client_tools.client_tools_uyuni is not a dictionary␛[0;0m
```
