### PR TITLE
Fix Ruby bundle binary path

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -96,7 +96,7 @@ install_npm:
 
 install_gems_via_bundle:
   cmd.run:
-    - name: bundle.ruby3.3 install --gemfile Gemfile
+    - name: bundle.ruby.ruby3.3 install --gemfile Gemfile
     - cwd: /root/spacewalk/testsuite
     - require:
       - pkg: cucumber_requisites


### PR DESCRIPTION
## What does this PR change?

Fix Ruby bundle binary path.

## Issue
```bash
02:56:00  cucumber_testsuite.controller.provisioning[0] (remote-exec): [ERROR   ] Command 'bundle.ruby3.3' failed with return code: 127
02:56:00  cucumber_testsuite.controller.provisioning[0] (remote-exec): [ERROR   ] stderr: /bin/bash: bundle.ruby3.3: command not found
02:56:00  cucumber_testsuite.controller.provisioning[0] (remote-exec): [ERROR   ] retcode: 127
02:56:00  cucumber_testsuite.controller.provisioning[0] (remote-exec): [ERROR   ] {'pid': 6342, 'retcode': 127, 'stdout': '', 'stderr': '/bin/bash: bundle.ruby3.3: command not found'}
```

## Investigation
```bash
uyuni-ci-master-podman-controller:/usr/bin # ll | grep bundle.
lrwxrwxrwx 1 root root         24 Jun 11 22:21 bundle -> /etc/alternatives/bundle
-rwxr-xr-x 1 root root        568 Jun 11 22:21 bundle.ruby.ruby3.3
lrwxrwxrwx 1 root root         32 Jun 11 22:21 bundle.ruby3.3 -> /etc/alternatives/bundle.ruby3.3
lrwxrwxrwx 1 root root         25 Jun 11 22:21 bundler -> /etc/alternatives/bundler
-rwxr-xr-x 1 root root        570 Jun 11 22:21 bundler.ruby.ruby3.3
lrwxrwxrwx 1 root root         33 Jun 11 22:21 bundler.ruby3.3 -> /etc/alternatives/bundler.ruby3.3
```

```bash
[INFO    ] Completed state [/root/.ssh/authorized_keys] at time 08:21:57.017306 (duration_in_ms=10.551)
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Running state [/usr/bin/ruby] at time 08:21:57.017379
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing state file.symlink for [/usr/bin/ruby]
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] {'new': '/usr/bin/ruby'}
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Loading fresh modules for state activity
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Completed state [/usr/bin/ruby] at time 08:21:57.038947 (duration_in_ms=21.567)
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Running state [/usr/bin/gem] at time 08:21:57.040075
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing state file.symlink for [/usr/bin/gem]
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] {'new': '/usr/bin/gem'}
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Loading fresh modules for state activity
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Completed state [/usr/bin/gem] at time 08:21:57.063651 (duration_in_ms=23.575)
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Running state [/usr/bin/irb] at time 08:21:57.064552
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing state file.symlink for [/usr/bin/irb]
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] {'new': '/usr/bin/irb'}
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Loading fresh modules for state activity
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Completed state [/usr/bin/irb] at time 08:21:57.087773 (duration_in_ms=23.221)
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Running state [update-alternatives --set rake /usr/bin/rake.ruby.ruby3.3] at time 08:21:57.088278
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing state cmd.run for [update-alternatives --set rake /usr/bin/rake.ruby.ruby3.3]
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing command 'update-alternatives' in directory '/root'
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] {'pid': 5684, 'retcode': 0, 'stdout': 'update-alternatives: using /usr/bin/rake.ruby.ruby3.3 to provide /usr/bin/rake (rake) in manual mode', 'stderr': ''}
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Completed state [update-alternatives --set rake /usr/bin/rake.ruby.ruby3.3] at time 08:21:57.097258 (duration_in_ms=8.979)
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Running state [update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.3] at time 08:21:57.097329
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing state cmd.run for [update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.3]
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing command 'update-alternatives' in directory '/root'
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] {'pid': 5685, 'retcode': 0, 'stdout': '', 'stderr': ''}
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Completed state [update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.3] at time 08:21:57.099604 (duration_in_ms=2.275)
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Running state [update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.3] at time 08:21:57.099678
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing state cmd.run for [update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.3]
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing command 'update-alternatives' in directory '/root'
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] {'pid': 5686, 'retcode': 0, 'stdout': 'update-alternatives: using /usr/bin/rdoc.ruby.ruby3.3 to provide /usr/bin/rdoc (rdoc) in manual mode', 'stderr': ''}
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Completed state [update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.3] at time 08:21:57.101658 (duration_in_ms=1.98)
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Running state [update-alternatives --set ri /usr/bin/ri.ruby.ruby3.3] at time 08:21:57.101723
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing state cmd.run for [update-alternatives --set ri /usr/bin/ri.ruby.ruby3.3]
[2026-06-12T06:21:58.501Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Executing command 'update-alternatives' in directory '/root'
[2026-06-12T06:22:25.005Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] {'pid': 5687, 'retcode': 0, 'stdout': 'update-alternatives: using /usr/bin/ri.ruby.ruby3.3 to provide /usr/bin/ri (ri) in manual mode', 'stderr': ''}
[2026-06-12T06:22:25.005Z] cucumber_testsuite.controller.provisioning[0] (remote-exec): [INFO    ] Completed state [update-alternatives --set ri /usr/bin/ri.ruby.ruby3.3] at time 08:21:57.103841 (duration_in_ms=2.119)
```

## Solution
```bash
uyuni-ci-master-podman-controller:~/spacewalk/testsuite # bundle.ruby3.3 install --gemfile Gemfile
-bash: bundle.ruby3.3: command not found

uyuni-ci-master-podman-controller:~/spacewalk/testsuite # bundle.ruby.ruby3.3 install --gemfile Gemfile
Don't run Bundler as root. Installing your bundle as root will break this application for all non-root users on this machine.
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Fetching rake 13.4.2
(...)
```
