### PR TITLE
Force update slemicro container server and proxy with up command

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -469,6 +469,9 @@ runcmd:
   # Packages needed for the testsuite
   - [ transactional-update, --continue, --non-interactive, pkg, install, wget, timezone, expect, ca-certificates ]
 %{ endif ~}
+%{ if container_server || container_proxy ~}
+  - [ transactional-update, --continue, --non-interactive, up ]
+%{ endif ~}
 %{ if container_server || server_kubernetes ~}
   - [ transactional-update, --continue, --non-interactive, pkg, install, mgrctl, mgradm, uyuni-storage-setup-server, netavark, aardvark-dns, ca-certificates-suse, podman ]
 %{ endif ~}


### PR DESCRIPTION
## What does this PR change?

I had scenarios for sleMU 5.0 on slemicro where the tested package was not updated. Force the slemicro 5.5 update when used as server or proxy.
