### PR TITLE
QE: Switching default RKE2 pipelines to slmicro6.2

### DIFF
--- a/modules/proxy_kubernetes/main.tf
+++ b/modules/proxy_kubernetes/main.tf
@@ -1,12 +1,8 @@
 variable "images" {
   default = {
-    "head"           = "sles15sp7o"
-    "head-staging"   = "sles15sp7o"
-    "5.0-released"   = "sles15sp7o"
-    "5.0-nightly"    = "sles15sp7o"
-    "5.1-released"   = "sles15sp7o"
-    "5.1-nightly"    = "sles15sp7o"
-    "5.2-released"   = "sles15sp7o"
+    "head"           = "slmicro62o"
+    "head-staging"   = "slmicro62o"
+    "5.2-released"   = "slmicro62o"
     "uyuni-master"   = "tumbleweedo"
     "uyuni-main"     = "tumbleweedo"
     "uyuni-released" = "tumbleweedo"

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -2,13 +2,9 @@
 
 variable "images" {
   default = {
-    "head"           = "sles15sp7o"
-    "head-staging"   = "sles15sp7o"
-    "5.0-released"   = "sles15sp7o"
-    "5.0-nightly"    = "sles15sp7o"
-    "5.1-released"   = "sles15sp7o"
-    "5.1-nightly"    = "sles15sp7o"
-    "5.2-released"   = "sles15sp7o"
+    "head"           = "slmicro62o"
+    "head-staging"   = "slmicro62o"
+    "5.2-released"   = "slmicro62o"
     "uyuni-master"   = "tumbleweedo"
     "uyuni-main"     = "tumbleweedo"
     "uyuni-released" = "tumbleweedo"


### PR DESCRIPTION
## What does this PR change?

The RKE2 pipelines are by default on slmicro 6.2, so switching the default baseOS to it. Also the RKE2 pipelines are 5.2, HEAD and Uyuni, therefore we can remove the options of 5.1 and 5.0.
