### PR TITLE
QE: Restart server in large_deployments

### DIFF
--- a/salt/server_containerized/large_deployment.sls
+++ b/salt/server_containerized/large_deployment.sls
@@ -28,13 +28,6 @@ large_deployment_tune_tomcat_maxthreads:
     - onchanges:
       - cmd: large_deployment_tune_tomcat_stylesheet_copy
 
-large_deployment_tomcat_restart:
-  cmd.run:
-    - name: mgrctl exec systemctl restart tomcat
-    - watch:
-      - manage_config: large_deployment_edit_rhn
-      - cmd: large_deployment_tune_tomcat_maxthreads
-
 {% if '5.1' in grains.get('product_version', '') or 'uyuni' in grains.get('product_version', '') or 'head' in grains.get('product_version', '') %}
 large_deployment_increase_sshd_maxstartups:
   file.managed:
@@ -69,12 +62,6 @@ large_deployment_increase_database_work_memory_db_container:
   cmd.run:
     - name: podman exec uyuni-db sed -i "s/work_mem = .*/work_mem = 20MB/" /var/lib/pgsql/data/postgresql.conf
 
-large_deployment_postgresql_restart_db_container:
-  cmd.run:
-    - name: podman restart uyuni-db
-    - watch:
-      - cmd: large_deployment_increase_database_max_connections_db_container
-      - cmd: large_deployment_increase_database_work_memory_db_container
 {% else %}
 large_deployment_increase_database_max_connections:
   cmd.run:
@@ -84,11 +71,11 @@ large_deployment_increase_database_work_memory:
   cmd.run:
     - name: mgrctl exec 'sed -i "s/work_mem = (.*)/work_mem = 20MB/" /var/lib/pgsql/data/postgresql.conf'
 
-large_deployment_postgresql_restart:
-  cmd.run:
-    - name: mgrctl exec systemctl restart postgresql
-    - watch:
-      - cmd: large_deployment_increase_database_max_connections
-      - cmd: large_deployment_increase_database_work_memory
 {% endif %}
+
+restart_whole_server:
+  cmd.run:
+    - name: mgradm restart
+
+
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Restart server in large deployments to avoid this issue: `Error while inserting data to the table: server closed the connection unexpectedly` in /var/log/salt/master.
As Vladimir reported [here](https://suse.slack.com/archives/C02D134507M/p1780564216180799).
