### PR TITLE
Add nfs_server module

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -331,7 +331,7 @@ resource "terraform_data" "provisioning" {
         connect_to_additional_network = var.connect_to_additional_network
         reset_ids                     = true
         ipv6                          = var.ipv6
-        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "server_containerized") || contains(var.roles, "server_kubernetes") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdb" : null
+        data_disk_device              = contains(var.roles, "server") || contains(var.roles, "server_containerized") || contains(var.roles, "server_kubernetes") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") || contains(var.roles, "nfs_server") ? "vdb" : null
         second_data_disk_device       = contains(var.roles, "server") || contains(var.roles, "server_containerized") || contains(var.roles, "server_kubernetes") || contains(var.roles, "proxy") || contains(var.roles, "mirror") || contains(var.roles, "jenkins") ? "vdc" : null
         provider                      = "libvirt"
       },

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -43,6 +43,7 @@ locals {
     contains(var.roles, "proxy_kubernetes") && lookup(var.base_configuration, "testsuite", false) ? { memory = 2048, vcpu = 2 } : {},
     contains(var.roles, "pxe_boot")? { memory = 2048} : {},
     contains(var.roles, "mirror") ? { memory = 1024 } : {},
+    contains(var.roles, "nfs_server") ? { memory = 2048, vcpu = 1 } : {},
     contains(var.roles, "build_host") ? { vcpu = 2 } : {},
     contains(var.roles, "controller") ? { memory = 2048 } : {},
     contains(var.roles, "grafana") ? { memory = 4096 } : {},

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -95,6 +95,14 @@ locals {
     host_key => lookup(var.host_settings[host_key], "scc_access_logging", false) if var.host_settings[host_key] != null }
   enable_oval_metadata     = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "enable_oval_metadata", false) if var.host_settings[host_key] != null }
+  nfs_export_path          = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "export_path", "/srv/nfs") if var.host_settings[host_key] != null }
+  nfs_allowed_cidr         = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "allowed_cidr", "0.0.0.0/0") if var.host_settings[host_key] != null }
+  nfs_export_options       = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "export_options", "rw,sync,no_subtree_check,no_root_squash") if var.host_settings[host_key] != null }
+  nfs_data_disk_size       = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "data_disk_size", 0) if var.host_settings[host_key] != null }
 
   minimal_configuration     = { hostname = contains(local.hosts, "proxy") ? local.proxy_full_name : local.server_full_name }
   server_configuration      = var.kubernetes ? module.server_kubernetes[0].configuration : ( var.container_server ? module.server_containerized[0].configuration : module.server[0].configuration)
@@ -634,6 +642,25 @@ module "controller" {
   provider_settings = lookup(local.provider_settings_by_host, "controller", {})
 }
 
+module "nfs_server" {
+  source = "../nfs_server"
+  count  = contains(local.hosts, "nfs_server") ? 1 : 0
+
+  base_configuration = module.base.configuration
+  name               = lookup(local.names, "nfs_server", "nfs")
+  image              = lookup(local.images, "nfs_server", "opensuse156o")
+
+  export_path    = lookup(local.nfs_export_path,    "nfs_server", "/srv/nfs")
+  allowed_cidr   = lookup(local.nfs_allowed_cidr,   "nfs_server", "0.0.0.0/0")
+  export_options = lookup(local.nfs_export_options, "nfs_server", "rw,sync,no_subtree_check,no_root_squash")
+  data_disk_size = lookup(local.nfs_data_disk_size, "nfs_server", 0)
+
+  additional_repos      = lookup(local.additional_repos, "nfs_server", {})
+  additional_repos_only = lookup(local.additional_repos_only, "nfs_server", false)
+  additional_packages   = lookup(local.additional_packages, "nfs_server", [])
+  provider_settings     = lookup(local.provider_settings_by_host, "nfs_server", {})
+}
+
 #### Example module
 ##
 ## module "example_module" {
@@ -668,5 +695,6 @@ output "configuration" {
     kvm_host = module.kvm_host.configuration
     monitoring_server = module.monitoring_server.configuration
     controller = module.controller.configuration
+    nfs_server = length(module.nfs_server) > 0 ? module.nfs_server[0].configuration : null
   }
 }

--- a/modules/nfs_server/main.tf
+++ b/modules/nfs_server/main.tf
@@ -1,0 +1,29 @@
+module "nfs_server" {
+  source = "../host"
+
+  base_configuration       = var.base_configuration
+  name                     = var.name
+  use_os_released_updates  = var.use_os_released_updates
+  install_salt_bundle      = var.install_salt_bundle
+  additional_repos         = var.additional_repos
+  additional_repos_only    = var.additional_repos_only
+  additional_packages      = var.additional_packages
+  swap_file_size           = var.swap_file_size
+  ssh_key_path             = var.ssh_key_path
+  roles                    = ["nfs_server"]
+  image                    = var.image
+  provider_settings        = var.provider_settings
+  volume_provider_settings = var.volume_provider_settings
+  additional_disk_size     = var.data_disk_size
+
+  grains = {
+    export_path    = var.export_path
+    allowed_cidr   = var.allowed_cidr
+    export_options = var.export_options
+    data_disk_size = var.data_disk_size
+  }
+}
+
+output "configuration" {
+  value = module.nfs_server.configuration
+}

