### PR TITLE
tumbleweedo can also run x86_64_v2

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -5,7 +5,7 @@ locals {
   product      = lookup(var.provider_settings, "product", "Genuine")
   // List of images that can benefit from cpu passthrough or host-model.
   // In particular, opensuse156o covers the controller and sles15sp7o is required for the upgrade test to sles160o
-  x86_64_v2_images = ["opensuse156o", "almalinux10o", "almalinux9o", "amazonlinux2023o", "libertylinux9o", "openeuler2403o", "oraclelinux9o", "oraclelinux10o", "rocky9o", "rocky10o", "sles15sp7o", "sles160o", "opensuse160o", "slemicro55o", "slmicro60o", "slmicro61o", "slmicro62o", "ubuntu2404o"]
+  x86_64_v2_images = ["opensuse156o", "almalinux10o", "almalinux9o", "amazonlinux2023o", "libertylinux9o", "openeuler2403o", "oraclelinux9o", "oraclelinux10o", "rocky9o", "rocky10o", "sles15sp7o", "sles160o", "opensuse160o", "slemicro55o", "slmicro60o", "slmicro61o", "slmicro62o", "ubuntu2404o", "tumbleweedo"]
   combustion_images  = ["slmicro60o", "slmicro61o", "slmicro62o", "sles160o"]
   gpg_keys = [
     for key in fileset("salt/default/gpg_keys/", "*.key"): {


### PR DESCRIPTION
## What does this PR change?

To run Uyuni based on Leap16 image, the host OS need to support it as well.
Tubleweed can also run v2.
(We should think about doing this my default as nearly all OSes can run v2 these days)
