### PR TITLE
Use AWS provider version 6

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 
 data "aws_ami" "tumbleweedo" {
   # Only execute this lookup if the region is eu-central-1 (Frankfurt)
-  count = data.aws_region.current.name == "eu-central-1" ? 1 : 0
+  count = data.aws_region.current.id == "eu-central-1" ? 1 : 0
 
   most_recent = true
   owners      = ["self"] // custom built AMI

--- a/backend_modules/aws/base/versions.tf
+++ b/backend_modules/aws/base/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws  = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/backend_modules/aws/db_host/versions.tf
+++ b/backend_modules/aws/db_host/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws  = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/backend_modules/aws/host/main.tf
+++ b/backend_modules/aws/host/main.tf
@@ -72,7 +72,7 @@ locals {
 resource "aws_eip" "host_eip" {
   count = local.host_eip ? var.quantity : 0
 
-  vpc = true
+  domain = "vpc"
   tags = {
     Name = "${local.resource_name_prefix}-host-eip${var.quantity > 1 ? "-${count.index + 1}" : ""}"
 

--- a/backend_modules/aws/host/versions.tf
+++ b/backend_modules/aws/host/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws  = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/backend_modules/aws/network/main.tf
+++ b/backend_modules/aws/network/main.tf
@@ -41,7 +41,7 @@ resource "aws_internet_gateway" "main" {
 resource "aws_eip" "nat_eip" {
   count = var.create_network ? 1 : 0
 
-  vpc = true
+  domain = "vpc"
   tags = {
     Name = "${var.name_prefix}nat-eip"
   }

--- a/backend_modules/aws/network/versions.tf
+++ b/backend_modules/aws/network/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws  = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 6.0"
     }
   }
 }


### PR DESCRIPTION
## What does this PR change?

Bumps the AWS provider version to the latest version 6.X available.
It also takes care of a couple attributes which have been deprecated or changed in the new versions.