--- a/modules/nfs_server/variables.tf
+++ b/modules/nfs_server/variables.tf
@@ -1,0 +1,83 @@
+variable "base_configuration" {
+  description = "use module.base.configuration, see the main.tf example file"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "nfs"
+}
+
+variable "image" {
+  description = "image to use for the NFS server VM"
+  type        = string
+  default     = "opensuse156o"
+}
+
+variable "use_os_released_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise repos"
+  default     = true
+}
+
+variable "install_salt_bundle" {
+  description = "use true to install the venv-salt-minion package in the hosts"
+  default     = true
+}
+
+variable "additional_repos" {
+  description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
+  default     = {}
+}
+
+variable "additional_repos_only" {
+  description = "whether to exclusively use additional repos"
+  default     = false
+}
+
+variable "additional_packages" {
+  description = "extra packages to install, see README_ADVANCED.md"
+  default     = []
+}
+
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default     = 0
+}
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default     = null
+}
+
+variable "provider_settings" {
+  description = "Settings specific to the provider, see README_ADVANCED.md"
+  default     = {}
+}
+
+variable "volume_provider_settings" {
+  description = "Settings for the data volume, see README_ADVANCED.md"
+  default     = {}
+}
+
+variable "data_disk_size" {
+  description = "Size of an additional disk used for the NFS export, defined in GiB. Use 0 for no extra disk."
+  default     = 0
+}
+
+variable "export_path" {
+  description = "Path on the NFS server VM that will be exported"
+  type        = string
+  default     = "/srv/nfs"
+}
+
+variable "allowed_cidr" {
+  description = "CIDR range allowed to mount the export"
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "export_options" {
+  description = "NFS export options applied to the share"
+  type        = string
+  default     = "rw,sync,no_subtree_check,no_root_squash"
+}

--- a/modules/nfs_server/versions.tf
+++ b/modules/nfs_server/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.8.3"
+    }
+  }
+}

--- a/modules/nfs_server/versions.tf
+++ b/modules/nfs_server/versions.tf
@@ -1,9 +1,1 @@
-terraform {
-  required_version = ">= 1.6.0"
-  required_providers {
-    libvirt = {
-      source = "dmacvicar/libvirt"
-      version = "0.8.3"
-    }
-  }
-}
+../backend/host/versions.tf

--- a/salt/nfs_server/init.sls
+++ b/salt/nfs_server/init.sls
@@ -1,0 +1,67 @@
+{% set export_path    = grains.get('export_path')    | default('/srv/nfs', true) %}
+{% set allowed_cidr   = grains.get('allowed_cidr')   | default('0.0.0.0/0', true) %}
+{% set export_options = grains.get('export_options') | default('rw,sync,no_subtree_check,no_root_squash', true) %}
+{% set data_disk_size = grains.get('data_disk_size') | int %}
+
+include:
+  - repos
+
+install_nfs_server:
+  pkg.installed:
+    - name: nfs-kernel-server
+    - require:
+      - sls: repos
+
+{% if data_disk_size > 0 %}
+
+format_nfs_data_disk:
+  blockdev.formatted:
+    - name: /dev/vdb
+    - fs_type: xfs
+
+mount_nfs_data_disk:
+  mount.mounted:
+    - name: {{ export_path }}
+    - device: /dev/vdb
+    - fstype: xfs
+    - mkmnt: True
+    - persist: True
+    - require:
+      - blockdev: format_nfs_data_disk
+
+{% else %}
+
+export_directory:
+  file.directory:
+    - name: {{ export_path }}
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+
+{% endif %}
+
+configure_exports:
+  file.managed:
+    - name: /etc/exports
+    - contents: |
+        {{ export_path }} {{ allowed_cidr }}({{ export_options }})
+    - user: root
+    - group: root
+    - mode: 644
+
+apply_exports:
+  cmd.run:
+    - name: exportfs -ra
+    - onchanges:
+      - file: configure_exports
+
+nfs_server_service:
+  service.running:
+    - name: nfs-server
+    - enable: True
+    - require:
+      - pkg: install_nfs_server
+      - file: configure_exports
+    - watch:
+      - file: configure_exports

