### PR TITLE
QE: Bump new RKE2 version and remove debug ports

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -244,6 +244,7 @@ module "server_kubernetes" {
   helm_chart_url                  = lookup(local.helm_chart_url, "server_kubernetes", "")
   use_devel_oci                   = var.use_devel_oci
   install_mlm_server              = var.install_mlm_server
+  java_debugging_on_rke2          = var.java_debugging_on_rke2
   install_traefik                 = var.install_traefik
   install_local_path_provisioner  = var.install_local_path_provisioner
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -198,6 +198,11 @@ variable "use_devel_oci" {
   default = false
 }
 
+variable "java_debugging_on_rke2" {
+  description = "Enable Java debugging on RKE2"
+  default     = false
+}
+
 variable "install_mlm_server" {
   description = "true to just install the RKE2 MLM server"
   default = true

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -91,6 +91,7 @@ module "server_kubernetes" {
     enable_oval_metadata           = var.enable_oval_metadata
     use_devel_oci                  = var.use_devel_oci
     install_mlm_server             = var.install_mlm_server
+    java_debugging_on_rke2         = var.java_debugging_on_rke2
     install_traefik                = var.install_traefik
     install_local_path_provisioner = var.install_local_path_provisioner
   }

--- a/modules/server_kubernetes/variables.tf
+++ b/modules/server_kubernetes/variables.tf
@@ -52,6 +52,11 @@ variable "install_mlm_server" {
   default = true
 }
 
+variable "java_debugging_on_rke2" {
+  description = "Enable Java debugging on RKE2"
+  default     = false
+}
+
 variable "install_traefik" {
   description = "true to install Traefik"
   default = true

--- a/salt/kubernetes_common/install_rke2.sls
+++ b/salt/kubernetes_common/install_rke2.sls
@@ -6,7 +6,7 @@
 {% set is_tumbleweed = osfullname == 'openSUSE Tumbleweed' %}
 {% set is_supported_os = is_sles_15_7 or is_slmicro_6_2 or is_ubuntu or is_tumbleweed %}
 {% if is_supported_os %}
-{% set rke2_version = "v1.34.2+rke2r1" %}
+{% set rke2_version = "v1.35.4+rke2r1" %}
 {% set kubeconfig = "/etc/rancher/rke2/rke2.yaml" %}
 
 {% set pkg_map = {

--- a/salt/server_kubernetes/install_kubernetes_server.sls
+++ b/salt/server_kubernetes/install_kubernetes_server.sls
@@ -124,6 +124,8 @@ copy_manifest_uyuni_ingress:
     - name: /var/lib/rancher/rke2/server/manifests/uyuni-ingress.yaml
     - source: salt://server_kubernetes/uyuni-ingress.yaml
     - template: jinja
+    - context:
+        java_debugging_on_rke2: {{ grains.get("java_debugging_on_rke2", false) }}
 
 transfer_python_management_file:
   file.managed:

--- a/salt/server_kubernetes/uyuni-ingress.yaml
+++ b/salt/server_kubernetes/uyuni-ingress.yaml
@@ -32,7 +32,7 @@ spec:
         protocol: TCP
         hostPort: 4506
         containerPort: 4506
-      # Only if java debugging is enabled
+{% if java_debugging_on_rke2 == true %}
       tasko-debug:
         port: 8001
         expose:
@@ -54,3 +54,4 @@ spec:
         exposedPort: 8003
         protocol: TCP
         hostPort: 8003
+{% endif %}


### PR DESCRIPTION
## What does this PR change?

Bump new RKE2 version and remove debug ports forwarded.
