### PR TITLE
Get controller.memory from environment_configuration in BV module

### DIFF
--- a/modules/build_validation/main.tf
+++ b/modules/build_validation/main.tf
@@ -1380,7 +1380,7 @@ module "controller" {
   name               = var.environment_configuration.controller.name
   provider_settings = {
     mac    = var.environment_configuration.controller.mac
-    memory = 16384
+    memory = length(var.environment_configuration.controller.memory) > 0 ? var.environment_configuration.controller.memory : 16384
     vcpu   = 8
   }
   swap_file_size = null


### PR DESCRIPTION
## What does this PR change?

This pull request makes a minor adjustment to the `controller` module configuration in `main.tf`. The change ensures that the controller's memory setting is configurable: if a memory value is provided in `var.environment_configuration.controller.memory`, it will be used; otherwise, the default value of 16384 is applied.