--- a/salt/nfs_server/init.sls
+++ b/salt/nfs_server/init.sls
@@ -1,7 +1,9 @@
-{% set export_path    = grains.get('export_path')    | default('/srv/nfs', true) %}
-{% set allowed_cidr   = grains.get('allowed_cidr')   | default('0.0.0.0/0', true) %}
-{% set export_options = grains.get('export_options') | default('rw,sync,no_subtree_check,no_root_squash', true) %}
-{% set data_disk_size = grains.get('data_disk_size') | int %}
+{% set export_path      = grains.get('export_path')      | default('/srv/nfs', true) %}
+{% set allowed_cidr     = grains.get('allowed_cidr')     | default('0.0.0.0/0', true) %}
+{% set export_options   = grains.get('export_options')   | default('rw,sync,no_subtree_check,no_root_squash', true) %}
+{% set data_disk_size   = grains.get('data_disk_size')   | int %}
+{% set data_disk_device = grains.get('data_disk_device') | default('vdb', true) %}
+{% set data_disk        = data_disk_device if data_disk_device.startswith('/dev/') else '/dev/' ~ data_disk_device %}
 
 include:
   - repos
@@ -16,13 +18,13 @@ install_nfs_server:
 
 format_nfs_data_disk:
   blockdev.formatted:
-    - name: /dev/vdb
+    - name: {{ data_disk }}
     - fs_type: xfs
 
 mount_nfs_data_disk:
   mount.mounted:
     - name: {{ export_path }}
-    - device: /dev/vdb
+    - device: {{ data_disk }}
     - fstype: xfs
     - mkmnt: True
     - persist: True
@@ -49,10 +51,18 @@ configure_exports:
     - user: root
     - group: root
     - mode: 644
+    - require:
+{% if data_disk_size > 0 %}
+      - mount: mount_nfs_data_disk
+{% else %}
+      - file: export_directory
+{% endif %}
 
 apply_exports:
   cmd.run:
     - name: exportfs -ra
+    - require:
+      - pkg: install_nfs_server
     - onchanges:
       - file: configure_exports
 

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -38,6 +38,10 @@ base:
     - match: grain
     - mirror
 
+  'roles:nfs_server':
+    - match: grain
+    - nfs_server
+
   'roles:controller':
     - match: grain
     - controller


### PR DESCRIPTION
## What does this PR change?

Adds a new `nfs_server` role to sumaform. The module provisions a VM that runs `nfs-kernel-server` and exports a single configurable share. It follows the pattern of the `example_module` template introduced in #2166.

Primary motivation: provide a lightweight, backend-agnostic source of persistent storage for the Uyuni-on-Kubernetes flow when no managed cloud storage (EBS/PD/Azure Disk) is available — e.g. on-prem clusters or sumaform test environments. The exported share can be plugged into a Kubernetes cluster via the [NFS CSI driver](https://github.com/kubernetes-csi/csi-driver-nfs) to back a `StorageClass`.

### Usage

```hcl
host_settings = {
  nfs_server = {
    name           = \"nfs\"
    export_path    = \"/srv/nfs\"                                # default
    allowed_cidr   = \"0.0.0.0/0\"                               # default
    export_options = \"rw,sync,no_subtree_check,no_root_squash\" # default
    data_disk_size = 0                                          # >0 attaches a dedicated XFS disk mounted at export_path
  }
  # ... other roles
}
```

All keys except `name` are optional — defaults aim for a working test setup out of the box.

### Files added/modified

- `modules/nfs_server/{main.tf,variables.tf,versions.tf}` — new role module
- `salt/nfs_server/init.sls` — installs `nfs-kernel-server`, configures `/etc/exports`, starts the service, optionally formats and mounts a dedicated data disk
- `modules/cucumber_testsuite/main.tf` — wires the module into the umbrella, gated on `host_settings` containing `nfs_server`
- `backend_modules/libvirt/host/main.tf` — default sizing for the role (2 GB / 1 vCPU)

Default behavior of the codebase is unchanged: without `nfs_server` in `host_settings`, no VM is created.

## Test plan

- [x] \`terraform apply\` with \`nfs_server = { name = \"nfs\" }\` in \`host_settings\`: verify the VM is created, \`nfs-kernel-server\` is installed, and \`/etc/exports\` contains the expected line.
- [x] From a client VM in the same network, \`mount nfs.<domain>:/srv/nfs /mnt/test\` succeeds; reading and writing files works.
- [x] \`terraform apply\` with \`data_disk_size = 5\`: verify \`/dev/vdb\` is formatted XFS and mounted at the export path, and the share works.
- [x] \`terraform apply\` with a custom \`export_path\`, \`allowed_cidr\`, and \`export_options\`: verify they all propagate into \`/etc/exports\`.
- [x] Default sumaform deployment (no \`nfs_server\` entry): verify nothing changed, no extra VM.

## Notes / follow-ups

- The Salt state assumes the data disk is at \`/dev/vdb\` (libvirt convention). If users want this on AWS/Azure, the device name would need to be backend-aware — out of scope here.
- Firewall: openSUSE images may have firewalld blocking port 2049. If that surfaces in testing, a small follow-up can add a firewalld rule for the \`nfs\` service.
- Only one export per VM is supported. Multi-export support could be a follow-up if there's demand.