### PR TITLE
Resurrect ruby3.3-devel

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -33,6 +33,7 @@ cucumber_requisites:
       - make
       - wget
       - ruby3.3
+      - ruby3.3-devel
       - ca-certificates-mozilla
       - apache2-worker
       - apache2-mod_nss


### PR DESCRIPTION
## What does this PR change?

Resurrect ruby3.3-devel

It is needed for building other gems