### PR TITLE
Move the prometheus_push_gateway_url variable to the main.tf file and…

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -83,6 +83,7 @@ module "controller" {
     product_version           = local.product_version
     container_runtime         = lookup(var.server_configuration, "runtime", "")
     catch_timeout_message     = var.catch_timeout_message
+    prometheus_push_gateway_url = var.prometheus_push_gateway_url
     beta_enabled              = var.beta_enabled
     web_server_hostname       = var.web_server_hostname
     install_kubectl_helm      = var.install_kubectl_helm

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -885,6 +885,12 @@ variable "catch_timeout_message" {
   default     = false
 }
 
+variable "prometheus_push_gateway_url" {
+  description = "URL of the Prometheus push gateway for quality intelligence metrics"
+  type        = string
+  default     = null
+}
+
 variable "beta_enabled" {
   description = "Enable the mechanism to take into account beta channels"
   default     = false

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -632,6 +632,8 @@ module "controller" {
   install_kubectl_helm     = var.install_kubectl_helm
   kubeconfig_path          = var.kubeconfig_path
 
+  prometheus_push_gateway_url = var.prometheus_push_gateway_url
+
   additional_repos  = lookup(local.additional_repos, "controller", {})
   additional_repos_only  = lookup(local.additional_repos_only, "controller", false)
   additional_packages = lookup(local.additional_packages, "controller", [])

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -288,3 +288,9 @@ variable "use_os_released_updates" {
   description = "Apply all updates from SUSE Linux Enterprise repos"
   default     = false
 }
+
+variable "prometheus_push_gateway_url" {
+  description = "URL of the Prometheus push gateway for quality intelligence metrics"
+  type        = string
+  default     = null
+}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -269,6 +269,12 @@ export PRODUCT="SUSE Multi-Linux Manager"
 # Ruby specific settings
 export GEM_PATH="/usr/lib64/ruby/gems/3.3.0"
 
+{% if grains.get('prometheus_push_gateway_url') | default(false, true) %}
+export QUALITY_INTELLIGENCE="true"
+export PROMETHEUS_PUSH_GATEWAY_URL="{{ grains.get('prometheus_push_gateway_url') }}"
+{% else %}# no Quality Intelligence configured
+{% endif %}
+
 #### Generate certificates for Google Chrome
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then
   wget http://$SERVER/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$SERVER.cert


### PR DESCRIPTION

## What does this PR change?

Add native support for Quality Intelligence environment variables on the controller

Move the configuration of QUALITY_INTELLIGENCE and PROMETHEUS_PUSH_GATEWAY_URL environment variables from a null_resource remote-exec provisioner in the CI files into sumaform itself, using the existing Salt/grains mechanism.

##  Changes

  - modules/cucumber_testsuite/variables.tf — add prometheus_push_gateway_url variable (optional, defaults to null)
  - modules/cucumber_testsuite/main.tf — pass prometheus_push_gateway_url to the controller module
  - modules/controller/variables.tf — add prometheus_push_gateway_url variable
  - modules/controller/main.tf — expose prometheus_push_gateway_url as a Salt grain
  - salt/controller/bashrc — render QUALITY_INTELLIGENCE=true and PROMETHEUS_PUSH_GATEWAY_URL conditionally when the grain is set

##  Why

The CI files were using a null_resource with triggers = { always_run = timestamp() } and an SSH remote-exec provisioner to append these variables to ~/.bashrc after provisioning. This approach has several drawbacks: it requires an extra SSH pass after Salt has already run, it re-executes on every terraform apply (even when nothing changed), and it duplicates logic that sumaform already handles natively through Salt grains and the bashrc Jinja template.

With this change, the variables are set once at provisioning time alongside all other controller environment variables. CI files only need to pass prometheus_push_gateway_url = var.PROMETHEUS_PUSH_GATEWAY_URL to the cucumber_testsuite module and can drop the null_resource block entirely.