### PR TITLE
Fix memory declaration for accept no declaration

### DIFF
--- a/modules/build_validation/main.tf
+++ b/modules/build_validation/main.tf
@@ -1380,7 +1380,7 @@ module "controller" {
   name               = var.environment_configuration.controller.name
   provider_settings = {
     mac    = var.environment_configuration.controller.mac
-    memory = var.environment_configuration.controller.memory != null ? var.environment_configuration.controller.memory : 16384
+    memory = lookup(var.environment_configuration.controller, "memory", "16384")
     vcpu   = 8
   }
   swap_file_size = null


### PR DESCRIPTION
## What does this PR change?

Fix memory declaration for cucumber.
It was failing when memory was not declared (sle MU).

```
12:05:58  [1mPlan:[0m 16 to add, 0 to change, 16 to destroy.
12:05:58  [0m[31m╷[0m[0m
12:05:58  [31m│[0m [0m[1m[31mError: [0m[0m[1mUnsupported attribute[0m
12:05:58  [31m│[0m [0m
12:05:58  [31m│[0m [0m[0m  on modules/build_validation/main.tf line 1383, in module "controller":
12:05:58  [31m│[0m [0m1383:     memory = var.environment_configuration.controller[4m.memory[0m != null ? var.environment_configuration.controller.memory : 16384[0m
12:05:58  [31m│[0m [0m    [90m├────────────────[0m
12:05:58  [31m│[0m [0m[0m    [90m│[0m [1mvar.environment_configuration.controller[0m is object with 2 attributes
12:05:58  [31m│[0m [0m[0m
12:05:58  [31m│[0m [0mThis object does not have an attribute named "memory".
12:05:58  [31m╵[0m[0m
```
