### PR TITLE
Do not expose GH credentials in the output from OpenTofu deployment

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -130,6 +130,7 @@ fix_cucumber_html_reporter_style:
 git_config:
   file.append:
     - name: ~/.netrc
+    - show_changes: False
     - text: |
 {%- if grains.get("git_username") and grains.get("git_password") %}
         machine github.com


### PR DESCRIPTION
# DO NOT MERGE THIS YET. IT REQUIRES https://github.com/openSUSE/salt/pull/760 to be merged and released

## What does this PR change?

This PR makes the salt state that configures the GH credentials in the controller node to not display the GH credentials as part of the state execution summary:

```
cucumber_testsuite.controller.provisioning[0] (remote-exec):----------
cucumber_testsuite.controller.provisioning[0] (remote-exec):       ID: git_config
cucumber_testsuite.controller.provisioning[0] (remote-exec): Function: file.append
cucumber_testsuite.controller.provisioning[0] (remote-exec):     Name: ~/.netrc
cucumber_testsuite.controller.provisioning[0] (remote-exec):   Result: True
cucumber_testsuite.controller.provisioning[0] (remote-exec):  Comment: Appended 4 lines
cucumber_testsuite.controller.provisioning[0] (remote-exec):  Started: 13:57:32.235144
cucumber_testsuite.controller.provisioning[0] (remote-exec): Duration: 3.858 ms
cucumber_testsuite.controller.provisioning[0] (remote-exec):      Changes:
cucumber_testsuite.controller.provisioning[0] (remote-exec):        ----------
cucumber_testsuite.controller.provisioning[0] (remote-exec):        diff:
cucumber_testsuite.controller.provisioning[0] (remote-exec):            --- 
cucumber_testsuite.controller.provisioning[0] (remote-exec):            +++ 
cucumber_testsuite.controller.provisioning[0] (remote-exec):            @@ -0,0 +1,4 @@
cucumber_testsuite.controller.provisioning[0] (remote-exec):            +machine github.com
cucumber_testsuite.controller.provisioning[0] (remote-exec):            +login XXXXXXXXXXX
cucumber_testsuite.controller.provisioning[0] (remote-exec):            +password XXXXXXXXXXXXXXXXXXX
cucumber_testsuite.controller.provisioning[0] (remote-exec):            +protocol https
cucumber_testsuite.controller.provisioning[0] (remote-exec):----------
```