### PR TITLE
Fix debian13 deployment

### DIFF
--- a/salt/repos/client_tools/client_tools_uyuni.sls
+++ b/salt/repos/client_tools/client_tools_uyuni.sls
@@ -241,17 +241,17 @@ tools_update_repo:
 tools_update_repo_raised_priority:
   file.managed:
     - name: /etc/apt/preferences.d/tools_update_repo
-{% if 'uyuni-main' in grains.get('product_version') | default('', true) -%}
+{% if 'uyuni-main' in grains.get('product_version') | default('', true) %}
     - contents: |
         Package: *
         Pin: release l=systemsmanagement:Uyuni:Main:UyuniTools
         Pin-Priority: 800
-{% else -%}
+{% else %}
     - contents: |
         Package: *
         Pin: release l=systemsmanagement:Uyuni:{{ uyuni_version }}:Debian{{ release }}-Uyuni-Client-Tools
         Pin-Priority: 800
-{% endif -%}
+{% endif %}
 
 {% endif %} {# grains['os'] == 'Debian' #}
 {% endif %} {# no client tools on server or proxy #}

--- a/salt/repos/client_tools/client_tools_uyuni.sls
+++ b/salt/repos/client_tools/client_tools_uyuni.sls
@@ -235,8 +235,9 @@ tools_update_repo:
     - file: /etc/apt/sources.list.d/tools_update_repo.list
     # We only have one shared Client Tools repository
     - refresh: True
-    - name: deb {{ tools_repo_url }} /
+    - name: deb [signed-by=/etc/apt/keyrings/sumaform-uyuni-debian-tools-update-{{ release }}.gpg] {{ tools_repo_url }} /
     - key_url: {{ tools_repo_url }}/Release.key
+    - aptkey: False
 
 tools_update_repo_raised_priority:
   file.managed:


### PR DESCRIPTION
## What does this PR change?

Fix debian13 deployment

Current error: 

```salt
local:
    Data failed to compile:
----------
    Rendering SLS 'base:repos.client_tools.client_tools_uyuni' failed: while parsing a block
mapping
  in "<unicode string>", line 20, column 1
did not find expected key
  in "<unicode string>", line 32, column 1
  ```
  
  Root cause: -%} strips all whitespace after the tag — including the newline and the 4-space indentation of the following line. So     - contents: | ended up at column 1, breaking the YAML  block mapping. Changing to %} (matching the Ubuntu section above it) preserves the indentation.
  