### PR TITLE
Hub support

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -594,6 +594,50 @@ module "slave" {
 
 Please note that `iss_master` is set from `master`'s module output variable `hostname`, while `iss_slave` is simply hardcoded. This is needed for OpenTofu to resolve dependencies correctly, as dependency cycles are not permitted.
 
+## Hub and peripheral servers
+
+A containerized server can be deployed as a Hub, and one or more other servers as its peripherals. The Hub server is installed with the Hub XML-RPC API enabled, generates the SSL material for each peripheral and publishes it, and each peripheral fetches that material, installs with it, and registers itself to the Hub.
+
+Three variables on the `server_containerized` module drive this:
+
+- `server_hub_main` (bool, default `false`) — install this server as a Hub, enabling the Hub XML-RPC API (`mgradm install ... --hubxmlrpc-replicas 1`).
+- `hub_peripheral_fqdns` (list of strings, default `[]`) — set on the Hub, the list of peripheral FQDNs to pre-generate and publish SSL certificates for.
+- `server_hub_peripheral` (string, default `null`) — set on each peripheral, the FQDN of the Hub it should fetch certificates from and register to.
+
+Example with a Hub and two peripherals:
+
+```hcl
+module "hub" {
+  source             = "./modules/server_containerized"
+  base_configuration = module.base_core.configuration
+
+  name                 = "hub"
+  product_version      = "head"
+  server_hub_main      = true
+  hub_peripheral_fqdns = [local.prh1_hostname, local.prh2_hostname]
+}
+
+module "prh1" {
+  source             = "./modules/server_containerized"
+  base_configuration = module.base_core.configuration
+
+  name                  = "prh1"
+  product_version       = "head"
+  server_hub_peripheral = module.hub.configuration.hostname
+}
+
+module "prh2" {
+  source             = "./modules/server_containerized"
+  base_configuration = module.base_core.configuration
+
+  name                  = "prh2"
+  product_version       = "head"
+  server_hub_peripheral = module.hub.configuration.hostname
+}
+```
+
+As with ISS, note that the peripherals reference the Hub through its module output (`module.hub.configuration.hostname`), while the Hub lists the peripheral FQDNs from `local` values. This avoids a dependency cycle between the modules, so the peripheral FQDNs must be known up front (e.g. computed in `locals`) rather than read back from the peripheral modules' outputs.
+
 ## Working on multiple configuration sets (workspaces) locally
 
 OpenTofu supports working on multiple infrastructure resource groups with the same set of files through the concept of [workspaces](https://opentofu.org/docs/cli/workspaces/). Unfortunately those are not supported for the default filesystem backend and do not really work well with different `main.tf` files, which is often needed in sumaform.

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -86,6 +86,9 @@ module "server_containerized" {
     beta_enabled                   = var.beta_enabled
     additional_repos               = var.additional_repos
     enable_oval_metadata           = var.enable_oval_metadata
+    server-hub-main                = var.server_hub_main
+    hub_peripheral_fqdns           = var.hub_peripheral_fqdns
+    server-hub-peripheral          = var.server_hub_peripheral
   }
 }
 

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -86,9 +86,9 @@ module "server_containerized" {
     beta_enabled                   = var.beta_enabled
     additional_repos               = var.additional_repos
     enable_oval_metadata           = var.enable_oval_metadata
-    server-hub-main                = var.server_hub_main
+    server_hub_main                = var.server_hub_main
     hub_peripheral_fqdns           = var.hub_peripheral_fqdns
-    server-hub-peripheral          = var.server_hub_peripheral
+    server_hub_peripheral          = var.server_hub_peripheral
   }
 }
 

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -356,3 +356,19 @@ variable "enable_oval_metadata" {
   type        = bool
   default     = false
 }
