### PR TITLE
Add multiserver support

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -53,6 +53,8 @@ module "controller" {
 
     server            = var.server_configuration["hostname"]
     proxy             = var.proxy_configuration["hostname"]
+    proxy2            = var.proxy2_configuration["hostname"]
+    proxy3            = var.proxy3_configuration["hostname"]
     server2           = var.server2_configuration["hostname"]
     server3           = var.server3_configuration["hostname"]
     server4           = var.server4_configuration["hostname"]

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -53,6 +53,9 @@ module "controller" {
 
     server            = var.server_configuration["hostname"]
     proxy             = var.proxy_configuration["hostname"]
+    server2           = var.server2_configuration["hostname"]
+    server3           = var.server3_configuration["hostname"]
+    server4           = var.server4_configuration["hostname"]
     client            = length(var.client_configuration["hostnames"]) > 0 ? var.client_configuration["hostnames"][0] : null
     minion            = length(var.minion_configuration["hostnames"]) > 0 ? var.minion_configuration["hostnames"][0] : null
     build_host        = length(var.buildhost_configuration["hostnames"]) > 0 ? var.buildhost_configuration["hostnames"][0] : null

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -50,6 +50,20 @@ variable "proxy_configuration" {
   }
 }
 
+variable "proxy2_configuration" {
+  description = "use module.<PROXY2_NAME>.configuration, see main.tf.libvirt-testsuite.example"
+  default = {
+    hostname = null
+  }
+}
+
+variable "proxy3_configuration" {
+  description = "use module.<PROXY3_NAME>.configuration, see main.tf.libvirt-testsuite.example"
+  default = {
+    hostname = null
+  }
+}
+
 variable "server2_configuration" {
   description = "use module.<SERVER2_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -50,6 +50,27 @@ variable "proxy_configuration" {
   }
 }
 
+variable "server2_configuration" {
+  description = "use module.<SERVER2_NAME>.configuration, see main.tf.libvirt-testsuite.example"
+  default = {
+    hostname = null
+  }
+}
+
+variable "server3_configuration" {
+  description = "use module.<SERVER3_NAME>.configuration, see main.tf.libvirt-testsuite.example"
+  default = {
+    hostname = null
+  }
+}
+
+variable "server4_configuration" {
+  description = "use module.<SERVER4_NAME>.configuration, see main.tf.libvirt-testsuite.example"
+  default = {
+    hostname = null
+  }
+}
+
 variable "client_configuration" {
   description = "use module.<CLIENT_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {


### PR DESCRIPTION
## What does this PR change?

Add multi server support declaration for controller.
To simplify, have a static number of server (we will probably need 3, but I added the support for 4 in case we need more).
This new env will be use with: https://github.com/uyuni-project/uyuni/pull/12130
