### PR TITLE
Add optional NFS Kubernetes provisioner

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -935,6 +935,42 @@ module "server" {
 }
 ```
 
+## Kubernetes storage
+
+The `server_kubernetes` and `proxy_kubernetes` modules install Rancher's `local-path-provisioner` by default and use the `local-path` StorageClass for Kubernetes persistent volume claims.
+This preserves the single-node test-lab behavior.
+
+To use a pre-existing StorageClass, for example one provided by NFS, Longhorn, OpenEBS, Rook/Ceph, or a cloud CSI driver, set the Kubernetes storage backend to one of `external`, `nfs`, `longhorn`, `openebs`, `rook-ceph`, or `cloud` and provide the StorageClass name:
+
+```hcl
+module "server" {
+  source             = "./modules/server_kubernetes"
+  base_configuration = module.base.configuration
+
+  name                       = "server"
+  kubernetes_storage_backend = "external"
+  kubernetes_storage_class   = "longhorn"
+}
+```
+
+With any non-`local-path` backend, sumaform does not install `local-path-provisioner` and does not create the static `var-spacewalk` hostPath PersistentVolume unless `kubernetes_create_static_var_spacewalk_pv` is explicitly set.
+Set `kubernetes_storage_class = null` to rely on the cluster's default StorageClass.
+
+The local-path backend can also be tuned without changing the default behavior:
+
+```hcl
+module "server" {
+  source             = "./modules/server_kubernetes"
+  base_configuration = module.base.configuration
+
+  name                                 = "server"
+  kubernetes_storage_backend           = "local-path"
+  kubernetes_storage_class             = "local-path"
+  local_path_provisioner_path          = "/opt/local-path-provisioner"
+  local_path_provisioner_default_class = true
+}
+```
+
 ## Large deployments
 
 By default to support the load in our test suites, when trying to reproduce situations with a large number of clients, it is advised to use `large_deployment` option.

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -956,6 +956,23 @@ module "server" {
 With any non-`local-path` backend, sumaform does not install `local-path-provisioner` and does not create the static `var-spacewalk` hostPath PersistentVolume unless `kubernetes_create_static_var_spacewalk_pv` is explicitly set.
 Set `kubernetes_storage_class = null` to rely on the cluster's default StorageClass.
 
+For NFS, sumaform can also install the NFS subdir external provisioner and create the StorageClass. This is opt-in so existing deployments that already provide an NFS StorageClass keep working unchanged:
+
+```hcl
+module "server" {
+  source             = "./modules/server_kubernetes"
+  base_configuration = module.base.configuration
+
+  name                       = "server"
+  kubernetes_storage_backend = "nfs"
+  install_nfs_provisioner    = true
+  nfs_storage_server         = "nfs.example.com"
+  nfs_storage_path           = "/srv/sumaform"
+}
+```
+
+With `install_nfs_provisioner = true`, `kubernetes_storage_class = null` defaults to `nfs-client`. Set `kubernetes_storage_class` explicitly to use a different StorageClass name.
+
 The local-path backend can also be tuned without changing the default behavior:
 
 ```hcl

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -99,6 +99,10 @@ locals {
     host_key => lookup(var.host_settings[host_key], "kubernetes_storage_backend", var.kubernetes_storage_backend) if var.host_settings[host_key] != null }
   kubernetes_storage_class = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "kubernetes_storage_class", var.kubernetes_storage_class) if var.host_settings[host_key] != null }
+  effective_kubernetes_storage_class = { for host_key in local.hosts :
+    host_key => lookup(local.kubernetes_storage_class, host_key, null) != null ? lookup(local.kubernetes_storage_class, host_key, null) : (
+      lookup(local.kubernetes_storage_backend, host_key, var.kubernetes_storage_backend) == "local-path" ? "local-path" : null
+    ) if var.host_settings[host_key] != null }
   local_path_provisioner_path = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "local_path_provisioner_path", var.local_path_provisioner_path) if var.host_settings[host_key] != null }
   local_path_provisioner_default_class = { for host_key in local.hosts :
@@ -262,7 +266,7 @@ module "server_kubernetes" {
   install_traefik                 = var.install_traefik
   install_local_path_provisioner  = var.install_local_path_provisioner
   kubernetes_storage_backend      = lookup(local.kubernetes_storage_backend, "server_kubernetes", var.kubernetes_storage_backend)
-  kubernetes_storage_class        = lookup(local.kubernetes_storage_class, "server_kubernetes", var.kubernetes_storage_class)
+  kubernetes_storage_class        = lookup(local.effective_kubernetes_storage_class, "server_kubernetes", var.kubernetes_storage_class)
   local_path_provisioner_path     = lookup(local.local_path_provisioner_path, "server_kubernetes", var.local_path_provisioner_path)
   local_path_provisioner_default_class = lookup(local.local_path_provisioner_default_class, "server_kubernetes", var.local_path_provisioner_default_class)
   local_path_provisioner_reclaim_policy = lookup(local.local_path_provisioner_reclaim_policy, "server_kubernetes", var.local_path_provisioner_reclaim_policy)
@@ -383,7 +387,7 @@ module "proxy_kubernetes" {
   install_traefik                 = var.install_traefik
   install_local_path_provisioner  = var.install_local_path_provisioner
   kubernetes_storage_backend      = lookup(local.kubernetes_storage_backend, "proxy_kubernetes", var.kubernetes_storage_backend)
-  kubernetes_storage_class        = lookup(local.kubernetes_storage_class, "proxy_kubernetes", var.kubernetes_storage_class)
+  kubernetes_storage_class        = lookup(local.effective_kubernetes_storage_class, "proxy_kubernetes", var.kubernetes_storage_class)
   local_path_provisioner_path     = lookup(local.local_path_provisioner_path, "proxy_kubernetes", var.local_path_provisioner_path)
   local_path_provisioner_default_class = lookup(local.local_path_provisioner_default_class, "proxy_kubernetes", var.local_path_provisioner_default_class)
   local_path_provisioner_reclaim_policy = lookup(local.local_path_provisioner_reclaim_policy, "proxy_kubernetes", var.local_path_provisioner_reclaim_policy)

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -99,9 +99,13 @@ locals {
     host_key => lookup(var.host_settings[host_key], "kubernetes_storage_backend", var.kubernetes_storage_backend) if var.host_settings[host_key] != null }
   kubernetes_storage_class = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "kubernetes_storage_class", var.kubernetes_storage_class) if var.host_settings[host_key] != null }
+  install_nfs_provisioner = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "install_nfs_provisioner", var.install_nfs_provisioner) if var.host_settings[host_key] != null }
   effective_kubernetes_storage_class = { for host_key in local.hosts :
     host_key => lookup(local.kubernetes_storage_class, host_key, null) != null ? lookup(local.kubernetes_storage_class, host_key, null) : (
-      lookup(local.kubernetes_storage_backend, host_key, var.kubernetes_storage_backend) == "local-path" ? "local-path" : null
+      lookup(local.kubernetes_storage_backend, host_key, var.kubernetes_storage_backend) == "local-path" ? "local-path" : (
+        lookup(local.kubernetes_storage_backend, host_key, var.kubernetes_storage_backend) == "nfs" && lookup(local.install_nfs_provisioner, host_key, var.install_nfs_provisioner) ? "nfs-client" : null
+      )
     ) if var.host_settings[host_key] != null }
   local_path_provisioner_path = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "local_path_provisioner_path", var.local_path_provisioner_path) if var.host_settings[host_key] != null }
