### PR TITLE
QE: Install mgrctl on slmicro 6.2 and TW

### DIFF
--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -149,7 +149,7 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
 # we do not support yet Leap Micro 6.2, even in Uyuni
 %{ if image == "slmicro62o" }
   # Still embryonary; only some cases are considered for now
-  %{ if container_server || container_proxy }
+  %{ if container_server || container_proxy || server_kubernetes }
     %{ if product_version == "5.2-released" }
       %{ if container_server }
         zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE/Products/Multi-Linux-Manager-Server/5.2/x86_64/product container_utils_repo
@@ -159,7 +159,7 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
       %{ endif }
     %{ endif }
     %{ if product_version == "head" }
-      %{ if container_server }
+      %{ if container_server || server_kubernetes }
         zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/Devel:/Galaxy:/Manager:/Main:/MLM-Beta-Products/images/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
       %{ endif }
       %{ if container_proxy }
@@ -167,7 +167,7 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
       %{ endif }
     %{ endif }
     %{ if product_version == "head-staging" }
-      %{ if container_server }
+      %{ if container_server || server_kubernetes }
         zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs" }/SUSE:/SLFO:/Products:/Multi-Linux-Manager:/5.2:/ToTest/product/repo/Multi-Linux-Manager-Server-5.2-x86_64/ container_utils_repo
       %{ endif }
       %{ if container_proxy }
@@ -206,7 +206,7 @@ PACKAGES="$PACKAGES helm"
 PACKAGES="$PACKAGES bash-completion ca-certificates-suse"
 %{ endif }
 
-%{ if container_server }
+%{ if container_server || server_kubernetes}
 PACKAGES="$PACKAGES mgradm mgrctl uyuni-storage-setup-server mgradm-bash-completion mgrctl-bash-completion"
 %{ endif }
 

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -29,7 +29,7 @@ runcmd:
 %{ if testsuite ~}
   - zypper --non-interactive install wget timezone expect bind-utils
 %{ endif ~}
-%{ if container_server ~}
+%{ if container_server || server_kubernetes ~}
   - zypper --non-interactive install mgrctl mgradm uyuni-storage-setup-server netavark aardvark-dns
 %{ endif ~}
 %{ if container_proxy ~}


### PR DESCRIPTION
## What does this PR change?

Install mgrctl on slmicro 6.2 and TW to execute commands in the uyuni pod on an RKE2 cluster..
