### PR TITLE
Add MLM client tools urls instead of uyuni only

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -55,7 +55,15 @@ bootcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL7/images/repo/ManagerTools-Beta-EL7-POOL-x86_64-Media/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL7/images/repo/ManagerTools-EL7-POOL-x86_64-Media/
+%{ endif ~}
+%{ endif ~}
     failovermethod: priority
     enabled: true
     gpgcheck: false
@@ -87,7 +95,15 @@ bootcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL8/images/repo/MultiLinuxManagerTools-Beta-EL-8-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL8/images/repo/MultiLinuxManagerTools-EL-8-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -129,7 +145,15 @@ bootcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL9/images/repo/MultiLinuxManagerTools-Beta-EL-9-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL9/images/repo/MultiLinuxManagerTools-EL-9-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -167,11 +191,28 @@ runcmd:
 zypper:
   repos:
     - id: tools_pool_repo
+# On MLM, we use the SLE client tools channels for Leap.
 %{ if image == "opensuse156o" ~}
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE15/images/repo/ManagerTools-Beta-SLE15-Pool-x86_64-Media1/
+%{ else ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLE15/images/repo/ManagerTools-SLE15-Pool-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
 %{ endif ~}
 %{ if image == "opensuse160o" ~}
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_16-Uyuni-Client-Tools/openSUSE_Leap_16.0/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE16/product/repo/Multi-Linux-ManagerTools-Beta-SLE-16-x86_64/
+%{ else ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLE16/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/
+%{ endif ~}
+%{ endif ~}
 %{ endif ~}
       enabled: true
       gpgcheck: false
@@ -209,7 +250,15 @@ zypper:
       enabled: 1
       autorefresh: 1
     - id: tools_pool_repo
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE12/images/repo/ManagerTools-Beta-SLE12-Pool-x86_64-Media1/
+%{ else ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLE12/images/repo/ManagerTools-SLE12-Pool-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
       enabled: true
       gpgcheck: false
       name: tools_pool_repo
@@ -232,7 +281,15 @@ zypper:
       enabled: 1
       autorefresh: 1
     - id: tools_pool_repo
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE15/images/repo/ManagerTools-Beta-SLE15-Pool-x86_64-Media1/
+%{ else ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLE15/images/repo/ManagerTools-SLE15-Pool-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
       enabled: true
       gpgcheck: false
       name: tools_pool_repo
@@ -268,7 +325,15 @@ zypper:
       enabled: 1
       autorefresh: 1
     - id: tools_pool_repo
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE15/images/repo/ManagerTools-Beta-SLE15-Pool-x86_64-Media1/
+%{ else ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLE15/images/repo/ManagerTools-SLE15-Pool-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
       enabled: true
       gpgcheck: false
       name: tools_pool_repo
@@ -291,7 +356,15 @@ zypper:
       enabled: 1
       autorefresh: 1
     - id: tools_pool_repo
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE15/images/repo/ManagerTools-Beta-SLE15-Pool-x86_64-Media1/
+%{ else ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLE15/images/repo/ManagerTools-SLE15-Pool-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
       enabled: true
       gpgcheck: false
       name: tools_pool_repo
@@ -314,7 +387,15 @@ zypper:
       enabled: 1
       autorefresh: 1
     - id: tools_pool_repo
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/SLE15-Uyuni-Client-Tools/SLE_15/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE15/images/repo/ManagerTools-Beta-SLE15-Pool-x86_64-Media1/
+%{ else ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLE15/images/repo/ManagerTools-SLE15-Pool-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
       enabled: true
       gpgcheck: false
       name: tools_pool_repo
@@ -338,7 +419,15 @@ zypper:
       enabled: 1
       autorefresh: 1
     - id: tools_pool_repo
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/SLE16-Uyuni-Client-Tools/SLE_16/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE16/product/repo/Multi-Linux-ManagerTools-Beta-SLE-16-x86_64/
+%{ else ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLE16/product/repo/Multi-Linux-ManagerTools-SLE-16-x86_64/
+%{ endif ~}
+%{ endif ~}
       enabled: true
       gpgcheck: false
       name: tools_pool_repo
@@ -481,8 +570,17 @@ runcmd:
 apt:
   sources:
     tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       source: deb http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2204-Uyuni-Client-Tools/xUbuntu_22.04/ /
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      source: deb http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-Ubuntu22.04/xUbuntu_22.04-debbuild/ /
+%{ else ~}
+      source: deb http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-Ubuntu22.04/xUbuntu_22.04/ /
+%{ endif ~}
+%{ endif ~}
       key: |
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
         -----BEGIN PGP PUBLIC KEY BLOCK-----
         Version: GnuPG v1.4.5 (GNU/Linux)
 
@@ -504,6 +602,28 @@ apt:
         3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
         =eJaK
         -----END PGP PUBLIC KEY BLOCK-----
+%{ else ~}
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v2.4.4 (GNU/Linux)
+
+        mQENBGLwyaYBCADNYZW2qfvrxVYK3A9ArHdCP2GuHo0tdZzvaVor3hEGZ1A6lwLR
+        S+r+l+o1pDywjZDSSSpdrLD3DT7T//OBZT9e0s9cluqy18FoGuXymvlL7MoeENo6
+        Q1nD379T0UBAnfF3TEIoTuFCWzQX2z668AK/bBQNLzAU2KylusGQlLjpraOlz+eO
+        LHXCc2EXZMiknbHuhku48j6YrvDCARdeQUFl+bHMEtZi2FXTEpFacy/oUbXIr8YG
+        /i6pBa9oDQr9R7lgU8rZtb4YfeX9jr3+1SehNogxwmh/QDpC13lqGqJ7rBNhW6p4
+        vT7rPlUgASV4ab+O4LDqexg4U96YV8DvgZIJABEBAAG0NURldmVsOkdhbGF4eSBP
+        QlMgUHJvamVjdCA8RGV2ZWw6R2FsYXh5QGJ1aWxkLnN1c2UuZGU+iQE+BBMBCAAo
+        BQJp61ypAhsDBQkLGUMDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRDkXcGY
+        beVjdoGFCADB3EggMqM+cT+6v+/OGk4KJist80ULpZwQo43BC+j8TSFhfjr+zfqz
+        Xk0VptsNEsvpACVnw4f/HaZmiC+w2pGB5v2rtryvneg340JnnnMCttir3l89mg3b
+        sifdysthq5zHEajG8q8Fw5+Kdg1eH76E+pNFOR8oLBU5kIBFoBRiIBs8JlM2xMNb
+        fanoOE191SCWlYpQO4xLFRp4/aJi+hpfuYeLblL4sD5Rucbqfx7QjL1FKhqaGdf9
+        Z+bbMLER9CFq95gtCsyWj4xLTwfT8rmQ8iH+gu09mF2nQa44IpyfPwJzmO1VUVPp
+        GvB2sVkh9wnF/19zrbDF+NxVrCkPyuJUiEYEExECAAYFAmLwyaYACgkQqE7a6JyA
+        Cso07QCePkklGUUjNG4p7x+TVPIANEs60dUAn20/EMPdf0BQNGW1/qdCb5MT2AIQ
+        =9dds
+        -----END PGP PUBLIC KEY BLOCK-----
+%{ endif ~}
 
 runcmd:
   # WORKAROUND: cloud-init in Ubuntu 22.04 does not take care of the following
@@ -526,8 +646,17 @@ runcmd:
 apt:
   sources:
     tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       source: deb http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2404-Uyuni-Client-Tools/xUbuntu_24.04/ /
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      source: deb http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-Ubuntu24.04/xUbuntu_24.04-debbuild/ /
+%{ else ~}
+      source: deb http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-Ubuntu24.04/xUbuntu_24.04/ /
+%{ endif ~}
+%{ endif ~}
       key: |
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
         -----BEGIN PGP PUBLIC KEY BLOCK-----
         Version: GnuPG v1.4.5 (GNU/Linux)
 
@@ -549,6 +678,28 @@ apt:
         3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
         =eJaK
         -----END PGP PUBLIC KEY BLOCK-----
+%{ else ~}
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v2.4.4 (GNU/Linux)
+
+        mQENBGLwyaYBCADNYZW2qfvrxVYK3A9ArHdCP2GuHo0tdZzvaVor3hEGZ1A6lwLR
+        S+r+l+o1pDywjZDSSSpdrLD3DT7T//OBZT9e0s9cluqy18FoGuXymvlL7MoeENo6
+        Q1nD379T0UBAnfF3TEIoTuFCWzQX2z668AK/bBQNLzAU2KylusGQlLjpraOlz+eO
+        LHXCc2EXZMiknbHuhku48j6YrvDCARdeQUFl+bHMEtZi2FXTEpFacy/oUbXIr8YG
+        /i6pBa9oDQr9R7lgU8rZtb4YfeX9jr3+1SehNogxwmh/QDpC13lqGqJ7rBNhW6p4
+        vT7rPlUgASV4ab+O4LDqexg4U96YV8DvgZIJABEBAAG0NURldmVsOkdhbGF4eSBP
+        QlMgUHJvamVjdCA8RGV2ZWw6R2FsYXh5QGJ1aWxkLnN1c2UuZGU+iQE+BBMBCAAo
+        BQJp61ypAhsDBQkLGUMDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRDkXcGY
+        beVjdoGFCADB3EggMqM+cT+6v+/OGk4KJist80ULpZwQo43BC+j8TSFhfjr+zfqz
+        Xk0VptsNEsvpACVnw4f/HaZmiC+w2pGB5v2rtryvneg340JnnnMCttir3l89mg3b
+        sifdysthq5zHEajG8q8Fw5+Kdg1eH76E+pNFOR8oLBU5kIBFoBRiIBs8JlM2xMNb
+        fanoOE191SCWlYpQO4xLFRp4/aJi+hpfuYeLblL4sD5Rucbqfx7QjL1FKhqaGdf9
+        Z+bbMLER9CFq95gtCsyWj4xLTwfT8rmQ8iH+gu09mF2nQa44IpyfPwJzmO1VUVPp
+        GvB2sVkh9wnF/19zrbDF+NxVrCkPyuJUiEYEExECAAYFAmLwyaYACgkQqE7a6JyA
+        Cso07QCePkklGUUjNG4p7x+TVPIANEs60dUAn20/EMPdf0BQNGW1/qdCb5MT2AIQ
+        =9dds
+        -----END PGP PUBLIC KEY BLOCK-----
+%{ endif ~}
 
 runcmd:
   # WORKAROUND: wrong interface name in noble's netplan configuration
@@ -575,8 +726,37 @@ runcmd:
 apt:
   sources:
     tools_pool_repo:
+%{ if contains(["head", "head-staging"], product_version) ~}
+      source: deb http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-Ubuntu26.04/xUbuntu_26.04-debbuild/ /
+%{ else ~}
+      # WORKAROUND: the non-head product versions should select
+      # Devel:/Galaxy:/Manager:/Stable:/MLMTools-Ubuntu26.04/xUbuntu_26.04/ like the other Ubuntu
+      # blocks do, but that project does not exist yet, so they stay on Uyuni
       source: deb http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/Ubuntu2604-Uyuni-Client-Tools/xUbuntu_26.04/ /
+%{ endif ~}
       key: |
+%{ if contains(["head", "head-staging"], product_version) ~}
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v2.4.4 (GNU/Linux)
+
+        mQENBGLwyaYBCADNYZW2qfvrxVYK3A9ArHdCP2GuHo0tdZzvaVor3hEGZ1A6lwLR
+        S+r+l+o1pDywjZDSSSpdrLD3DT7T//OBZT9e0s9cluqy18FoGuXymvlL7MoeENo6
+        Q1nD379T0UBAnfF3TEIoTuFCWzQX2z668AK/bBQNLzAU2KylusGQlLjpraOlz+eO
+        LHXCc2EXZMiknbHuhku48j6YrvDCARdeQUFl+bHMEtZi2FXTEpFacy/oUbXIr8YG
+        /i6pBa9oDQr9R7lgU8rZtb4YfeX9jr3+1SehNogxwmh/QDpC13lqGqJ7rBNhW6p4
+        vT7rPlUgASV4ab+O4LDqexg4U96YV8DvgZIJABEBAAG0NURldmVsOkdhbGF4eSBP
+        QlMgUHJvamVjdCA8RGV2ZWw6R2FsYXh5QGJ1aWxkLnN1c2UuZGU+iQE+BBMBCAAo
+        BQJp61ypAhsDBQkLGUMDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRDkXcGY
+        beVjdoGFCADB3EggMqM+cT+6v+/OGk4KJist80ULpZwQo43BC+j8TSFhfjr+zfqz
+        Xk0VptsNEsvpACVnw4f/HaZmiC+w2pGB5v2rtryvneg340JnnnMCttir3l89mg3b
+        sifdysthq5zHEajG8q8Fw5+Kdg1eH76E+pNFOR8oLBU5kIBFoBRiIBs8JlM2xMNb
+        fanoOE191SCWlYpQO4xLFRp4/aJi+hpfuYeLblL4sD5Rucbqfx7QjL1FKhqaGdf9
+        Z+bbMLER9CFq95gtCsyWj4xLTwfT8rmQ8iH+gu09mF2nQa44IpyfPwJzmO1VUVPp
+        GvB2sVkh9wnF/19zrbDF+NxVrCkPyuJUiEYEExECAAYFAmLwyaYACgkQqE7a6JyA
+        Cso07QCePkklGUUjNG4p7x+TVPIANEs60dUAn20/EMPdf0BQNGW1/qdCb5MT2AIQ
+        =9dds
+        -----END PGP PUBLIC KEY BLOCK-----
+%{ else ~}
         -----BEGIN PGP PUBLIC KEY BLOCK-----
         Version: GnuPG v1.4.5 (GNU/Linux)
 
@@ -598,6 +778,7 @@ apt:
         3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
         =eJaK
         -----END PGP PUBLIC KEY BLOCK-----
+%{ endif ~}
 
 runcmd:
   # WORKAROUND: wrong interface name in noble's netplan configuration
@@ -623,8 +804,17 @@ runcmd:
 apt:
   sources:
     tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       source: deb http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/Debian12-Uyuni-Client-Tools/Debian_12/ /
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      source: deb http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-Debian12/Debian_12/ /
+%{ else ~}
+      source: deb http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-Debian12/Debian_12/ /
+%{ endif ~}
+%{ endif ~}
       key: |
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
         -----BEGIN PGP PUBLIC KEY BLOCK-----
         Version: GnuPG v1.4.5 (GNU/Linux)
 
@@ -646,6 +836,28 @@ apt:
         3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
         =eJaK
         -----END PGP PUBLIC KEY BLOCK-----
+%{ else ~}
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v2.4.4 (GNU/Linux)
+
+        mQENBGLwyaYBCADNYZW2qfvrxVYK3A9ArHdCP2GuHo0tdZzvaVor3hEGZ1A6lwLR
+        S+r+l+o1pDywjZDSSSpdrLD3DT7T//OBZT9e0s9cluqy18FoGuXymvlL7MoeENo6
+        Q1nD379T0UBAnfF3TEIoTuFCWzQX2z668AK/bBQNLzAU2KylusGQlLjpraOlz+eO
+        LHXCc2EXZMiknbHuhku48j6YrvDCARdeQUFl+bHMEtZi2FXTEpFacy/oUbXIr8YG
+        /i6pBa9oDQr9R7lgU8rZtb4YfeX9jr3+1SehNogxwmh/QDpC13lqGqJ7rBNhW6p4
+        vT7rPlUgASV4ab+O4LDqexg4U96YV8DvgZIJABEBAAG0NURldmVsOkdhbGF4eSBP
+        QlMgUHJvamVjdCA8RGV2ZWw6R2FsYXh5QGJ1aWxkLnN1c2UuZGU+iQE+BBMBCAAo
+        BQJp61ypAhsDBQkLGUMDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRDkXcGY
+        beVjdoGFCADB3EggMqM+cT+6v+/OGk4KJist80ULpZwQo43BC+j8TSFhfjr+zfqz
+        Xk0VptsNEsvpACVnw4f/HaZmiC+w2pGB5v2rtryvneg340JnnnMCttir3l89mg3b
+        sifdysthq5zHEajG8q8Fw5+Kdg1eH76E+pNFOR8oLBU5kIBFoBRiIBs8JlM2xMNb
+        fanoOE191SCWlYpQO4xLFRp4/aJi+hpfuYeLblL4sD5Rucbqfx7QjL1FKhqaGdf9
+        Z+bbMLER9CFq95gtCsyWj4xLTwfT8rmQ8iH+gu09mF2nQa44IpyfPwJzmO1VUVPp
+        GvB2sVkh9wnF/19zrbDF+NxVrCkPyuJUiEYEExECAAYFAmLwyaYACgkQqE7a6JyA
+        Cso07QCePkklGUUjNG4p7x+TVPIANEs60dUAn20/EMPdf0BQNGW1/qdCb5MT2AIQ
+        =9dds
+        -----END PGP PUBLIC KEY BLOCK-----
+%{ endif ~}
 
 %{ endif ~}
 
@@ -653,8 +865,17 @@ apt:
 apt:
   sources:
     tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       source: deb http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/Debian13-Uyuni-Client-Tools/Debian_13/ /
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      source: deb http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-Debian13/Debian_13/ /
+%{ else ~}
+      source: deb http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-Debian13/Debian_13/ /
+%{ endif ~}
+%{ endif ~}
       key: |
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
         -----BEGIN PGP PUBLIC KEY BLOCK-----
         Version: GnuPG v1.4.5 (GNU/Linux)
 
@@ -676,6 +897,28 @@ apt:
         3B2boakAnA9A9b8UoEYgmLTRpwXYuhsxOCDE
         =eJaK
         -----END PGP PUBLIC KEY BLOCK-----
+%{ else ~}
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: GnuPG v2.4.4 (GNU/Linux)
+
+        mQENBGLwyaYBCADNYZW2qfvrxVYK3A9ArHdCP2GuHo0tdZzvaVor3hEGZ1A6lwLR
+        S+r+l+o1pDywjZDSSSpdrLD3DT7T//OBZT9e0s9cluqy18FoGuXymvlL7MoeENo6
+        Q1nD379T0UBAnfF3TEIoTuFCWzQX2z668AK/bBQNLzAU2KylusGQlLjpraOlz+eO
+        LHXCc2EXZMiknbHuhku48j6YrvDCARdeQUFl+bHMEtZi2FXTEpFacy/oUbXIr8YG
+        /i6pBa9oDQr9R7lgU8rZtb4YfeX9jr3+1SehNogxwmh/QDpC13lqGqJ7rBNhW6p4
+        vT7rPlUgASV4ab+O4LDqexg4U96YV8DvgZIJABEBAAG0NURldmVsOkdhbGF4eSBP
+        QlMgUHJvamVjdCA8RGV2ZWw6R2FsYXh5QGJ1aWxkLnN1c2UuZGU+iQE+BBMBCAAo
+        BQJp61ypAhsDBQkLGUMDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRDkXcGY
+        beVjdoGFCADB3EggMqM+cT+6v+/OGk4KJist80ULpZwQo43BC+j8TSFhfjr+zfqz
+        Xk0VptsNEsvpACVnw4f/HaZmiC+w2pGB5v2rtryvneg340JnnnMCttir3l89mg3b
+        sifdysthq5zHEajG8q8Fw5+Kdg1eH76E+pNFOR8oLBU5kIBFoBRiIBs8JlM2xMNb
+        fanoOE191SCWlYpQO4xLFRp4/aJi+hpfuYeLblL4sD5Rucbqfx7QjL1FKhqaGdf9
+        Z+bbMLER9CFq95gtCsyWj4xLTwfT8rmQ8iH+gu09mF2nQa44IpyfPwJzmO1VUVPp
+        GvB2sVkh9wnF/19zrbDF+NxVrCkPyuJUiEYEExECAAYFAmLwyaYACgkQqE7a6JyA
+        Cso07QCePkklGUUjNG4p7x+TVPIANEs60dUAn20/EMPdf0BQNGW1/qdCb5MT2AIQ
+        =9dds
+        -----END PGP PUBLIC KEY BLOCK-----
+%{ endif ~}
 
 %{ endif ~}
 
@@ -707,7 +950,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL8/images/repo/MultiLinuxManagerTools-Beta-EL-8-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL8/images/repo/MultiLinuxManagerTools-EL-8-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -732,7 +983,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL9/images/repo/MultiLinuxManagerTools-Beta-EL-9-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL9/images/repo/MultiLinuxManagerTools-EL-9-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -760,7 +1019,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL10-Uyuni-Client-Tools/EL_10/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL10/images/repo/MultiLinuxManagerTools-Beta-EL-10-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL10/images/repo/MultiLinuxManagerTools-EL-10-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -786,7 +1053,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL7/images/repo/ManagerTools-Beta-EL7-POOL-x86_64-Media/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL7/images/repo/ManagerTools-EL7-POOL-x86_64-Media/
+%{ endif ~}
+%{ endif ~}
     failovermethod: priority
     enabled: true
     gpgcheck: false
@@ -813,7 +1088,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL9/images/repo/MultiLinuxManagerTools-Beta-EL-9-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL9/images/repo/MultiLinuxManagerTools-EL-9-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -852,7 +1135,15 @@ runcmd:
     cat <<EOF > /etc/yum.repos.d/tools_pool_repo.repo
     [tools_pool_repo]
     name=tools_pool_repo
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl=http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl=http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL9/images/repo/MultiLinuxManagerTools-Beta-EL-9-x86_64-Media1/
+%{ else ~}
+    baseurl=http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL9/images/repo/MultiLinuxManagerTools-EL-9-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled=1
     gpgcheck=0
     EOF
@@ -899,7 +1190,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL9/images/repo/MultiLinuxManagerTools-Beta-EL-9-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL9/images/repo/MultiLinuxManagerTools-EL-9-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -920,7 +1219,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL8/images/repo/MultiLinuxManagerTools-Beta-EL-8-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL8/images/repo/MultiLinuxManagerTools-EL-8-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -946,7 +1253,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL9/images/repo/MultiLinuxManagerTools-Beta-EL-9-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL9/images/repo/MultiLinuxManagerTools-EL-9-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -974,7 +1289,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL10-Uyuni-Client-Tools/EL_10/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL10/images/repo/MultiLinuxManagerTools-Beta-EL-10-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL10/images/repo/MultiLinuxManagerTools-EL-10-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -1002,7 +1325,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL8/images/repo/MultiLinuxManagerTools-Beta-EL-8-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL8/images/repo/MultiLinuxManagerTools-EL-8-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -1027,7 +1358,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL9-Uyuni-Client-Tools/EL_9
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL9/images/repo/MultiLinuxManagerTools-Beta-EL-9-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL9/images/repo/MultiLinuxManagerTools-EL-9-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -1055,7 +1394,15 @@ runcmd:
 yum_repos:
   # repo for salt
   tools_pool_repo:
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
     baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/EL10-Uyuni-Client-Tools/EL_10/
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-EL10/images/repo/MultiLinuxManagerTools-Beta-EL-10-x86_64-Media1/
+%{ else ~}
+    baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-EL10/images/repo/MultiLinuxManagerTools-EL-10-x86_64-Media1/
+%{ endif ~}
+%{ endif ~}
     enabled: true
     gpgcheck: false
     name: tools_pool_repo
@@ -1083,11 +1430,28 @@ runcmd:
 zypper:
   repos:
     - id: tools_pool_repo
+# On MLM, we use the SLE client tools channels for Leap.
 %{ if image == "opensuse156armo" ~}
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 %{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE15/images/repo/ManagerTools-Beta-SLE15-Pool-aarch64-Media1/
+%{ else ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLE15/images/repo/ManagerTools-SLE15-Pool-aarch64-Media1/
+%{ endif ~}
+%{ endif ~}
+%{ else ~}
+%{ if contains(["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr"], product_version) ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_16-Uyuni-Client-Tools/openSUSE_Leap_16.0/
-%{ endif ~}     
+%{ else ~}
+%{ if contains(["head", "head-staging"], product_version) ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE16/product/repo/Multi-Linux-ManagerTools-Beta-SLE-16-aarch64/
+%{ else ~}
+      baseurl: http://${ use_mirror_images ? mirror : "dist.suse.de" }/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLE16/product/repo/Multi-Linux-ManagerTools-SLE-16-aarch64/
+%{ endif ~}
+%{ endif ~}
+%{ endif ~}
       enabled: true
       gpgcheck: false
       name: tools_pool_repo

--- a/salt/repos/client_tools/client_tools_mlm.sls
+++ b/salt/repos/client_tools/client_tools_mlm.sls
@@ -400,7 +400,6 @@ additional_tools_update_repo_raised_priority:
             Pin: release l=Devel:Galaxy:Manager:Stable:MLMTools-Ubuntu{{ release }}
             Pin-Priority: 800
 
-{# WORKAROUND: disable because of https://bugzilla.suse.com/show_bug.cgi?id=1271613
 {% elif 'head' == grains.get('product_version') | default('', true) %}
 
 {% set additional_tools_update_repo = 'http://' + grains.get("mirror") | default("dist.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-Ubuntu' + release + '/xUbuntu_' + release + '-debbuild' %}
@@ -419,7 +418,6 @@ tools_additional_tools_update_repo:
             Package: *
             Pin: release l=Devel:Galaxy:Manager:Main:MLMTools-Beta-Ubuntu{{ release }}
             Pin-Priority: 800
-#}
 
 {% endif %} {# Devel Tools Repos #}
 {% endif %} {# grains['os'] == 'Ubuntu' #}


### PR DESCRIPTION
## What does this PR change?

Selects the Multi Linux Manager client tools repositories in `user_data.yaml` instead of the Uyuni ones for MLM product versions, and re-enables the Ubuntu `head` devel tools repo in `client_tools_mlm.sls`.

Every image block picked the Uyuni client tools regardless of product version. Now the repository is chosen by `product_version`:

- `uyuni-*` -> `systemsmanagement:/Uyuni:/Stable:/*-Uyuni-Client-Tools`, unchanged
- `head` / `head-staging` -> `Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-*`
- everything else, 5.1 and 5.2 included -> `Devel:/Galaxy:/Manager:/Stable:/MLMTools-*`

The `Stable:` projects track the current release, so the URLs no longer need touching on every version bump. This also gives `sles160o`, the Leap images and the apt images an MLM repo for the first time; Leap has no MLM client tools of its own, so it uses the SLE channels, matching what `client_tools_mlm.sls` already does.

The apt blocks inline a GPG key, and the Uyuni OBS key does not verify an IBS `Devel:Galaxy` repository, so `key:` is selected by the same condition as `source:` and the MLM branch inlines `salt/default/gpg_keys/galaxy.key`.

One `WORKAROUND` stays: `ubuntu2604o` keeps its non-`head` versions on Uyuni until releng creates `Devel:/Galaxy:/Manager:/Stable:/MLMTools-Ubuntu26.04`. Tracked in https://github.com/SUSE/spacewalk/issues/31432.

### Testing

All 25 repository URLs return 200 and serve valid metadata, on IBS and through the CI/BV mirror. Every rendered apt block resolves to the intended URL and the intended key, checked by fingerprint. The template renders and parses as YAML for 8 product versions across 34 images.

Comes together with https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/1206

fixes https://github.com/SUSE/spacewalk/issues/27328