@@ -109,6 +113,22 @@ locals {
     host_key => lookup(var.host_settings[host_key], "local_path_provisioner_default_class", var.local_path_provisioner_default_class) if var.host_settings[host_key] != null }
   local_path_provisioner_reclaim_policy = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "local_path_provisioner_reclaim_policy", var.local_path_provisioner_reclaim_policy) if var.host_settings[host_key] != null }
+  nfs_storage_server = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "nfs_storage_server", var.nfs_storage_server) if var.host_settings[host_key] != null }
+  nfs_storage_path = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "nfs_storage_path", var.nfs_storage_path) if var.host_settings[host_key] != null }
+  nfs_provisioner_namespace = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "nfs_provisioner_namespace", var.nfs_provisioner_namespace) if var.host_settings[host_key] != null }
+  nfs_provisioner_name = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "nfs_provisioner_name", var.nfs_provisioner_name) if var.host_settings[host_key] != null }
+  nfs_provisioner_image = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "nfs_provisioner_image", var.nfs_provisioner_image) if var.host_settings[host_key] != null }
+  nfs_provisioner_default_class = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "nfs_provisioner_default_class", var.nfs_provisioner_default_class) if var.host_settings[host_key] != null }
+  nfs_provisioner_reclaim_policy = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "nfs_provisioner_reclaim_policy", var.nfs_provisioner_reclaim_policy) if var.host_settings[host_key] != null }
+  nfs_provisioner_archive_on_delete = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "nfs_provisioner_archive_on_delete", var.nfs_provisioner_archive_on_delete) if var.host_settings[host_key] != null }
   kubernetes_create_static_var_spacewalk_pv = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "kubernetes_create_static_var_spacewalk_pv", var.kubernetes_create_static_var_spacewalk_pv) if var.host_settings[host_key] != null }
   kubernetes_var_spacewalk_host_path = { for host_key in local.hosts :
@@ -265,11 +285,20 @@ module "server_kubernetes" {
   java_debugging_on_rke2          = var.java_debugging_on_rke2
   install_traefik                 = var.install_traefik
   install_local_path_provisioner  = var.install_local_path_provisioner
+  install_nfs_provisioner         = lookup(local.install_nfs_provisioner, "server_kubernetes", var.install_nfs_provisioner)
   kubernetes_storage_backend      = lookup(local.kubernetes_storage_backend, "server_kubernetes", var.kubernetes_storage_backend)
   kubernetes_storage_class        = lookup(local.effective_kubernetes_storage_class, "server_kubernetes", var.kubernetes_storage_class)
   local_path_provisioner_path     = lookup(local.local_path_provisioner_path, "server_kubernetes", var.local_path_provisioner_path)
   local_path_provisioner_default_class = lookup(local.local_path_provisioner_default_class, "server_kubernetes", var.local_path_provisioner_default_class)
   local_path_provisioner_reclaim_policy = lookup(local.local_path_provisioner_reclaim_policy, "server_kubernetes", var.local_path_provisioner_reclaim_policy)
+  nfs_storage_server              = lookup(local.nfs_storage_server, "server_kubernetes", var.nfs_storage_server)
+  nfs_storage_path                = lookup(local.nfs_storage_path, "server_kubernetes", var.nfs_storage_path)
+  nfs_provisioner_namespace       = lookup(local.nfs_provisioner_namespace, "server_kubernetes", var.nfs_provisioner_namespace)
+  nfs_provisioner_name            = lookup(local.nfs_provisioner_name, "server_kubernetes", var.nfs_provisioner_name)
+  nfs_provisioner_image           = lookup(local.nfs_provisioner_image, "server_kubernetes", var.nfs_provisioner_image)
+  nfs_provisioner_default_class   = lookup(local.nfs_provisioner_default_class, "server_kubernetes", var.nfs_provisioner_default_class)
+  nfs_provisioner_reclaim_policy  = lookup(local.nfs_provisioner_reclaim_policy, "server_kubernetes", var.nfs_provisioner_reclaim_policy)
+  nfs_provisioner_archive_on_delete = lookup(local.nfs_provisioner_archive_on_delete, "server_kubernetes", var.nfs_provisioner_archive_on_delete)
   kubernetes_create_static_var_spacewalk_pv = lookup(local.kubernetes_create_static_var_spacewalk_pv, "server_kubernetes", var.kubernetes_create_static_var_spacewalk_pv)
   kubernetes_var_spacewalk_host_path = lookup(local.kubernetes_var_spacewalk_host_path, "server_kubernetes", var.kubernetes_var_spacewalk_host_path)
 }
@@ -386,11 +415,20 @@ module "proxy_kubernetes" {
   install_mlm_proxy               = var.install_mlm_proxy
   install_traefik                 = var.install_traefik
   install_local_path_provisioner  = var.install_local_path_provisioner
+  install_nfs_provisioner         = lookup(local.install_nfs_provisioner, "proxy_kubernetes", var.install_nfs_provisioner)
   kubernetes_storage_backend      = lookup(local.kubernetes_storage_backend, "proxy_kubernetes", var.kubernetes_storage_backend)
   kubernetes_storage_class        = lookup(local.effective_kubernetes_storage_class, "proxy_kubernetes", var.kubernetes_storage_class)
   local_path_provisioner_path     = lookup(local.local_path_provisioner_path, "proxy_kubernetes", var.local_path_provisioner_path)
   local_path_provisioner_default_class = lookup(local.local_path_provisioner_default_class, "proxy_kubernetes", var.local_path_provisioner_default_class)
   local_path_provisioner_reclaim_policy = lookup(local.local_path_provisioner_reclaim_policy, "proxy_kubernetes", var.local_path_provisioner_reclaim_policy)
+  nfs_storage_server              = lookup(local.nfs_storage_server, "proxy_kubernetes", var.nfs_storage_server)
+  nfs_storage_path                = lookup(local.nfs_storage_path, "proxy_kubernetes", var.nfs_storage_path)
+  nfs_provisioner_namespace       = lookup(local.nfs_provisioner_namespace, "proxy_kubernetes", var.nfs_provisioner_namespace)
+  nfs_provisioner_name            = lookup(local.nfs_provisioner_name, "proxy_kubernetes", var.nfs_provisioner_name)
+  nfs_provisioner_image           = lookup(local.nfs_provisioner_image, "proxy_kubernetes", var.nfs_provisioner_image)
+  nfs_provisioner_default_class   = lookup(local.nfs_provisioner_default_class, "proxy_kubernetes", var.nfs_provisioner_default_class)
+  nfs_provisioner_reclaim_policy  = lookup(local.nfs_provisioner_reclaim_policy, "proxy_kubernetes", var.nfs_provisioner_reclaim_policy)
+  nfs_provisioner_archive_on_delete = lookup(local.nfs_provisioner_archive_on_delete, "proxy_kubernetes", var.nfs_provisioner_archive_on_delete)
 }
 
 

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -95,6 +95,20 @@ locals {
     host_key => lookup(var.host_settings[host_key], "scc_access_logging", false) if var.host_settings[host_key] != null }
   enable_oval_metadata     = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "enable_oval_metadata", false) if var.host_settings[host_key] != null }
