### PR TITLE
Augment ulimits and mmaps on the controller

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -265,3 +265,15 @@ node_exporter_service:
     - enable: True
     - require:
       - pkg: node_exporter
+
+augment_ulimits:
+  file.managed:
+    - name: /etc/security/limits.conf
+    - source: salt://controller/limits.conf
+
+augment_mmaps:
+  file.managed:
+    - name: /etc/sysctl.conf
+    - source: salt://controller/sysctl.conf
+  cmd.run:
+    - name: sysctl -p

--- a/salt/controller/limits.conf
+++ b/salt/controller/limits.conf
@@ -1,0 +1,6 @@
+# Per-user open files limits
+root           soft   nofile         32768
+root           hard   nofile         32768
+
+admin          soft   nofile         32768
+admin          hard   nofile         32768

--- a/salt/controller/sysctl.conf
+++ b/salt/controller/sysctl.conf
@@ -1,0 +1,2 @@
+# Maximum number of memory map areas
+vm.max_map_count=524288


### PR DESCRIPTION
## What does this PR change?

Augment ulimits and mmaps on the controller: the ulimits by a factor 32, and the mmaps by a factor 20.

Mostly useful for full BV. Tailored for 50 chrome processes.

Tested on 5.1.3 full BV:
```
mlm-bv-51-sles-controller:~ # cat /proc/sys/vm/max_map_count 
524288
mlm-bv-51-sles-controller:~ # ulimit -n 
32768
```