### PR TITLE
Add use_os_released_updates variable to cucumber_testsuite module

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -124,7 +124,7 @@ module "server" {
   disable_auto_bootstrap         = false
   forward_registration           = false
   monitored                      = true
-  use_os_released_updates        = false
+  use_os_released_updates        = var.use_os_released_updates
   beta_enabled                   = var.beta_enabled
   install_salt_bundle            = lookup(local.install_salt_bundle, "server", true)
   ssh_key_path                   = "./salt/controller/id_ed25519.pub"
@@ -172,7 +172,7 @@ module "server_containerized" {
   publish_private_ssl_key        = false
   disable_download_tokens        = false
   //forward_registration           = false
-  use_os_released_updates        = false
+  use_os_released_updates        = var.use_os_released_updates
   beta_enabled                   = var.beta_enabled
   install_salt_bundle            = lookup(local.install_salt_bundle, "server_containerized", true)
   ssh_key_path                   = "./salt/controller/id_ed25519.pub"
@@ -261,7 +261,7 @@ module "proxy" {
   auto_configure            = false
   generate_bootstrap_script = false
   publish_private_ssl_key   = false
-  use_os_released_updates   = false
+  use_os_released_updates   = var.use_os_released_updates
   ssh_key_path              = "./salt/controller/id_ed25519.pub"
   install_salt_bundle = lookup(local.install_salt_bundle, "proxy", true)
 
@@ -301,7 +301,7 @@ module "proxy_containerized" {
 
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "proxy_containerized", true)
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   additional_repos        = lookup(local.additional_repos, "proxy_containerized", {})
   additional_repos_only   = lookup(local.additional_repos_only, "proxy_containerized", false)
   additional_packages     = lookup(local.additional_packages, "proxy_containerized", [])
@@ -339,7 +339,7 @@ module "proxy_kubernetes" {
 
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "proxy_kubernetes", true)
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   additional_repos        = lookup(local.additional_repos, "proxy_kubernetes", {})
   additional_repos_only   = lookup(local.additional_repos_only, "proxy_kubernetes", false)
   additional_packages     = lookup(local.additional_packages, "proxy_kubernetes", [])
@@ -385,7 +385,7 @@ module "suse_client" {
   sles_registration_code = lookup(local.sles_registration_code, "suse_client", null)
 
   auto_register           = false
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "suse_client", true)
 
@@ -407,7 +407,7 @@ module "suse_minion" {
   sles_registration_code = lookup(local.sles_registration_code, "suse_minion", null)
 
   auto_connect_to_master  = false
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "suse_minion", true)
 
@@ -428,7 +428,7 @@ module "suse_sshminion" {
   name               = lookup(local.names, "suse_sshminion", "suse-sshminion")
   sles_registration_code = lookup(local.sles_registration_code, "suse_sshminion", null)
 
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   gpg_keys                = ["default/gpg_keys/galaxy.key"]
   install_salt_bundle     = lookup(local.install_salt_bundle, "suse_sshminion", true)
@@ -450,7 +450,7 @@ module "slemicro_minion" {
   server_configuration = local.minimal_configuration
   sles_registration_code = lookup(local.sles_registration_code, "slemicro_minion", null)
 
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "slemicro_minion", true)
 
@@ -473,7 +473,7 @@ module "rhlike_minion" {
   server_configuration   = local.minimal_configuration
 
   auto_connect_to_master  = false
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "rhlike_minion", true)
 
@@ -496,7 +496,7 @@ module "deblike_minion" {
   server_configuration   = local.minimal_configuration
 
   auto_connect_to_master  = false
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "deblike_minion", true)
 
@@ -518,7 +518,7 @@ module "build_host" {
   server_configuration = local.minimal_configuration
 
   auto_connect_to_master  = false
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   avahi_reflector         = var.avahi_reflector
   install_salt_bundle     = lookup(local.install_salt_bundle, "build_host", true)
@@ -556,7 +556,7 @@ module "kvm_host" {
   sles_registration_code = lookup(local.sles_registration_code, "kvm_host", null)
 
   auto_connect_to_master  = false
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "kvm_host", true)
 
@@ -580,7 +580,7 @@ module "monitoring_server" {
   sles_registration_code = lookup(local.sles_registration_code, "monitoring_server", null)
 
   auto_connect_to_master  = false
-  use_os_released_updates = false
+  use_os_released_updates = var.use_os_released_updates
   ssh_key_path            = "./salt/controller/id_ed25519.pub"
   install_salt_bundle     = lookup(local.install_salt_bundle, "monitoring_server", true)
 

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -272,3 +272,8 @@ variable "web_server_hostname" {
   description = "FQDN of the web server or leave the default for no web server"
   default = null
 }
+
+variable "use_os_released_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise repos"
+  default     = false
+}


### PR DESCRIPTION
## What does this PR change?

Add use_os_released_updates variable to cucumber_testsuite module with
default value of false. Replace all 14 hardcoded 'false' values in main.tf
with var.use_os_released_updates to make this setting configurable.

This fixes the inconsistency where the setting could not be configured
when using the cucumber_testsuite module, even though individual modules
support it. Default behavior remains unchanged (updates disabled).

Fixes https://github.com/SUSE/spacewalk/issues/23974


