### PR TITLE
Adapt to sles161 hypervisors

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -226,7 +226,7 @@ resource "libvirt_domain" "domain" {
   }
 
   graphics {
-    type        = "spice"
+    type        = "vnc"
     listen_type = "address"
     listen_address = "0.0.0.0"
     autoport    = true


### PR DESCRIPTION
## What does this PR change?

Adapt to sles 16.1 hypervisors (suma-13, and soon suma-01), where spice is not supported by qemu anymore.
