### PR TITLE
Add InfraScan audit workflow

### DIFF
--- a/.github/workflows/infrascan.yml
+++ b/.github/workflows/infrascan.yml
@@ -1,0 +1,32 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.6
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14


### PR DESCRIPTION
**What does this PR change?**

This PR adds a new GitHub Actions workflow that automatically runs InfraScan audits on every push and pull request.

**Changes introduced**

- Added .github/workflows/infrascan.yml
- Runs InfraScan using the comprehensive scanner profile
- Generates an HTML report for each scan
- Uploads the report as a GitHub Actions artifact
- Ensures reports are available even when the scan fails (if: always())
- Retains generated reports for 14 days

**Motivation**
This workflow provides automated infrastructure code auditing and makes it easier to identify security, compliance, and cost-related issues in the Terraform-based infrastructure.

It also supports the discussion in #2064 by establishing a continuous auditing mechanism that helps validate infrastructure improvements and detect potential issues early in the development process.

**Closes**
Closes #2064