### PR TITLE
Wire s390 local user variable and update module dependencies

### DIFF
--- a/modules/build_validation/main.tf
+++ b/modules/build_validation/main.tf
@@ -21,7 +21,7 @@ provider "libvirt" {
 provider "feilong" {
   connector   = "https://feilong.mgr.suse.de"
   admin_token = var.zvm_admin_token
-  local_user  = "jenkins@jenkins-worker.mgr.suse.de"
+  local_user  = var.s390_local_user
 }
 
 module "base_arm" {

--- a/modules/build_validation/variables.tf
+++ b/modules/build_validation/variables.tf
@@ -123,3 +123,9 @@ variable "public_ssh_key_path" {
   default     = "./salt/controller/id_ed25519.pub"
   description = "Path to public key used for ssh access"
 }
+
+variable "s390_local_user" {
+  type        = string
+  default     = "jenkins@jenkins-worker.mgr.suse.de"
+  description = "Jenkins worker from were the deployment is executed."
+}


### PR DESCRIPTION
## What does this PR change?

For feilong to be able to deploy and configure a minion, it needs to access the Jenkins Worker.

Add support to configure this variable so we can specify any jenkins worker. By default jenkins-worker.mgr.suse.de
