### PR TITLE
Install Node exporter service on controller

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -252,3 +252,16 @@ web_server_directory:
         - file: /etc/fstab
         - pkg: nfs_client
 {% endif %}
+
+node_exporter:
+  pkg.installed:
+    - name: golang-github-prometheus-node_exporter
+    - require:
+      - sls: repos
+
+node_exporter_service:
+  service.running:
+    - name: prometheus-node_exporter
+    - enable: True
+    - require:
+      - pkg: node_exporter


### PR DESCRIPTION
## What does this PR change?

This pull request adds monitoring capabilities to the controller by installing and enabling the Prometheus Node Exporter. The changes ensure that the necessary package is installed and the corresponding service is running and enabled on startup.

**Monitoring enhancements:**

* Added installation of the `golang-github-prometheus-node_exporter` package to provide system metrics for Prometheus monitoring.
* Ensured the `prometheus-node_exporter` service is running and enabled, with dependencies set to guarantee the package is installed first.
* The package will be sourced by the OS repositories.

Related PR: https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/1183


I made a manually attempt here:
<img width="2540" height="1011" alt="image" src="https://github.com/user-attachments/assets/d9a90f43-ac66-4511-8261-b76c8fe894e0" />

```
mlm-ci-head-podman-controller:~ # ss -lntp | grep ':9100'
LISTEN 0      4096               *:9100             *:*    users:(("node_exporter",pid=22269,fd=3))
mlm-ci-head-podman-controller:~ # curl -sS --max-time 3 http://127.0.0.1:9100/metrics | head
# HELP go_gc_duration_seconds A summary of the wall-time pause (stop-the-world) duration in garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 2.564e-05
go_gc_duration_seconds{quantile="0.25"} 2.713e-05
go_gc_duration_seconds{quantile="0.5"} 2.797e-05
go_gc_duration_seconds{quantile="0.75"} 2.9141e-05
go_gc_duration_seconds{quantile="1"} 3.224e-05
go_gc_duration_seconds_sum 0.000142121
go_gc_duration_seconds_count 5
# HELP go_gc_gogc_percent Heap size target percentage configured by the user, otherwise 100. This value is set by the GOGC environment variable, and the runtime/debug.SetGCPercent function. Sourced from /gc/gogc:percent
curl: (23) Failure writing output to destination, passed 2048 returned 0
mlm-ci-head-podman-controller:~ # systemctl status prometheus-node_exporter
● prometheus-node_exporter.service - Prometheus exporter for machine metrics
     Loaded: loaded (/usr/lib/systemd/system/prometheus-node_exporter.service; disabled; preset: disabled)
     Active: active (running) since Wed 2026-04-22 15:37:04 CEST; 4min 39s ago
       Docs: https://github.com/prometheus/node_exporter
   Main PID: 22269 (node_exporter)
      Tasks: 5 (limit: 4667)
        CPU: 70ms
     CGroup: /system.slice/prometheus-node_exporter.service
             └─22269 /usr/bin/node_exporter

Apr 22 15:41:39 mlm-ci-head-podman-controller node_exporter[22269]: time=2026-04-22T13:41:39.137Z level=ERROR source=ht>
Apr 22 15:41:39 mlm-ci-head-podman-controller node_exporter[22269]: time=2026-04-22T13:41:39.137Z level=ERROR source=ht>
Apr 22 15:41:39 mlm-ci-head-podman-controller node_exporter[22269]: time=2026-04-22T13:41:39.137Z level=ERROR source=ht>
Apr 22 15:41:39 mlm-ci-head-podman-controller node_exporter[22269]: time=2026-04-22T13:41:39.137Z level=ERROR source=ht>
Apr 22 15:41:39 mlm-ci-head-
```