+  kubernetes_storage_backend = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "kubernetes_storage_backend", var.kubernetes_storage_backend) if var.host_settings[host_key] != null }
+  kubernetes_storage_class = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "kubernetes_storage_class", var.kubernetes_storage_class) if var.host_settings[host_key] != null }
+  local_path_provisioner_path = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "local_path_provisioner_path", var.local_path_provisioner_path) if var.host_settings[host_key] != null }
+  local_path_provisioner_default_class = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "local_path_provisioner_default_class", var.local_path_provisioner_default_class) if var.host_settings[host_key] != null }
+  local_path_provisioner_reclaim_policy = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "local_path_provisioner_reclaim_policy", var.local_path_provisioner_reclaim_policy) if var.host_settings[host_key] != null }
+  kubernetes_create_static_var_spacewalk_pv = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "kubernetes_create_static_var_spacewalk_pv", var.kubernetes_create_static_var_spacewalk_pv) if var.host_settings[host_key] != null }
+  kubernetes_var_spacewalk_host_path = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "kubernetes_var_spacewalk_host_path", var.kubernetes_var_spacewalk_host_path) if var.host_settings[host_key] != null }
 
   minimal_configuration     = { hostname = contains(local.hosts, "proxy") ? local.proxy_full_name : local.server_full_name }
   server_configuration      = var.kubernetes ? module.server_kubernetes[0].configuration : ( var.container_server ? module.server_containerized[0].configuration : module.server[0].configuration)
