### PR TITLE
Explicitly disable dhcp v6

### DIFF
--- a/backend_modules/libvirt/host/network_config.yaml
+++ b/backend_modules/libvirt/host/network_config.yaml
@@ -1,24 +1,41 @@
-%{ if image == "debian12o" || image == "debian13o" || image == "amazonlinux2023o" }
+%{ if image == "debian12o" || image == "debian13o" || image == "amazonlinux2023o" || image == "ubuntu2404o" || image == "ubuntu2204o" }
 network:
   version: 2
   ethernets:
     ens3:
+%{ if dhcp_dns }
+      dhcp4: false
+      dhcp6: false
+      addresses: ['${dhcp_dns_address}/24']
+%{ else }
       dhcp4: true
+      dhcp6: false
+%{ endif }
 %{ else }
 network:
+%{ if image == "slemicro55o" || image == "sles15sp6o" || image == "sles15sp7o" || image == "opensuse156o" || image == "opensuse160o" || image == "opensuse156armo" || image == "opensuse160armo" }
+  version: 2
+  ethernets:
+    eth0:
+%{ if dhcp_dns }
+      dhcp4: false
+      dhcp6: false
+      addresses: ['${dhcp_dns_address}/24']
+%{ else }
+      dhcp4: true
+      dhcp6: false
+%{ endif }
+%{ else }
   version: 1
   config:
   - type: physical
-%{ if image == "ubuntu2404o" || image == "ubuntu2204o" || image == "slmicro62o" }
-    name: ens3
-%{ else }
     name: eth0
-%{ endif }
     subnets:
 %{ if dhcp_dns }
       - type: static
         address: ${dhcp_dns_address}
 %{ else }
       - type: dhcp4
+%{ endif }
 %{ endif }
 %{ endif }

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -7,6 +7,16 @@ chpasswd:
   list: |
      root:linux
 
+%{ if image == "slemicro55o" || image == "sles15sp6o" || image == "sles15sp7o" || image == "opensuse156o" || image == "opensuse160o" || image == "opensuse156armo" || image == "opensuse160armo" ~}
+bootcmd:
+  # Disable IPv6 SLAAC before wicked starts (cloud-init-local runs before wicked.service)
+  # Without this, the kernel assigns SLAAC addresses from RA packets, and Terraform
+  # picks them up as the SSH target, causing "network is unreachable" failures.
+  - mkdir -p /etc/sysctl.d
+  - "printf 'net.ipv6.conf.all.disable_ipv6=1\\nnet.ipv6.conf.default.disable_ipv6=1\\n' > /etc/sysctl.d/70-disable-ipv6.conf"
+  - sysctl -p /etc/sysctl.d/70-disable-ipv6.conf
+%{ endif ~}
+
 %{ if image == "tumbleweedo" ~}
 zypper:
   repos:


### PR DESCRIPTION
## What does this PR change?

DHCP6 is still enable after last changes.

```
root@localhost ~# cat /etc/sysconfig/network/ifcfg-eth0
# Created by cloud-init on instance boot automatically, do not edit.
#
BOOTPROTO=dhcp4
STARTMODE=auto
root@localhost ~# ^C
root@localhost ~# systemd-analyze
Startup finished in 890ms (kernel) + 12.012s (initrd) + 22.129s (userspace) = 35.033s
multi-user.target reached after 12.260s in userspace.
root@localhost ~# systemd-analyze blame | grep -E "wicked|network|dhcp"
 5.298s wicked.service
   39ms wickedd-auto4.service
   37ms wickedd-dhcp6.service
   35ms wickedd-dhcp4.service
   31ms wickedd.service
   10ms wickedd-nanny.service
root@localhost ~# systemd-analyze critical-chain network-online.target
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

network-online.target @11.606s
└─cloud-init.service @9.374s +2.230s
  └─wicked.service @4.060s +5.298s
    └─wickedd-nanny.service @4.048s +10ms
      └─wickedd.service @4.012s +31ms
        └─wickedd-dhcp6.service @3.965s +37ms
          └─network-pre.target @3.951s
            └─cloud-init-local.service @2.954s +996ms
              └─basic.target @2.945s
                └─sockets.target @2.944s
                  └─dbus.socket @2.944s
                    └─sysinit.target @2.939s
                      └─apparmor.service @432ms +2.505s
                        └─systemd-journald.socket
                          └─system.slice
                            └─-.slice
```

Explicitly disable dhcpv6