### PR TITLE
Install kubectl and helm on the controller

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -80,6 +80,8 @@ module "controller" {
     catch_timeout_message     = var.catch_timeout_message
     beta_enabled              = var.beta_enabled
     web_server_hostname       = var.web_server_hostname
+    install_kubectl_helm      = var.install_kubectl_helm
+    kubeconfig_content        = var.kubeconfig_path != null ? base64encode(file(var.kubeconfig_path)) : ""
 
     sle12sp5_paygo_minion    = length(var.sle12sp5_paygo_minion_configuration["hostnames"]) > 0 ? var.sle12sp5_paygo_minion_configuration["hostnames"][0] : null
     sle15sp5_paygo_minion    = length(var.sle15sp5_paygo_minion_configuration["hostnames"]) > 0 ? var.sle15sp5_paygo_minion_configuration["hostnames"][0] : null

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -885,3 +885,13 @@ variable "web_server_hostname" {
   description = "FQDN of the web server or leave the default for no web server"
   default = null
 }
+
+variable "install_kubectl_helm" {
+  description = "true to install kubectl and helm on the controller"
+  default = false
+}
+
+variable "kubeconfig_path" {
+  description = "Path to a kubeconfig file on the host running Terraform; its contents will be copied to /root/.kube/config on the controller. Leave null to skip."
+  default = null
+}

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -629,6 +629,8 @@ module "controller" {
   swap_file_size           = null
   beta_enabled             = var.beta_enabled
   web_server_hostname      = var.web_server_hostname
+  install_kubectl_helm     = var.install_kubectl_helm
+  kubeconfig_path          = var.kubeconfig_path
 
   additional_repos  = lookup(local.additional_repos, "controller", {})
   additional_repos_only  = lookup(local.additional_repos_only, "controller", false)

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -223,6 +223,16 @@ variable "install_local_path_provisioner" {
   default = true
 }
 
+variable "install_kubectl_helm" {
+  description = "true to install kubectl and helm on the controller"
+  default = false
+}
+
+variable "kubeconfig_path" {
+  description = "Path to a kubeconfig file on the host running Terraform; its contents will be copied to /root/.kube/config on the controller. Leave null to skip."
+  default = null
+}
+
 variable "beta_enabled" {
   description = "Enable the mechanism to take into account beta channels"
   default     = false

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -261,3 +261,33 @@ augment_mmaps:
     - source: salt://controller/sysctl.conf
   cmd.run:
     - name: sysctl -p
+
+{% if grains.get('install_kubectl_helm') == true %}
+
+install_kubectl:
+  pkg.installed:
+    - name: kubernetes-client
+
+install_helm_on_controller:
+  cmd.run:
+    - name: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash
+    - unless: command -v helm
+
+{% endif %}
+
+{% if grains.get('kubeconfig_content') %}
+
+kube_directory:
+  file.directory:
+    - name: /root/.kube
+    - user: root
+    - group: root
+    - mode: 700
+
+write_kubeconfig:
+  cmd.run:
+    - name: 'printf "%s" "{{ grains.get("kubeconfig_content") }}" | base64 -d > /root/.kube/config && chmod 600 /root/.kube/config'
+    - require:
+      - file: kube_directory
+
+{% endif %}


### PR DESCRIPTION
## What does this PR change?

Adds two new variables on the `cucumber_testsuite` module:

- `install_kubectl_helm` (bool, default `false`) — when true, installs `kubectl` (`kubernetes-client` package) and `helm` (via the official `get-helm-4` script) on the controller VM.
- `kubeconfig_path` (string, default `null`) — path to a kubeconfig file on the machine running Terraform; its contents are base64-encoded into a grain and written to `/root/.kube/config` on the controller with `0600` permissions.

This is the first step toward driving cluster operations (helm install, kubectl exec, etc.) from the controller rather than from the `server_kubernetes` VM, which is a prerequisite for supporting an existing (user-provided) Kubernetes cluster — per discussion with @cbosdo and @Pablogoliva.

Default behavior is unchanged: both variables default to false/null, so existing deployments are unaffected.

## Usage

```hcl
module "cucumber_testsuite" {
  source = "./modules/cucumber_testsuite"
  # ...
  install_kubectl_helm = true
  kubeconfig_path      = "/home/user/.kube/config"
}
```

## Test plan

- [ ] `terraform apply` with `install_kubectl_helm = true` and `kubeconfig_path` pointing at a valid kubeconfig: verify `kubectl` and `helm` are installed on the controller and `/root/.kube/config` exists with `0600` perms.
- [ ] `kubectl get nodes` from the controller succeeds against the configured cluster.
- [ ] `terraform apply` without the new variables: verify the controller behaves exactly as before (no `kubectl`, no `/root/.kube/` directory).