@@ -247,6 +261,13 @@ module "server_kubernetes" {
   java_debugging_on_rke2          = var.java_debugging_on_rke2
   install_traefik                 = var.install_traefik
   install_local_path_provisioner  = var.install_local_path_provisioner
+  kubernetes_storage_backend      = lookup(local.kubernetes_storage_backend, "server_kubernetes", var.kubernetes_storage_backend)
+  kubernetes_storage_class        = lookup(local.kubernetes_storage_class, "server_kubernetes", var.kubernetes_storage_class)
+  local_path_provisioner_path     = lookup(local.local_path_provisioner_path, "server_kubernetes", var.local_path_provisioner_path)
+  local_path_provisioner_default_class = lookup(local.local_path_provisioner_default_class, "server_kubernetes", var.local_path_provisioner_default_class)
+  local_path_provisioner_reclaim_policy = lookup(local.local_path_provisioner_reclaim_policy, "server_kubernetes", var.local_path_provisioner_reclaim_policy)
+  kubernetes_create_static_var_spacewalk_pv = lookup(local.kubernetes_create_static_var_spacewalk_pv, "server_kubernetes", var.kubernetes_create_static_var_spacewalk_pv)
+  kubernetes_var_spacewalk_host_path = lookup(local.kubernetes_var_spacewalk_host_path, "server_kubernetes", var.kubernetes_var_spacewalk_host_path)
 }
 
 module "proxy" {
@@ -361,6 +382,11 @@ module "proxy_kubernetes" {
   install_mlm_proxy               = var.install_mlm_proxy
   install_traefik                 = var.install_traefik
   install_local_path_provisioner  = var.install_local_path_provisioner
+  kubernetes_storage_backend      = lookup(local.kubernetes_storage_backend, "proxy_kubernetes", var.kubernetes_storage_backend)
+  kubernetes_storage_class        = lookup(local.kubernetes_storage_class, "proxy_kubernetes", var.kubernetes_storage_class)
+  local_path_provisioner_path     = lookup(local.local_path_provisioner_path, "proxy_kubernetes", var.local_path_provisioner_path)
+  local_path_provisioner_default_class = lookup(local.local_path_provisioner_default_class, "proxy_kubernetes", var.local_path_provisioner_default_class)
+  local_path_provisioner_reclaim_policy = lookup(local.local_path_provisioner_reclaim_policy, "proxy_kubernetes", var.local_path_provisioner_reclaim_policy)
 }
 
 

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -219,8 +219,48 @@ variable "install_traefik" {
 }
 
 variable "install_local_path_provisioner" {
-  description = "true to install local-path-provisioner"
+  description = "true to install local-path-provisioner when kubernetes_storage_backend is local-path"
   default = true
+}
+
+variable "kubernetes_storage_backend" {
+  description = "Storage backend for Kubernetes PVCs. Use local-path to let sumaform install Rancher's local-path provisioner. Other values expect a pre-existing StorageClass."
+  default     = "local-path"
+
+  validation {
+    condition     = contains(["local-path", "external", "nfs", "longhorn", "openebs", "rook-ceph", "cloud"], var.kubernetes_storage_backend)
+    error_message = "kubernetes_storage_backend must be one of: local-path, external, nfs, longhorn, openebs, rook-ceph, cloud."
+  }
+}
+
+variable "kubernetes_storage_class" {
+  description = "StorageClass name used by Kubernetes PVCs. Set to null to rely on the cluster default StorageClass."
+  default     = "local-path"
+}
+
+variable "local_path_provisioner_path" {
+  description = "Host path used by Rancher's local-path provisioner for dynamically provisioned volumes."
+  default     = "/opt/local-path-provisioner"
+}
+
+variable "local_path_provisioner_default_class" {
+  description = "true to mark the local-path StorageClass as the cluster default when it is installed."
+  default     = true
+}
+
+variable "local_path_provisioner_reclaim_policy" {
+  description = "Reclaim policy for the local-path StorageClass."
+  default     = "Delete"
+}
+
+variable "kubernetes_create_static_var_spacewalk_pv" {
+  description = "Whether to create the static var-spacewalk PersistentVolume. Leave null to enable it only with the local-path backend."
+  default     = null
+}
+
+variable "kubernetes_var_spacewalk_host_path" {
+  description = "Host path used by the static var-spacewalk PersistentVolume."
+  default     = "/var/lib/rancher/rke2/storage/var-spacewalk"
 }
 
 variable "beta_enabled" {

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -223,8 +223,13 @@ variable "install_local_path_provisioner" {
   default = true
 }
 
+variable "install_nfs_provisioner" {
+  description = "true to install the NFS subdir external provisioner when kubernetes_storage_backend is nfs"
+  default     = false
+}
+
 variable "kubernetes_storage_backend" {
-  description = "Storage backend for Kubernetes PVCs. Use local-path to let sumaform install Rancher's local-path provisioner. Other values expect a pre-existing StorageClass."
+  description = "Storage backend for Kubernetes PVCs. Use local-path to let sumaform install Rancher's local-path provisioner. Use nfs with install_nfs_provisioner to install an NFS provisioner. Other values expect a pre-existing StorageClass."
   default     = "local-path"
 
   validation {
@@ -251,6 +256,46 @@ variable "local_path_provisioner_default_class" {
 variable "local_path_provisioner_reclaim_policy" {
   description = "Reclaim policy for the local-path StorageClass."
   default     = "Delete"
+}
+
+variable "nfs_storage_server" {
+  description = "Hostname or IP address of the NFS server used by the NFS provisioner."
+  default     = null
+}
+
+variable "nfs_storage_path" {
+  description = "Export path on the NFS server used by the NFS provisioner."
+  default     = null
+}
+
+variable "nfs_provisioner_namespace" {
+  description = "Kubernetes namespace where the NFS provisioner is installed."
+  default     = "nfs-provisioner"
+}
+
+variable "nfs_provisioner_name" {
+  description = "Provisioner identifier used by the NFS provisioner and StorageClass."
+  default     = "sumaform.io/nfs-subdir-external-provisioner"
+}
+
+variable "nfs_provisioner_image" {
+  description = "Container image used for the NFS subdir external provisioner."
+  default     = "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2"
+}
+
+variable "nfs_provisioner_default_class" {
+  description = "true to mark the NFS StorageClass as the cluster default when it is installed."
+  default     = false
+}
+
+variable "nfs_provisioner_reclaim_policy" {
+  description = "Reclaim policy for the NFS StorageClass."
+  default     = "Delete"
+}
+
+variable "nfs_provisioner_archive_on_delete" {
+  description = "true to archive dynamically provisioned NFS directories when PVCs are deleted."
+  default     = true
 }
 
 variable "kubernetes_create_static_var_spacewalk_pv" {

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -234,8 +234,8 @@ variable "kubernetes_storage_backend" {
 }
 
 variable "kubernetes_storage_class" {
-  description = "StorageClass name used by Kubernetes PVCs. Set to null to rely on the cluster default StorageClass."
-  default     = "local-path"
+  description = "StorageClass name used by Kubernetes PVCs. Set to null to use the backend default, or the cluster default for externally managed backends."
+  default     = null
 }
 
 variable "local_path_provisioner_path" {

--- a/modules/proxy_kubernetes/main.tf
+++ b/modules/proxy_kubernetes/main.tf
@@ -68,6 +68,11 @@ module "proxy_kubernetes" {
     install_mlm_proxy               = var.install_mlm_proxy
     install_traefik                 = var.install_traefik
     install_local_path_provisioner  = var.install_local_path_provisioner
+    kubernetes_storage_backend            = var.kubernetes_storage_backend
+    kubernetes_storage_class              = var.kubernetes_storage_class
+    local_path_provisioner_path           = var.local_path_provisioner_path
+    local_path_provisioner_default_class  = var.local_path_provisioner_default_class
+    local_path_provisioner_reclaim_policy = var.local_path_provisioner_reclaim_policy
   }
 }
 

--- a/modules/proxy_kubernetes/main.tf
+++ b/modules/proxy_kubernetes/main.tf
@@ -17,7 +17,9 @@ variable "images" {
 locals {
   product_version = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
   kubernetes_storage_class = var.kubernetes_storage_class != null ? var.kubernetes_storage_class : (
-    var.kubernetes_storage_backend == "local-path" ? "local-path" : null
+    var.kubernetes_storage_backend == "local-path" ? "local-path" : (
+      var.kubernetes_storage_backend == "nfs" && var.install_nfs_provisioner ? "nfs-client" : null
+    )
   )
 }
 
@@ -71,11 +73,20 @@ module "proxy_kubernetes" {
     install_mlm_proxy               = var.install_mlm_proxy
     install_traefik                 = var.install_traefik
     install_local_path_provisioner  = var.install_local_path_provisioner
+    install_nfs_provisioner         = var.install_nfs_provisioner
     kubernetes_storage_backend            = var.kubernetes_storage_backend
     kubernetes_storage_class              = local.kubernetes_storage_class
     local_path_provisioner_path           = var.local_path_provisioner_path
     local_path_provisioner_default_class  = var.local_path_provisioner_default_class
     local_path_provisioner_reclaim_policy = var.local_path_provisioner_reclaim_policy
+    nfs_storage_server                    = var.nfs_storage_server
+    nfs_storage_path                      = var.nfs_storage_path
+    nfs_provisioner_namespace             = var.nfs_provisioner_namespace
+    nfs_provisioner_name                  = var.nfs_provisioner_name
+    nfs_provisioner_image                 = var.nfs_provisioner_image
+    nfs_provisioner_default_class         = var.nfs_provisioner_default_class
+    nfs_provisioner_reclaim_policy        = var.nfs_provisioner_reclaim_policy
+    nfs_provisioner_archive_on_delete     = var.nfs_provisioner_archive_on_delete
   }
 }
 

--- a/modules/proxy_kubernetes/main.tf
+++ b/modules/proxy_kubernetes/main.tf
@@ -16,6 +16,9 @@ variable "images" {
 
 locals {
   product_version = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
+  kubernetes_storage_class = var.kubernetes_storage_class != null ? var.kubernetes_storage_class : (
+    var.kubernetes_storage_backend == "local-path" ? "local-path" : null
+  )
 }
 
 module "proxy_kubernetes" {
@@ -69,7 +72,7 @@ module "proxy_kubernetes" {
     install_traefik                 = var.install_traefik
     install_local_path_provisioner  = var.install_local_path_provisioner
     kubernetes_storage_backend            = var.kubernetes_storage_backend
-    kubernetes_storage_class              = var.kubernetes_storage_class
+    kubernetes_storage_class              = local.kubernetes_storage_class
     local_path_provisioner_path           = var.local_path_provisioner_path
     local_path_provisioner_default_class  = var.local_path_provisioner_default_class
     local_path_provisioner_reclaim_policy = var.local_path_provisioner_reclaim_policy

--- a/modules/proxy_kubernetes/variables.tf
+++ b/modules/proxy_kubernetes/variables.tf
@@ -89,8 +89,13 @@ variable "install_local_path_provisioner" {
   default = true
 }
 
+variable "install_nfs_provisioner" {
+  description = "true to install the NFS subdir external provisioner when kubernetes_storage_backend is nfs"
+  default     = false
+}
+
 variable "kubernetes_storage_backend" {
-  description = "Storage backend for Kubernetes PVCs. Use local-path to let sumaform install Rancher's local-path provisioner. Other values expect a pre-existing StorageClass."
+  description = "Storage backend for Kubernetes PVCs. Use local-path to let sumaform install Rancher's local-path provisioner. Use nfs with install_nfs_provisioner to install an NFS provisioner. Other values expect a pre-existing StorageClass."
   default     = "local-path"
 
   validation {
@@ -117,6 +122,46 @@ variable "local_path_provisioner_default_class" {
 variable "local_path_provisioner_reclaim_policy" {
   description = "Reclaim policy for the local-path StorageClass."
   default     = "Delete"
+}
+
+variable "nfs_storage_server" {
+  description = "Hostname or IP address of the NFS server used by the NFS provisioner."
+  default     = null
+}
+
+variable "nfs_storage_path" {
+  description = "Export path on the NFS server used by the NFS provisioner."
+  default     = null
+}
+
+variable "nfs_provisioner_namespace" {
+  description = "Kubernetes namespace where the NFS provisioner is installed."
+  default     = "nfs-provisioner"
+}
+
+variable "nfs_provisioner_name" {
+  description = "Provisioner identifier used by the NFS provisioner and StorageClass."
+  default     = "sumaform.io/nfs-subdir-external-provisioner"
+}
+
+variable "nfs_provisioner_image" {
+  description = "Container image used for the NFS subdir external provisioner."
+  default     = "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2"
+}
+
+variable "nfs_provisioner_default_class" {
+  description = "true to mark the NFS StorageClass as the cluster default when it is installed."
+  default     = false
+}
+
+variable "nfs_provisioner_reclaim_policy" {
+  description = "Reclaim policy for the NFS StorageClass."
+  default     = "Delete"
+}
+
+variable "nfs_provisioner_archive_on_delete" {
+  description = "true to archive dynamically provisioned NFS directories when PVCs are deleted."
+  default     = true
 }
 
 variable "server_configuration" {

--- a/modules/proxy_kubernetes/variables.tf
+++ b/modules/proxy_kubernetes/variables.tf
@@ -100,8 +100,8 @@ variable "kubernetes_storage_backend" {
 }
 
 variable "kubernetes_storage_class" {
-  description = "StorageClass name used by Kubernetes PVCs. Set to null to rely on the cluster default StorageClass."
-  default     = "local-path"
+  description = "StorageClass name used by Kubernetes PVCs. Set to null to use the backend default, or the cluster default for externally managed backends."
+  default     = null
 }
 
 variable "local_path_provisioner_path" {

--- a/modules/proxy_kubernetes/variables.tf
+++ b/modules/proxy_kubernetes/variables.tf
@@ -85,8 +85,38 @@ variable "install_traefik" {
 }
 
 variable "install_local_path_provisioner" {
-  description = "true to install local-path-provisioner"
+  description = "true to install local-path-provisioner when kubernetes_storage_backend is local-path"
   default = true
+}
+
+variable "kubernetes_storage_backend" {
+  description = "Storage backend for Kubernetes PVCs. Use local-path to let sumaform install Rancher's local-path provisioner. Other values expect a pre-existing StorageClass."
+  default     = "local-path"
+
+  validation {
+    condition     = contains(["local-path", "external", "nfs", "longhorn", "openebs", "rook-ceph", "cloud"], var.kubernetes_storage_backend)
+    error_message = "kubernetes_storage_backend must be one of: local-path, external, nfs, longhorn, openebs, rook-ceph, cloud."
+  }
+}
+
+variable "kubernetes_storage_class" {
+  description = "StorageClass name used by Kubernetes PVCs. Set to null to rely on the cluster default StorageClass."
+  default     = "local-path"
+}
+
+variable "local_path_provisioner_path" {
+  description = "Host path used by Rancher's local-path provisioner for dynamically provisioned volumes."
+  default     = "/opt/local-path-provisioner"
+}
+
+variable "local_path_provisioner_default_class" {
+  description = "true to mark the local-path StorageClass as the cluster default when it is installed."
+  default     = true
+}
+
+variable "local_path_provisioner_reclaim_policy" {
+  description = "Reclaim policy for the local-path StorageClass."
+  default     = "Delete"
 }
 
 variable "server_configuration" {

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -94,6 +94,13 @@ module "server_kubernetes" {
     java_debugging_on_rke2         = var.java_debugging_on_rke2
     install_traefik                = var.install_traefik
     install_local_path_provisioner = var.install_local_path_provisioner
+    kubernetes_storage_backend                = var.kubernetes_storage_backend
+    kubernetes_storage_class                  = var.kubernetes_storage_class
+    local_path_provisioner_path               = var.local_path_provisioner_path
+    local_path_provisioner_default_class      = var.local_path_provisioner_default_class
+    local_path_provisioner_reclaim_policy     = var.local_path_provisioner_reclaim_policy
+    kubernetes_create_static_var_spacewalk_pv = var.kubernetes_create_static_var_spacewalk_pv
+    kubernetes_var_spacewalk_host_path        = var.kubernetes_var_spacewalk_host_path
   }
 }
 

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -18,6 +18,9 @@ variable "images" {
 
 locals {
   product_version = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
+  kubernetes_storage_class = var.kubernetes_storage_class != null ? var.kubernetes_storage_class : (
+    var.kubernetes_storage_backend == "local-path" ? "local-path" : null
+  )
 }
 
 module "server_kubernetes" {
@@ -95,7 +98,7 @@ module "server_kubernetes" {
     install_traefik                = var.install_traefik
     install_local_path_provisioner = var.install_local_path_provisioner
     kubernetes_storage_backend                = var.kubernetes_storage_backend
-    kubernetes_storage_class                  = var.kubernetes_storage_class
+    kubernetes_storage_class                  = local.kubernetes_storage_class
     local_path_provisioner_path               = var.local_path_provisioner_path
     local_path_provisioner_default_class      = var.local_path_provisioner_default_class
     local_path_provisioner_reclaim_policy     = var.local_path_provisioner_reclaim_policy

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -19,7 +19,9 @@ variable "images" {
 locals {
   product_version = var.product_version != null ? var.product_version : var.base_configuration["product_version"]
   kubernetes_storage_class = var.kubernetes_storage_class != null ? var.kubernetes_storage_class : (
-    var.kubernetes_storage_backend == "local-path" ? "local-path" : null
+    var.kubernetes_storage_backend == "local-path" ? "local-path" : (
+      var.kubernetes_storage_backend == "nfs" && var.install_nfs_provisioner ? "nfs-client" : null
+    )
   )
 }
 
@@ -97,11 +99,20 @@ module "server_kubernetes" {
     java_debugging_on_rke2         = var.java_debugging_on_rke2
     install_traefik                = var.install_traefik
     install_local_path_provisioner = var.install_local_path_provisioner
+    install_nfs_provisioner        = var.install_nfs_provisioner
     kubernetes_storage_backend                = var.kubernetes_storage_backend
     kubernetes_storage_class                  = local.kubernetes_storage_class
     local_path_provisioner_path               = var.local_path_provisioner_path
     local_path_provisioner_default_class      = var.local_path_provisioner_default_class
     local_path_provisioner_reclaim_policy     = var.local_path_provisioner_reclaim_policy
+    nfs_storage_server                        = var.nfs_storage_server
+    nfs_storage_path                          = var.nfs_storage_path
+    nfs_provisioner_namespace                 = var.nfs_provisioner_namespace
+    nfs_provisioner_name                      = var.nfs_provisioner_name
+    nfs_provisioner_image                     = var.nfs_provisioner_image
+    nfs_provisioner_default_class             = var.nfs_provisioner_default_class
+    nfs_provisioner_reclaim_policy            = var.nfs_provisioner_reclaim_policy
+    nfs_provisioner_archive_on_delete         = var.nfs_provisioner_archive_on_delete
     kubernetes_create_static_var_spacewalk_pv = var.kubernetes_create_static_var_spacewalk_pv
     kubernetes_var_spacewalk_host_path        = var.kubernetes_var_spacewalk_host_path
   }

--- a/modules/server_kubernetes/variables.tf
+++ b/modules/server_kubernetes/variables.tf
@@ -63,8 +63,48 @@ variable "install_traefik" {
 }
 
 variable "install_local_path_provisioner" {
-  description = "true to install local-path-provisioner"
+  description = "true to install local-path-provisioner when kubernetes_storage_backend is local-path"
   default = true
+}
+
+variable "kubernetes_storage_backend" {
+  description = "Storage backend for Kubernetes PVCs. Use local-path to let sumaform install Rancher's local-path provisioner. Other values expect a pre-existing StorageClass."
+  default     = "local-path"
+
+  validation {
+    condition     = contains(["local-path", "external", "nfs", "longhorn", "openebs", "rook-ceph", "cloud"], var.kubernetes_storage_backend)
+    error_message = "kubernetes_storage_backend must be one of: local-path, external, nfs, longhorn, openebs, rook-ceph, cloud."
+  }
+}
+
+variable "kubernetes_storage_class" {
+  description = "StorageClass name used by Kubernetes PVCs. Set to null to rely on the cluster default StorageClass."
+  default     = "local-path"
+}
+
+variable "local_path_provisioner_path" {
+  description = "Host path used by Rancher's local-path provisioner for dynamically provisioned volumes."
+  default     = "/opt/local-path-provisioner"
+}
+
+variable "local_path_provisioner_default_class" {
+  description = "true to mark the local-path StorageClass as the cluster default when it is installed."
+  default     = true
+}
+
+variable "local_path_provisioner_reclaim_policy" {
+  description = "Reclaim policy for the local-path StorageClass."
+  default     = "Delete"
+}
+
+variable "kubernetes_create_static_var_spacewalk_pv" {
+  description = "Whether to create the static var-spacewalk PersistentVolume. Leave null to enable it only with the local-path backend."
+  default     = null
+}
+
+variable "kubernetes_var_spacewalk_host_path" {
+  description = "Host path used by the static var-spacewalk PersistentVolume."
+  default     = "/var/lib/rancher/rke2/storage/var-spacewalk"
 }
 
 variable "db_container_repository" {

--- a/modules/server_kubernetes/variables.tf
+++ b/modules/server_kubernetes/variables.tf
@@ -78,8 +78,8 @@ variable "kubernetes_storage_backend" {
 }
 
 variable "kubernetes_storage_class" {
-  description = "StorageClass name used by Kubernetes PVCs. Set to null to rely on the cluster default StorageClass."
-  default     = "local-path"
+  description = "StorageClass name used by Kubernetes PVCs. Set to null to use the backend default, or the cluster default for externally managed backends."
+  default     = null
 }
 
 variable "local_path_provisioner_path" {

--- a/modules/server_kubernetes/variables.tf
+++ b/modules/server_kubernetes/variables.tf
@@ -67,8 +67,13 @@ variable "install_local_path_provisioner" {
   default = true
 }
 
+variable "install_nfs_provisioner" {
+  description = "true to install the NFS subdir external provisioner when kubernetes_storage_backend is nfs"
+  default     = false
+}
+
 variable "kubernetes_storage_backend" {
-  description = "Storage backend for Kubernetes PVCs. Use local-path to let sumaform install Rancher's local-path provisioner. Other values expect a pre-existing StorageClass."
+  description = "Storage backend for Kubernetes PVCs. Use local-path to let sumaform install Rancher's local-path provisioner. Use nfs with install_nfs_provisioner to install an NFS provisioner. Other values expect a pre-existing StorageClass."
   default     = "local-path"
 
   validation {
@@ -95,6 +100,46 @@ variable "local_path_provisioner_default_class" {
 variable "local_path_provisioner_reclaim_policy" {
   description = "Reclaim policy for the local-path StorageClass."
   default     = "Delete"
+}
+
+variable "nfs_storage_server" {
+  description = "Hostname or IP address of the NFS server used by the NFS provisioner."
+  default     = null
+}
+
+variable "nfs_storage_path" {
+  description = "Export path on the NFS server used by the NFS provisioner."
+  default     = null
+}
+
+variable "nfs_provisioner_namespace" {
+  description = "Kubernetes namespace where the NFS provisioner is installed."
+  default     = "nfs-provisioner"
+}
+
+variable "nfs_provisioner_name" {
+  description = "Provisioner identifier used by the NFS provisioner and StorageClass."
+  default     = "sumaform.io/nfs-subdir-external-provisioner"
+}
+
+variable "nfs_provisioner_image" {
+  description = "Container image used for the NFS subdir external provisioner."
+  default     = "registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2"
+}
+
+variable "nfs_provisioner_default_class" {
+  description = "true to mark the NFS StorageClass as the cluster default when it is installed."
+  default     = false
+}
+
+variable "nfs_provisioner_reclaim_policy" {
+  description = "Reclaim policy for the NFS StorageClass."
+  default     = "Delete"
+}
+
+variable "nfs_provisioner_archive_on_delete" {
+  description = "true to archive dynamically provisioned NFS directories when PVCs are deleted."
+  default     = true
 }
 
 variable "kubernetes_create_static_var_spacewalk_pv" {

--- a/salt/kubernetes_common/local-path-storage.yaml
+++ b/salt/kubernetes_common/local-path-storage.yaml
@@ -1,3 +1,6 @@
+{% set storage_class = grains.get('kubernetes_storage_class') or 'local-path' %}
+{% set local_path = grains.get('local_path_provisioner_path') or '/opt/local-path-provisioner' %}
+{% set reclaim_policy = grains.get('local_path_provisioner_reclaim_policy') or 'Delete' %}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -115,10 +118,10 @@ spec:
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: local-path
+  name: "{{ storage_class }}"
 provisioner: rancher.io/local-path
 volumeBindingMode: WaitForFirstConsumer
-reclaimPolicy: Delete
+reclaimPolicy: "{{ reclaim_policy }}"
 
 ---
 kind: ConfigMap
@@ -132,7 +135,7 @@ data:
             "nodePathMap":[
             {
                     "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
-                    "paths":["/opt/local-path-provisioner"]
+                    "paths":["{{ local_path }}"]
             }
             ]
     }

--- a/salt/kubernetes_common/nfs-storage.yaml
+++ b/salt/kubernetes_common/nfs-storage.yaml
@@ -1,0 +1,138 @@
+{% set storage_class = grains.get('kubernetes_storage_class') or 'nfs-client' %}
+{% set namespace = grains.get('nfs_provisioner_namespace') or 'nfs-provisioner' %}
+{% set provisioner_name = grains.get('nfs_provisioner_name') or 'sumaform.io/nfs-subdir-external-provisioner' %}
+{% set provisioner_image = grains.get('nfs_provisioner_image') or 'registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2' %}
+{% set nfs_server = grains.get('nfs_storage_server') %}
+{% set nfs_path = grains.get('nfs_storage_path') %}
+{% set reclaim_policy = grains.get('nfs_provisioner_reclaim_policy') or 'Delete' %}
+{% set archive_on_delete = grains.get('nfs_provisioner_archive_on_delete', true) %}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ namespace }}"
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nfs-subdir-external-provisioner
+  namespace: "{{ namespace }}"
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nfs-subdir-external-provisioner-runner
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: run-nfs-subdir-external-provisioner
+subjects:
+  - kind: ServiceAccount
+    name: nfs-subdir-external-provisioner
+    namespace: "{{ namespace }}"
+roleRef:
+  kind: ClusterRole
+  name: nfs-subdir-external-provisioner-runner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-nfs-subdir-external-provisioner
+  namespace: "{{ namespace }}"
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: leader-locking-nfs-subdir-external-provisioner
+  namespace: "{{ namespace }}"
+subjects:
+  - kind: ServiceAccount
+    name: nfs-subdir-external-provisioner
+    namespace: "{{ namespace }}"
+roleRef:
+  kind: Role
+  name: leader-locking-nfs-subdir-external-provisioner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nfs-subdir-external-provisioner
+  namespace: "{{ namespace }}"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: nfs-subdir-external-provisioner
+  template:
+    metadata:
+      labels:
+        app: nfs-subdir-external-provisioner
+    spec:
+      serviceAccountName: nfs-subdir-external-provisioner
+      containers:
+        - name: nfs-subdir-external-provisioner
+          image: "{{ provisioner_image }}"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PROVISIONER_NAME
+              value: "{{ provisioner_name }}"
+            - name: NFS_SERVER
+              value: "{{ nfs_server }}"
+            - name: NFS_PATH
+              value: "{{ nfs_path }}"
+          volumeMounts:
+            - name: nfs-client-root
+              mountPath: /persistentvolumes
+      volumes:
+        - name: nfs-client-root
+          nfs:
+            server: "{{ nfs_server }}"
+            path: "{{ nfs_path }}"
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: "{{ storage_class }}"
+provisioner: "{{ provisioner_name }}"
+parameters:
+  archiveOnDelete: "{% if archive_on_delete %}true{% else %}false{% endif %}"
+reclaimPolicy: "{{ reclaim_policy }}"
+allowVolumeExpansion: true
+volumeBindingMode: Immediate

--- a/salt/kubernetes_common/set_up_local-path-provisioner.sls
+++ b/salt/kubernetes_common/set_up_local-path-provisioner.sls
@@ -7,6 +7,9 @@
 {% set is_supported_os = is_sles_15_7 or is_slmicro_6_2 or is_ubuntu or is_tumbleweed %}
 {% if is_supported_os %}
 {% set kubeconfig = "/etc/rancher/rke2/rke2.yaml" %}
+{% set storage_class = grains.get('kubernetes_storage_class') or 'local-path' %}
+{% set local_path = grains.get('local_path_provisioner_path') or '/opt/local-path-provisioner' %}
+{% set default_class = grains.get('local_path_provisioner_default_class', true) %}
 {% set pkg_map = {} %}
 
 {% if osfullname in pkg_map %}
@@ -20,6 +23,7 @@ copy_local-path-storage_installation_file:
   file.managed:
   - name: /root/local-path-storage.yaml
   - source: salt://kubernetes_common/local-path-storage.yaml
+  - template: jinja
   - makedirs: true
 
 install_local_path_provisioner:
@@ -28,22 +32,26 @@ install_local_path_provisioner:
     - env:
       - KUBECONFIG: {{ kubeconfig }}
 
+{% if default_class %}
 set_local-path-storage-file-as-default:
   cmd.run:
     - name: |
-        kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+        kubectl patch storageclass {{ storage_class }} -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
     - env:
       - KUBECONFIG: {{ kubeconfig }}
+    - require:
+      - cmd: install_local_path_provisioner
+{% endif %}
 
 {% if is_tumbleweed or is_slmicro_6_2 %}
 
 create_local-path-provisioner_directory:
   file.directory:
-    - name: /opt/local-path-provisioner
+    - name: {{ local_path }}
 
 set_local-path-provisioner_selinux_tags:
   cmd.run:
-    - name: restorecon -R -v /opt/local-path-provisioner
+    - name: restorecon -R -v {{ local_path }}
     - require:
       - file: create_local-path-provisioner_directory
     - env:

--- a/salt/kubernetes_common/set_up_nfs_provisioner.sls
+++ b/salt/kubernetes_common/set_up_nfs_provisioner.sls
@@ -1,0 +1,59 @@
+{% set osfullname = grains['osfullname'] %}
+{% set osrelease = grains['osrelease'] %}
+{% set is_sles_15_7 = osfullname == 'SLES' and osrelease == '15.7' %}
+{% set is_slmicro_6_2 = osfullname == 'SL-Micro' and osrelease == '6.2' %}
+{% set is_ubuntu = osfullname == 'Ubuntu' %}
+{% set is_tumbleweed = osfullname == 'openSUSE Tumbleweed' %}
+{% set is_supported_os = is_sles_15_7 or is_slmicro_6_2 or is_ubuntu or is_tumbleweed %}
+{% if is_supported_os %}
+{% set kubeconfig = "/etc/rancher/rke2/rke2.yaml" %}
+{% set nfs_server = grains.get('nfs_storage_server') %}
+{% set nfs_path = grains.get('nfs_storage_path') %}
+{% set pkg_map = {
+    'SLES': ['nfs-client'],
+    'SL-Micro': ['nfs-client'],
+    'openSUSE Tumbleweed': ['nfs-client'],
+    'Ubuntu': ['nfs-common']
+} %}
+
+{% if not nfs_server or not nfs_path %}
+missing_nfs_storage_configuration:
+  test.fail_without_changes:
+    - name: nfs_storage_server and nfs_storage_path must be set when install_nfs_provisioner is true
+{% else %}
+
+install_nfs_client_package:
+  pkg.latest:
+    - pkgs: {{ pkg_map.get(osfullname) }}
+    - refresh: True
+
+copy_nfs_storage_installation_file:
+  file.managed:
+  - name: /root/nfs-storage.yaml
+  - source: salt://kubernetes_common/nfs-storage.yaml
+  - template: jinja
+  - makedirs: true
+
+install_nfs_provisioner:
+  cmd.run:
+    - name: kubectl apply -f /root/nfs-storage.yaml
+    - env:
+      - KUBECONFIG: {{ kubeconfig }}
+    - require:
+      - pkg: install_nfs_client_package
+      - file: copy_nfs_storage_installation_file
+
+{% if grains.get('nfs_provisioner_default_class', false) %}
+set_nfs-storage-file-as-default:
+  cmd.run:
+    - name: |
+        kubectl patch storageclass {{ grains.get('kubernetes_storage_class') or 'nfs-client' }} -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+    - env:
+      - KUBECONFIG: {{ kubeconfig }}
+    - require:
+      - cmd: install_nfs_provisioner
+{% endif %}
+
+{% endif %}
+
+{% endif %}

--- a/salt/proxy_kubernetes/init.sls
+++ b/salt/proxy_kubernetes/init.sls
@@ -1,9 +1,10 @@
+{% set storage_backend = grains.get('kubernetes_storage_backend', 'local-path') %}
 include:
   - repos
   - kubernetes_common.install_rke2
   - kubernetes_common.install_helm
   - proxy_kubernetes.config_node
-  {% if grains.get('install_local_path_provisioner') == true %}
+  {% if grains.get('install_local_path_provisioner') == true and storage_backend == 'local-path' %}
   - kubernetes_common.set_up_local-path-provisioner
   {% endif %}
   {% if grains.get('install_traefik') == true %}

--- a/salt/proxy_kubernetes/init.sls
+++ b/salt/proxy_kubernetes/init.sls
@@ -7,6 +7,9 @@ include:
   {% if grains.get('install_local_path_provisioner') == true and storage_backend == 'local-path' %}
   - kubernetes_common.set_up_local-path-provisioner
   {% endif %}
+  {% if grains.get('install_nfs_provisioner') == true and storage_backend == 'nfs' %}
+  - kubernetes_common.set_up_nfs_provisioner
+  {% endif %}
   {% if grains.get('install_traefik') == true %}
   - kubernetes_common.install_traefik
   {% endif %}

--- a/salt/server_kubernetes/init.sls
+++ b/salt/server_kubernetes/init.sls
@@ -7,6 +7,9 @@ include:
   {% if grains.get('install_local_path_provisioner') == true and storage_backend == 'local-path' %}
   - kubernetes_common.set_up_local-path-provisioner
   {% endif %}
+  {% if grains.get('install_nfs_provisioner') == true and storage_backend == 'nfs' %}
+  - kubernetes_common.set_up_nfs_provisioner
+  {% endif %}
   {% if grains.get('install_traefik') == true %}
   - kubernetes_common.install_traefik
   {% endif %}

--- a/salt/server_kubernetes/init.sls
+++ b/salt/server_kubernetes/init.sls
@@ -1,9 +1,10 @@
+{% set storage_backend = grains.get('kubernetes_storage_backend', 'local-path') %}
 include:
   - repos
   - kubernetes_common.install_rke2
   - kubernetes_common.install_helm
   - server_kubernetes.set-persistent-volumes
-  {% if grains.get('install_local_path_provisioner') == true %}
+  {% if grains.get('install_local_path_provisioner') == true and storage_backend == 'local-path' %}
   - kubernetes_common.set_up_local-path-provisioner
   {% endif %}
   {% if grains.get('install_traefik') == true %}

--- a/salt/server_kubernetes/set-persistent-volumes.sls
+++ b/salt/server_kubernetes/set-persistent-volumes.sls
@@ -1,18 +1,29 @@
 {% set kubeconfig = "/etc/rancher/rke2/rke2.yaml" %}
+{% set storage_backend = grains.get('kubernetes_storage_backend', 'local-path') %}
+{% set create_static_var_spacewalk_pv = grains.get('kubernetes_create_static_var_spacewalk_pv') %}
+{% if create_static_var_spacewalk_pv is none %}
+{% set create_static_var_spacewalk_pv = storage_backend == 'local-path' %}
+{% endif %}
 
 create_uyuni_namespace:
   cmd.run: 
   - name: kubectl create namespace uyuni
   - env:
     - KUBECONFIG: {{ kubeconfig }}
+  - unless: KUBECONFIG={{ kubeconfig }} kubectl get namespace uyuni
 
+{% if create_static_var_spacewalk_pv %}
 copy_var_spacewalk_file:
   file.managed:
     - name: /root/volume-configuration-var-spacewalk.yml
     - source: salt://server_kubernetes/volume-configuration-var-spacewalk.yml
+    - template: jinja
 
 apply_var_spacewalk_file:
   cmd.run:
     - name: kubectl apply -f /root/volume-configuration-var-spacewalk.yml
     - env:
       - KUBECONFIG: {{ kubeconfig }}
+    - require:
+      - file: copy_var_spacewalk_file
+{% endif %}

--- a/salt/server_kubernetes/values_server.yaml
+++ b/salt/server_kubernetes/values_server.yaml
@@ -3,6 +3,36 @@
 #
 # SPDX-License-Identifier: MIT
 
+{% set kubernetes_storage_class = grains.get('kubernetes_storage_class') %}
+{% set server_volume_names = [
+  'ca-certs',
+  'etc-apache2',
+  'etc-cobbler',
+  'etc-postfix',
+  'etc-rhn',
+  'etc-salt',
+  'etc-sssd',
+  'etc-sysconfig',
+  'etc-systemd-multi',
+  'etc-systemd-sockets',
+  'etc-tomcat',
+  'root',
+  'run-salt-master',
+  'srv-formulametadata',
+  'srv-pillar',
+  'srv-salt',
+  'srv-spacewalk',
+  'srv-susemanager',
+  'srv-tftpboot',
+  'srv-www',
+  'var-cache',
+  'var-cobbler',
+  'var-log',
+  'var-pgsql',
+  'var-salt',
+  'var-search',
+  'var-spacewalk',
+] %}
 # Default credentials, make sure to set them
 credentials:
   admin:
@@ -45,9 +75,15 @@ server-helm:
   pullPolicy: "Always"
   tftp:
     enable: true
+{% if kubernetes_storage_class %}
+  db:
+    volumes:
+{% for volume_name in server_volume_names %}
+      {{ volume_name }}:
+        storageClass: "{{ kubernetes_storage_class }}"
+{% endfor %}
+{% endif %}
 {% if app_armor_name %}
   server:
     apparmorProfile: {{ app_armor_name }}
 {% endif %}
-
-

--- a/salt/server_kubernetes/volume-configuration-var-spacewalk.yml
+++ b/salt/server_kubernetes/volume-configuration-var-spacewalk.yml
@@ -1,4 +1,6 @@
 # The size of the volume is defined in this file: https://github.com/uyuni-project/uyuni/blob/master/containers/server-helm/README.md
+{% set storage_class = grains.get('kubernetes_storage_class') or 'local-path' %}
+{% set var_spacewalk_host_path = grains.get('kubernetes_var_spacewalk_host_path') or '/var/lib/rancher/rke2/storage/var-spacewalk' %}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -8,11 +10,13 @@ spec:
     storage: 100Gi
   accessModes:
     - ReadWriteOnce
-  storageClassName: local-path
+  {% if storage_class %}
+  storageClassName: "{{ storage_class }}"
+  {% endif %}
 
   claimRef:
     namespace: uyuni
     name: var-spacewalk
 
   hostPath:
-    path: /var/lib/rancher/rke2/storage/var-spacewalk
+    path: "{{ var_spacewalk_host_path }}"


### PR DESCRIPTION
## What does this PR change?

Adds optional NFS provisioning for the Kubernetes storage backend.

When `kubernetes_storage_backend = "nfs"` and `install_nfs_provisioner = true`, sumaform installs the NFS subdir external provisioner and creates the configured StorageClass. The NFS server and export are provided through `nfs_storage_server` and `nfs_storage_path`.

Existing deployments that already provide an NFS StorageClass can leave `install_nfs_provisioner = false` and continue using the external class selection path from the shared storage backend change.

This PR includes the shared storage backend changes from #2155. The NFS-specific change is in the final commit.

## Validation

- Rendered and parsed the new NFS provisioner Salt/Jinja templates.
- Rendered and parsed the missing-configuration failure path.
- Ran `terraform validate`.

`terraform fmt -check` still reports formatting differences in the existing touched HCL files; no broad formatting pass was applied to keep the functional diff focused.
