### PR TITLE
AWS remove Leap 15.6 image and setup Leap 16.0

### DIFF
--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -37,6 +37,8 @@ runcmd:
 
 %{ if image == "opensuse160o" ~}
 runcmd:
+  - zypper addrepo -G -e http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_16-Uyuni-Client-Tools/openSUSE_Leap_16.0/ client_tools_tmp
+  - zypper ref
 %{ if install_salt_bundle ~}
   - zypper in --allow-vendor-change --no-confirm venv-salt-minion
 %{ else ~}

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -143,6 +143,7 @@ install_gems_via_bundle:
       - pkg: cucumber_requisites
       - cmd: spacewalk_git_repository
 
+
 # https://github.com/WasiqB/multiple-cucumber-html-reporter
 # Replaces cucumber-html-reporter
 # Preserves JSON execution order, supports filter by passed/failed/skipped

--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -35,20 +35,20 @@ change_searchlist_netconfig:
     - name: /etc/sysconfig/network/config
     - pattern: NETCONFIG_DNS_STATIC_SEARCHLIST=.*
     - repl: NETCONFIG_DNS_STATIC_SEARCHLIST="{{ grains['domain'] }}"
-    - onlyif: test -f /etc/sysconfig/network/config
+    - onlyif: test -f /etc/sysconfig/network/config && command -v netconfig
 
 netconfig_update:
   cmd.run:
     - name: netconfig update -f
     - require:
       - file: change_searchlist_netconfig
-    - onlyif: test -f /etc/sysconfig/network/config
+    - onlyif: test -f /etc/sysconfig/network/config && command -v netconfig
 
 change_searchlist:
   file.append:
     - name: /etc/resolv.conf
     - text: search {{ grains['domain'] }}
-    - unless: test -f /etc/sysconfig/network/config
+    - unless: test -f /etc/sysconfig/network/config && command -v netconfig
 
 # set the hostname and FQDN name in /etc/hosts
 # this is not needed if a proper DNS server is in place, but when using avahi this

--- a/salt/repos/ruby.sls
+++ b/salt/repos/ruby.sls
@@ -1,4 +1,5 @@
 {% if grains['os'] == 'SUSE' and ('controller' in grains.get('roles')) %}
+{% set repo_version = grains['osrelease'] %}
 
 ruby_add_devel_repository:
     pkgrepo.managed:

--- a/salt/repos/tools.sls
+++ b/salt/repos/tools.sls
@@ -6,7 +6,7 @@
 ) %}
 
 {% if grains['osfullname'] == 'Leap' %}
-{% set path = 'openSUSE_Leap_' + grains['osrelease'] %}
+{% set path = grains['osrelease'] if grains['osrelease'] == '16.0' else 'openSUSE_Leap_' + grains['osrelease'] %}
 {% endif %}
 
 {% if grains['osfullname'] != 'Leap' %}


### PR DESCRIPTION
## What does this PR change?

Leap 15.6 is no longer available in AWS.
Our controller needs to use Leap 16.0 there, so the PR takes care of doing some setups for that too.

This involves:

- Adding the possibility to use an arbitrary image for the controller instead of harcoding one. Leap 15.6 is still preserved as default.

- Adding and handling the Sumaform and Uyuni tools repos for Leap 16.0

- Leap 16.0 dropped the old network stack, so we need to check for netconfig to be actually available

- `apache2-mod_nss` is not available in Leap 16.0. **According to Gemini** it should not be necessary for our needs also on old images, it was only used to setup some apache2 directories paths ---> needs to be properly checked

- Adding healthcheck tool repo for Leap 16.0 - the proper one is not yet available, so we use Tumbleweed for the time being

- Adding Ruby repositories for Leap 16.0 and the corresponding Ruby version
