### PR TITLE
Split private key. One for access minions and the other for hyperviso…

### DIFF
--- a/modules/build_validation/main.tf
+++ b/modules/build_validation/main.tf
@@ -1498,7 +1498,7 @@ module "dhcp_dns" {
   hypervisor = {
     host        = var.base_configurations.base_core.hypervisor
     user        = "root"
-    private_key = file(var.private_ssh_key_path)
+    private_key = file(var.hypervisor_private_ssh_key_path)
   }
 }
 

--- a/modules/build_validation/variables.tf
+++ b/modules/build_validation/variables.tf
@@ -112,9 +112,15 @@ variable "module_base_configurations" {
   description = "Module base configurations"
 }
 
-variable "private_ssh_key_path" {
+variable "hypervisor_private_ssh_key_path" {
   type        = string
   default     = "~/.ssh/id_ed25519"
+  description = "Path to private key used to access hypervisor (dhcp deployment)"
+}
+
+variable "private_ssh_key_path" {
+  type        = string
+  default     = "./salt/controller/id_ed25519"
   description = "Path to private key used for ssh access"
 }
 


### PR DESCRIPTION
## What does this PR change?

In sumaform, we have two different private keys with two different purpose:

 - access hypervisor
 - access minion
 
 We have been mixing those keys and it create issue with s390 deployment.
Fix by splitting the keys.

