### PR TITLE
QE: Register slmicro 6.2 to SCC to install RKE2

### DIFF
--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -95,6 +95,8 @@ locals {
     host_key => lookup(var.host_settings[host_key], "scc_access_logging", false) if var.host_settings[host_key] != null }
   enable_oval_metadata     = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "enable_oval_metadata", false) if var.host_settings[host_key] != null }
+  scc_slmicro_pass     = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "scc_slmicro_pass", null) if var.host_settings[host_key] != null }
 
   minimal_configuration     = { hostname = contains(local.hosts, "proxy") ? local.proxy_full_name : local.server_full_name }
   server_configuration      = var.kubernetes ? module.server_kubernetes[0].configuration : ( var.container_server ? module.server_containerized[0].configuration : module.server[0].configuration)
@@ -230,6 +232,7 @@ module "server_kubernetes" {
   helm_chart_name                 = lookup(local.helm_chart_name, "server_kubernetes", "")
   helm_chart_url                  = lookup(local.helm_chart_url, "server_kubernetes", "")
   use_devel_oci                   = var.use_devel_oci
+  scc_slmicro_pass                = var.scc_slmicro_pass
   install_mlm_server              = var.install_mlm_server
   deploy_coco_attestation         = var.deploy_coco_attestation
   deploy_saline                   = var.deploy_saline

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -198,6 +198,12 @@ variable "use_devel_oci" {
   default = false
 }
 
+variable "scc_slmicro_pass" {
+  description = "SCC registration key for SL-Micro"
+  type        = string
+  default     = null
+}
+
 variable "java_debugging_on_rke2" {
   description = "Enable Java debugging on RKE2"
   default     = false

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -53,9 +53,10 @@ module "server_kubernetes" {
     db_container_image             = var.db_container_image
     db_container_tag               = var.db_container_tag
     helm_chart_url                 = var.helm_chart_url
-    helm_chart_name                = var.helm_chart_name  
+    helm_chart_name                = var.helm_chart_name
     cc_username                    = var.base_configuration["cc_username"]
     cc_password                    = var.base_configuration["cc_password"]
+    scc_slmicro_pass               = var.scc_slmicro_pass
     channels                       = var.channels
     mirror                         = var.base_configuration["mirror"]
     use_mirror_images              = var.base_configuration["use_mirror_images"]
@@ -86,6 +87,7 @@ module "server_kubernetes" {
     additional_repos               = var.additional_repos
     enable_oval_metadata           = var.enable_oval_metadata
     use_devel_oci                  = var.use_devel_oci
+    scc_slmicro_pass               = var.scc_slmicro_pass
     install_mlm_server             = var.install_mlm_server
     deploy_coco_attestation        = var.deploy_coco_attestation
     deploy_saline                  = var.deploy_saline

--- a/modules/server_kubernetes/variables.tf
+++ b/modules/server_kubernetes/variables.tf
@@ -47,6 +47,12 @@ variable "use_devel_oci" {
   default = false
 }
 
+variable "scc_slmicro_pass" {
+  description = "SCC registration key for SL-Micro"
+  type        = string
+  default     = null
+}
+
 variable "install_mlm_server" {
   description = "true to install the MLM server. The flags install_rke2 and install_helm must be true as well to install it"
   default = true

--- a/salt/kubernetes_common/install_rke2.sls
+++ b/salt/kubernetes_common/install_rke2.sls
@@ -20,6 +20,18 @@ install_dependencies:
     - refresh: True
 {% endif %}
 
+{% if is_slmicro_6_2 and grains.get('scc_slmicro_pass') %}
+register_to_scc:
+  cmd.run:
+    - name: transactional-update register -r {{ grains.get('scc_slmicro_pass') }}
+
+apply_transition_scc:
+  cmd.run:
+    - name: transactional-update apply
+    - require:
+      - cmd: register_to_scc
+{% endif %}
+
 tls-san_setup_file:
   file.managed:
     - name: /etc/rancher/rke2/config.yaml
@@ -27,7 +39,7 @@ tls-san_setup_file:
         tls-san:
           - "{{ grains.get("fqdn") }}"
         ingress-controller: traefik
-        {% if is_tumbleweed %}
+        {% if is_tumbleweed or is_slmicro_6_2 %}
         selinux: true
         kubelet-arg:
           - "seccomp-default=true"
@@ -45,6 +57,11 @@ rke2_install:
       - INSTALL_RKE2_SELINUX: true
       {% endif %}
     - unless: systemctl is-active rke2-server
+    {% if is_slmicro_6_2  and grains.get('scc_slmicro_pass') %} 
+    - require:
+      - cmd: register_to_scc
+      - cmd: apply_transition_scc
+    {% endif %}
 
 {% if is_slmicro_6_2 %}
 apply_transition_rke2:
@@ -60,6 +77,10 @@ rke2_server_enable:
     - require:
       - cmd: rke2_install
       - file: tls-san_setup_file
+      {% if is_slmicro_6_2 and grains.get('scc_slmicro_pass') %}
+      - cmd: register_to_scc
+      - cmd: apply_transition_scc
+      {% endif %}
 
 {% if is_tumbleweed %}
 rke2_selinux_install:


### PR DESCRIPTION
## What does this PR change?

Register slmicro 6.2 to SCC to install RKE2 on it. Since some weeks ago I can't install RKE2 on top of slmicro 6.2 if the machine is not registered to SCC, so I need to do it for the pipelines.