### PR TITLE
Fix wrong comparison on bv controller, about memory

### DIFF
--- a/modules/build_validation/main.tf
+++ b/modules/build_validation/main.tf
@@ -1380,7 +1380,7 @@ module "controller" {
   name               = var.environment_configuration.controller.name
   provider_settings = {
     mac    = var.environment_configuration.controller.mac
-    memory = length(var.environment_configuration.controller.memory) > 0 ? var.environment_configuration.controller.memory : 16384
+    memory = var.environment_configuration.controller.memory != null ? var.environment_configuration.controller.memory : 16384
     vcpu   = 8
   }
   swap_file_size = null


### PR DESCRIPTION
## What does this PR change?

This pull request makes a minor update to how the default memory value is determined for the `controller` module in the Terraform configuration. The logic now explicitly checks for `null` instead of relying on the length of the memory value, which improves clarity and correctness when handling unset or empty values.