+
+variable "server_hub_main" {
+  description = "install as a hub server, enabling the hub XMLRPC API (adds --hubxmlrpc-replicas 1)"
+  type        = bool
+  default     = false
+}
+
+variable "hub_peripheral_fqdns" {
+  description = "list of peripheral server FQDNs to pre-generate SSL certificates for on this hub"
+  default     = []
+}
+
+variable "server_hub_peripheral" {
+  description = "FQDN of the hub server this peripheral connects to; leave null for non-peripheral servers"
+  default     = null
+}

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -365,10 +365,12 @@ variable "server_hub_main" {
 
 variable "hub_peripheral_fqdns" {
   description = "list of peripheral server FQDNs to pre-generate SSL certificates for on this hub"
+  type        = list(string)
   default     = []
 }
 
 variable "server_hub_peripheral" {
   description = "FQDN of the hub server this peripheral connects to; leave null for non-peripheral servers"
+  type        = string
   default     = null
 }

--- a/salt/server_containerized/check_peripheral_registered.py
+++ b/salt/server_containerized/check_peripheral_registered.py
@@ -6,10 +6,10 @@ import ssl
 import sys
 import xmlrpc.client
 
-HUB_FQDN = "{{ hub_fqdn }}"
-PERIPHERAL_FQDN = "{{ peripheral_fqdn }}"
-USERNAME = "{{ server_username }}"
-PASSWORD = "{{ server_password }}"
+HUB_FQDN = {{ hub_fqdn | tojson }}
+PERIPHERAL_FQDN = {{ peripheral_fqdn | tojson }}
+USERNAME = {{ server_username | tojson }}
+PASSWORD = {{ server_password | tojson }}
 HUB_CA = "/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT"
 
 # Validate the hub certificate against the hub CA we already downloaded.

--- a/salt/server_containerized/check_peripheral_registered.py
+++ b/salt/server_containerized/check_peripheral_registered.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Idempotence check for hub_peripheral_register: exits 0 if this peripheral is
+# already registered to the hub (so the registration step is skipped), 1 otherwise.
+# Rendered by Salt (file.managed template: jinja) on the peripheral minion.
+import ssl
+import sys
+import xmlrpc.client
+
+HUB_FQDN = "{{ hub_fqdn }}"
+PERIPHERAL_FQDN = "{{ peripheral_fqdn }}"
+USERNAME = "{{ server_username }}"
+PASSWORD = "{{ server_password }}"
+HUB_CA = "/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT"
+
+# Validate the hub certificate against the hub CA we already downloaded.
+ctx = ssl.create_default_context(cafile=HUB_CA)
+hub = xmlrpc.client.ServerProxy("https://%s/rpc/api" % HUB_FQDN, context=ctx)
+
+session = hub.auth.login(USERNAME, PASSWORD)
+try:
+    servers = hub.sync.hub.listPeripheralServers(session)
+finally:
+    hub.auth.logout(session)
+
+sys.exit(0 if any(p.get("fqdn") == PERIPHERAL_FQDN for p in servers) else 1)

--- a/salt/server_containerized/hub_peripheral.sls
+++ b/salt/server_containerized/hub_peripheral.sls
@@ -1,6 +1,6 @@
-{% if grains.get('server-hub-peripheral') | default(false, true) %}
+{% if grains.get('server_hub_peripheral') | default(false, true) %}
 
-{% set hub_fqdn = grains['server-hub-peripheral'] %}
+{% set hub_fqdn = grains['server_hub_peripheral'] %}
 {% set peripheral_fqdn = grains['fqdn'] %}
 
 hub_ssl_build_dir:

--- a/salt/server_containerized/hub_peripheral.sls
+++ b/salt/server_containerized/hub_peripheral.sls
@@ -35,7 +35,7 @@ hub_peripheral_server_key:
       - file: hub_ssl_build_dir
 
 hub_ca_trust_anchor:
-  file.managed:
+  file.copy:
     - name: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT.pem
     - source: /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT
     - require:
@@ -67,34 +67,37 @@ mgradm_install:
       - file: hub_peripheral_server_key
       - cmd: hub_ca_trust_update
 
+hub_peripheral_register_script:
+  file.managed:
+    - name: /root/register_peripheral.py
+    - source: salt://server_containerized/register_peripheral.py
+    - mode: '0700'
+    - template: jinja
+    - context:
+        hub_fqdn: {{ hub_fqdn }}
+        peripheral_fqdn: {{ peripheral_fqdn }}
+        server_username: {{ server_username }}
+        server_password: {{ server_password }}
+
+hub_peripheral_check_script:
+  file.managed:
+    - name: /root/check_peripheral_registered.py
+    - source: salt://server_containerized/check_peripheral_registered.py
+    - mode: '0700'
+    - template: jinja
+    - context:
+        hub_fqdn: {{ hub_fqdn }}
+        peripheral_fqdn: {{ peripheral_fqdn }}
+        server_username: {{ server_username }}
+        server_password: {{ server_password }}
+
 hub_peripheral_register:
   cmd.run:
-    - name: |
-        python3 << 'PYEOF'
-        import xmlrpc.client, ssl
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-        hub = xmlrpc.client.ServerProxy("https://{{ hub_fqdn }}/rpc/api", context=ctx)
-        s = hub.auth.login("{{ server_username }}", "{{ server_password }}")
-        with open("/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT") as f:
-            ca = f.read()
-        hub.sync.hub.registerPeripheral(s, "{{ peripheral_fqdn }}", "{{ server_username }}", "{{ server_password }}", ca)
-        hub.auth.logout(s)
-        PYEOF
-    - unless: |
-        python3 << 'PYEOF'
-        import xmlrpc.client, ssl, sys
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-        hub = xmlrpc.client.ServerProxy("https://{{ hub_fqdn }}/rpc/api", context=ctx)
-        s = hub.auth.login("{{ server_username }}", "{{ server_password }}")
-        servers = hub.sync.hub.listPeripheralServers(s)
-        hub.auth.logout(s)
-        sys.exit(0 if any(p.get("fqdn") == "{{ peripheral_fqdn }}" for p in servers) else 1)
-        PYEOF
+    - name: python3 /root/register_peripheral.py
+    - unless: python3 /root/check_peripheral_registered.py
     - require:
       - cmd: mgradm_install
+      - file: hub_peripheral_register_script
+      - file: hub_peripheral_check_script
 
 {% endif %}

--- a/salt/server_containerized/hub_peripheral.sls
+++ b/salt/server_containerized/hub_peripheral.sls
@@ -1,0 +1,68 @@
+{% if grains.get('server-hub-peripheral') | default(false, true) %}
+
+{% set hub_fqdn = grains['server-hub-peripheral'] %}
+{% set peripheral_fqdn = grains['fqdn'] %}
+
+hub_ssl_build_dir:
+  file.directory:
+    - name: /root/ssl-build
+
+hub_ca_cert:
+  file.managed:
+    - name: /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT
+    - source: http://{{ hub_fqdn }}/pub/RHN-ORG-TRUSTED-SSL-CERT
+    - source_hash: http://{{ hub_fqdn }}/pub/RHN-ORG-TRUSTED-SSL-CERT.sha512
+    - require:
+      - file: hub_ssl_build_dir
+
+hub_peripheral_server_cert:
+  file.managed:
+    - name: /root/ssl-build/peripheral-{{ peripheral_fqdn }}-server.crt
+    - source: http://{{ hub_fqdn }}/pub/peripheral-{{ peripheral_fqdn }}-server.crt
+    - source_hash: http://{{ hub_fqdn }}/pub/peripheral-{{ peripheral_fqdn }}-server.crt.sha512
+    - require:
+      - file: hub_ssl_build_dir
+
+hub_peripheral_server_key:
+  file.managed:
+    - name: /root/ssl-build/peripheral-{{ peripheral_fqdn }}-server.key
+    - mode: '0600'
+    - source: http://{{ hub_fqdn }}/pub/peripheral-{{ peripheral_fqdn }}-server.key
+    - source_hash: http://{{ hub_fqdn }}/pub/peripheral-{{ peripheral_fqdn }}-server.key.sha512
+    - require:
+      - file: hub_ssl_build_dir
+
+hub_ca_trust_anchor:
+  file.managed:
+    - name: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT.pem
+    - source: /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT
+    - require:
+      - file: hub_ca_cert
+
+hub_ca_trust_update:
+  cmd.run:
+    - name: update-ca-certificates
+    - onchanges:
+      - file: hub_ca_trust_anchor
+
+mgradm_install:
+  cmd.run:
+    - name: >-
+        mgradm install podman --logLevel=debug --config /root/mgradm.yaml
+        --ssl-ca-root /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT
+        --ssl-server-cert /root/ssl-build/peripheral-{{ peripheral_fqdn }}-server.crt
+        --ssl-server-key /root/ssl-build/peripheral-{{ peripheral_fqdn }}-server.key
+        --ssl-db-ca-root /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT
+        --ssl-db-cert /root/ssl-build/peripheral-{{ peripheral_fqdn }}-server.crt
+        --ssl-db-key /root/ssl-build/peripheral-{{ peripheral_fqdn }}-server.key
+        {{ peripheral_fqdn }}
+    - unless: podman ps | grep uyuni-server
+    - require:
+      - sls: server_containerized.install_common
+      - sls: server_containerized.install_podman
+      - file: mgradm_config
+      - file: hub_peripheral_server_cert
+      - file: hub_peripheral_server_key
+      - cmd: hub_ca_trust_update
+
+{% endif %}

--- a/salt/server_containerized/hub_peripheral.sls
+++ b/salt/server_containerized/hub_peripheral.sls
@@ -2,6 +2,8 @@
 
 {% set hub_fqdn = grains['server_hub_peripheral'] %}
 {% set peripheral_fqdn = grains['fqdn'] %}
+{% set server_username = grains.get('server_username') | default('admin', true) %}
+{% set server_password = grains.get('server_password') | default('admin', true) %}
 
 hub_ssl_build_dir:
   file.directory:
@@ -64,5 +66,35 @@ mgradm_install:
       - file: hub_peripheral_server_cert
       - file: hub_peripheral_server_key
       - cmd: hub_ca_trust_update
+
+hub_peripheral_register:
+  cmd.run:
+    - name: |
+        python3 << 'PYEOF'
+        import xmlrpc.client, ssl
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        hub = xmlrpc.client.ServerProxy("https://{{ hub_fqdn }}/rpc/api", context=ctx)
+        s = hub.auth.login("{{ server_username }}", "{{ server_password }}")
+        with open("/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT") as f:
+            ca = f.read()
+        hub.sync.hub.registerPeripheral(s, "{{ peripheral_fqdn }}", "{{ server_username }}", "{{ server_password }}", ca)
+        hub.auth.logout(s)
+        PYEOF
+    - unless: |
+        python3 << 'PYEOF'
+        import xmlrpc.client, ssl, sys
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        hub = xmlrpc.client.ServerProxy("https://{{ hub_fqdn }}/rpc/api", context=ctx)
+        s = hub.auth.login("{{ server_username }}", "{{ server_password }}")
+        servers = hub.sync.hub.listPeripheralServers(s)
+        hub.auth.logout(s)
+        sys.exit(0 if any(p.get("fqdn") == "{{ peripheral_fqdn }}" for p in servers) else 1)
+        PYEOF
+    - require:
+      - cmd: mgradm_install
 
 {% endif %}

--- a/salt/server_containerized/hub_peripheral_certs.sls
+++ b/salt/server_containerized/hub_peripheral_certs.sls
@@ -1,0 +1,24 @@
+{% if grains.get('hub_peripheral_fqdns') | default([], true) %}
+
+{% for peripheral_fqdn in grains.get('hub_peripheral_fqdns', []) %}
+
+hub_peripheral_generate_cert_{{ peripheral_fqdn }}:
+  cmd.run:
+    - name: mgrctl exec "rhn-ssl-tool --gen-server --dir=/root/ssl-build --set-hostname={{ peripheral_fqdn }} --set-cname=reportdb --set-cname=db"
+    - unless: mgrctl exec "test -f /root/ssl-build/{{ peripheral_fqdn }}/server.crt"
+    - require:
+      - cmd: mgradm_install
+
+hub_peripheral_publish_cert_{{ peripheral_fqdn }}:
+  cmd.run:
+    - name: |
+        mgrctl exec "cp /root/ssl-build/{{ peripheral_fqdn }}/server.crt /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.crt && chmod 644 /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.crt"
+        mgrctl exec "sha512sum /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.crt > /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.crt.sha512"
+        mgrctl exec "cp /root/ssl-build/{{ peripheral_fqdn }}/server.key /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.key && chmod 644 /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.key"
+        mgrctl exec "sha512sum /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.key > /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.key.sha512"
+    - onchanges:
+      - cmd: hub_peripheral_generate_cert_{{ peripheral_fqdn }}
+
+{% endfor %}
+
+{% endif %}

--- a/salt/server_containerized/hub_peripheral_certs.sls
+++ b/salt/server_containerized/hub_peripheral_certs.sls
@@ -1,3 +1,11 @@
+# NOTE: temporary, test-only mechanism. The hub generates each peripheral's
+# server certificate and key and publishes them under /pub so the peripheral can
+# fetch them over HTTP. This exposes the peripheral private key on the hub's
+# public endpoint and is only acceptable on sumaform's trusted, ephemeral test
+# networks. The built-in publish/download_private_ssl_key path does not fit here
+# (it is gated to the minion role and distributes the CA key for self-signing
+# rather than per-host server certs). Replace with a secure transfer if this ever
+# needs to leave a test environment.
 {% if grains.get('hub_peripheral_fqdns') | default([], true) %}
 
 hub_ca_cert_checksum:

--- a/salt/server_containerized/hub_peripheral_certs.sls
+++ b/salt/server_containerized/hub_peripheral_certs.sls
@@ -4,7 +4,7 @@
 
 hub_peripheral_generate_cert_{{ peripheral_fqdn }}:
   cmd.run:
-    - name: mgrctl exec "rhn-ssl-tool --gen-server --dir=/root/ssl-build --set-hostname={{ peripheral_fqdn }} --set-cname=reportdb --set-cname=db"
+    - name: mgrctl exec "rhn-ssl-tool --gen-server --dir=/root/ssl-build --set-hostname={{ peripheral_fqdn }} --set-cname=reportdb --set-cname=db --password=spacewalk"
     - unless: mgrctl exec "test -f /root/ssl-build/{{ peripheral_fqdn }}/server.crt"
     - require:
       - cmd: mgradm_install

--- a/salt/server_containerized/hub_peripheral_certs.sls
+++ b/salt/server_containerized/hub_peripheral_certs.sls
@@ -1,5 +1,12 @@
 {% if grains.get('hub_peripheral_fqdns') | default([], true) %}
 
+hub_ca_cert_checksum:
+  cmd.run:
+    - name: mgrctl exec "sha512sum /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT > /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT.sha512 && chmod 644 /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT.sha512"
+    - unless: mgrctl exec "test -f /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT.sha512"
+    - require:
+      - cmd: mgradm_install
+
 {% for peripheral_fqdn in grains.get('hub_peripheral_fqdns', []) %}
 
 hub_peripheral_generate_cert_{{ peripheral_fqdn }}:
@@ -8,6 +15,7 @@ hub_peripheral_generate_cert_{{ peripheral_fqdn }}:
     - unless: mgrctl exec "find /root/ssl-build -maxdepth 2 -name 'server.crt' -path '*{{ peripheral_fqdn.split('.')[0] }}*' | grep -q ."
     - require:
       - cmd: mgradm_install
+      - cmd: hub_ca_cert_checksum
 
 hub_peripheral_publish_cert_{{ peripheral_fqdn }}:
   cmd.run:

--- a/salt/server_containerized/hub_peripheral_certs.sls
+++ b/salt/server_containerized/hub_peripheral_certs.sls
@@ -5,16 +5,17 @@
 hub_peripheral_generate_cert_{{ peripheral_fqdn }}:
   cmd.run:
     - name: mgrctl exec "rhn-ssl-tool --gen-server --dir=/root/ssl-build --set-hostname={{ peripheral_fqdn }} --set-cname=reportdb --set-cname=db --password=spacewalk"
-    - unless: mgrctl exec "test -f /root/ssl-build/{{ peripheral_fqdn }}/server.crt"
+    - unless: mgrctl exec "find /root/ssl-build -maxdepth 2 -name 'server.crt' -path '*{{ peripheral_fqdn.split('.')[0] }}*' | grep -q ."
     - require:
       - cmd: mgradm_install
 
 hub_peripheral_publish_cert_{{ peripheral_fqdn }}:
   cmd.run:
     - name: |
-        mgrctl exec "cp /root/ssl-build/{{ peripheral_fqdn }}/server.crt /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.crt && chmod 644 /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.crt"
+        CERT_DIR=$(mgrctl exec "find /root/ssl-build -maxdepth 1 -type d -name '{{ peripheral_fqdn.split('.')[0] }}*' | head -1")
+        mgrctl exec "cp ${CERT_DIR}/server.crt /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.crt && chmod 644 /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.crt"
         mgrctl exec "sha512sum /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.crt > /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.crt.sha512"
-        mgrctl exec "cp /root/ssl-build/{{ peripheral_fqdn }}/server.key /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.key && chmod 644 /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.key"
+        mgrctl exec "cp ${CERT_DIR}/server.key /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.key && chmod 644 /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.key"
         mgrctl exec "sha512sum /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.key > /srv/www/htdocs/pub/peripheral-{{ peripheral_fqdn }}-server.key.sha512"
     - onchanges:
       - cmd: hub_peripheral_generate_cert_{{ peripheral_fqdn }}

--- a/salt/server_containerized/init.sls
+++ b/salt/server_containerized/init.sls
@@ -6,6 +6,8 @@ include:
   - server_containerized.install_{{ runtime }}
   - server_containerized.additional_disks
   - server_containerized.install_mgradm
+  - server_containerized.hub_peripheral_certs
+  - server_containerized.hub_peripheral
   - server_containerized.initial_content
   - server_containerized.rhn
   - server_containerized.large_deployment

--- a/salt/server_containerized/install_mgradm.sls
+++ b/salt/server_containerized/install_mgradm.sls
@@ -4,7 +4,7 @@ mgradm_config:
     - source: salt://server_containerized/mgradm.yaml
     - template: jinja
 
-{% if not grains.get('server_hub_peripheral') | default(false, true) %}
+{% if not (grains.get('server_hub_peripheral') | default(false, true)) %}
 mgradm_install:
   cmd.run:
     - name: mgradm install podman --logLevel=debug --config /root/mgradm.yaml {{ grains['fqdn'] }}{% if grains.get('server_hub_main') | default(false, true) %} --hubxmlrpc-replicas 1{% endif %}

--- a/salt/server_containerized/install_mgradm.sls
+++ b/salt/server_containerized/install_mgradm.sls
@@ -4,11 +4,13 @@ mgradm_config:
     - source: salt://server_containerized/mgradm.yaml
     - template: jinja
 
+{% if not grains.get('server-hub-peripheral') | default(false, true) %}
 mgradm_install:
   cmd.run:
-    - name: mgradm install podman --logLevel=debug --config /root/mgradm.yaml {{ grains['fqdn'] }}
+    - name: mgradm install podman --logLevel=debug --config /root/mgradm.yaml {{ grains['fqdn'] }}{% if grains.get('server-hub-main') | default(false, true) %} --hubxmlrpc-replicas 1{% endif %}
     - unless: podman ps | grep uyuni-server
     - require:
       - sls: server_containerized.install_common
       - sls: server_containerized.install_podman
       - file: mgradm_config
+{% endif %}

--- a/salt/server_containerized/install_mgradm.sls
+++ b/salt/server_containerized/install_mgradm.sls
@@ -4,10 +4,10 @@ mgradm_config:
     - source: salt://server_containerized/mgradm.yaml
     - template: jinja
 
-{% if not grains.get('server-hub-peripheral') | default(false, true) %}
+{% if not grains.get('server_hub_peripheral') | default(false, true) %}
 mgradm_install:
   cmd.run:
-    - name: mgradm install podman --logLevel=debug --config /root/mgradm.yaml {{ grains['fqdn'] }}{% if grains.get('server-hub-main') | default(false, true) %} --hubxmlrpc-replicas 1{% endif %}
+    - name: mgradm install podman --logLevel=debug --config /root/mgradm.yaml {{ grains['fqdn'] }}{% if grains.get('server_hub_main') | default(false, true) %} --hubxmlrpc-replicas 1{% endif %}
     - unless: podman ps | grep uyuni-server
     - require:
       - sls: server_containerized.install_common

--- a/salt/server_containerized/register_peripheral.py
+++ b/salt/server_containerized/register_peripheral.py
@@ -4,10 +4,10 @@
 import ssl
 import xmlrpc.client
 
-HUB_FQDN = "{{ hub_fqdn }}"
-PERIPHERAL_FQDN = "{{ peripheral_fqdn }}"
-USERNAME = "{{ server_username }}"
-PASSWORD = "{{ server_password }}"
+HUB_FQDN = {{ hub_fqdn | tojson }}
+PERIPHERAL_FQDN = {{ peripheral_fqdn | tojson }}
+USERNAME = {{ server_username | tojson }}
+PASSWORD = {{ server_password | tojson }}
 HUB_CA = "/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT"
 
 # Validate the hub certificate against the hub CA we already downloaded.

--- a/salt/server_containerized/register_peripheral.py
+++ b/salt/server_containerized/register_peripheral.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# Registers this peripheral server to the hub via the hub XML-RPC API.
+# Rendered by Salt (file.managed template: jinja) on the peripheral minion.
+import ssl
+import xmlrpc.client
+
+HUB_FQDN = "{{ hub_fqdn }}"
+PERIPHERAL_FQDN = "{{ peripheral_fqdn }}"
+USERNAME = "{{ server_username }}"
+PASSWORD = "{{ server_password }}"
+HUB_CA = "/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT"
+
+# Validate the hub certificate against the hub CA we already downloaded.
+ctx = ssl.create_default_context(cafile=HUB_CA)
+hub = xmlrpc.client.ServerProxy("https://%s/rpc/api" % HUB_FQDN, context=ctx)
+
+session = hub.auth.login(USERNAME, PASSWORD)
+try:
+    with open(HUB_CA) as f:
+        ca = f.read()
+    hub.sync.hub.registerPeripheral(session, PERIPHERAL_FQDN, USERNAME, PASSWORD, ca)
+finally:
+    hub.auth.logout(session)


### PR DESCRIPTION
  ## What does this PR change?

  Adds support for deploying a containerized server as a **Hub** with one or more **peripheral** servers:

  - **Hub** (`server_hub_main = true`): installed with the Hub XML-RPC API enabled  (`mgradm install ... --hubxmlrpc-replicas 1`). For every FQDN listed in `hub_peripheral_fqdns`, the hub pre-generates the peripheral's SSL material and
    publishes it under `/pub`.
  - **Peripheral** (`server_hub_peripheral = <hub fqdn>`): fetches the hub CA and its  own SSL material from the hub, installs with those certificates, and registers  itself to the hub over the XML-RPC API (`sync.hub.registerPeripheral`),    authenticating with the server admin credentials.

New module variables on `server_containerized`:

  | variable | type | default | purpose |
  |----------|------|---------|---------|
  | `server_hub_main` | bool | `false` | install as a hub (enables hub XML-RPC API) |
  | `hub_peripheral_fqdns` | list(string) | `[]` | peripheral FQDNs to pre-generate certs for (set on the hub) |
  | `server_hub_peripheral` | string | `null` | FQDN of the hub to attach to (set on each peripheral) |

See the "Hub and peripheral servers" section in `README_ADVANCED.md` for usage.

### Example

```terraform
module "hub" {
  source             = "./modules/server_containerized"
  base_configuration = module.base_core.configuration
  name               = "hub"
  product_version    = "head-staging"
  image              = "sles15sp7o"
  provider_settings  = { mac = "xxxxx", memory = 20480, vcpu = 10 }
  install_salt_bundle  = true
  runtime              = "podman"
  container_repository = "registry.suse.de/devel/galaxy/manager/main/mlm-beta-products-sle15/containerfile"
  container_tag        = "latest"
  ssh_key_path         = var.PUBLIC_SSH_KEY_PATH
  server_hub_main      = true
  hub_peripheral_fqdns = [local.prh1_hostname, local.prh2_hostname]
  large_deployment     = false
}

module "prh1" {
  source             = "./modules/server_containerized"
  base_configuration = module.base_core.configuration
  name               = "prh1"
  product_version    = "head-staging"
  auto_accept        = true
  from_email         = "root@suse.de"
  image              = "sles15sp7o"
  provider_settings  = { mac = "aa:b2:93:01:01:c5" }
  runtime               = "podman"
  container_repository  = "registry.suse.de/devel/galaxy/manager/main/mlm-beta-products-sle15/containerfile"
  container_tag         = "latest"
  ssh_key_path          = var.PUBLIC_SSH_KEY_PATH
  server_hub_peripheral = module.hub.configuration.hostname
  large_deployment        = false
  publish_private_ssl_key = false
}
```
