### PR TITLE
Add CPU v2 features to SLES15SP7 (Server) and Leap 15.6 (Controller)

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -3,7 +3,9 @@ locals {
   resource_name_prefix = "${var.base_configuration["name_prefix"]}${var.name}"
   manufacturer = lookup(var.provider_settings, "manufacturer", "Intel")
   product      = lookup(var.provider_settings, "product", "Genuine")
-  x86_64_v2_images = ["almalinux10o", "almalinux9o", "amazonlinux2023o", "libertylinux9o", "openeuler2403o", "oraclelinux9o", "rocky9o", "sles160o", "opensuse160o", "slemicro55o", "slmicro60o", "slmicro61o", "slmicro62o", "ubuntu2404o"]
+  // List of images that can benefit from cpu passthrough or host-model.
+  // In particular, opensuse156o covers the controller and sles15sp7o is required for the upgrade test to sles160o
+  x86_64_v2_images = ["opensuse156o", "almalinux10o", "almalinux9o", "amazonlinux2023o", "libertylinux9o", "openeuler2403o", "oraclelinux9o", "rocky9o", "sles15sp7o", "sles160o", "opensuse160o", "slemicro55o", "slmicro60o", "slmicro61o", "slmicro62o", "ubuntu2404o"]
   combustion_images  = ["slmicro60o", "slmicro61o", "slmicro62o", "sles160o"]
   gpg_keys = [
     for key in fileset("salt/default/gpg_keys/", "*.key"): {


### PR DESCRIPTION
## What does this PR change?

This pull request updates the list of supported `x86_64_v2_images` in the `backend_modules/libvirt/host/main.tf` file. The main change is the addition of new image types to the list, improving compatibility with more operating system versions.

**Image support updates:**

* Added `opensuse156o` and `sles15sp7o` to the `x86_64_v2_images` list, expanding the range of supported OS images.
