### PR TITLE
Correctly detect avahi ip during provisioning

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -265,18 +265,40 @@ resource "terraform_data" "provisioning" {
   }
 
   provisioner "local-exec" {
+    environment = {
+      HOST          = local.overwrite_fqdn != "" ? local.overwrite_fqdn : "${libvirt_domain.domain[count.index].name}.${var.base_configuration["domain"]}"
+      IP_FROM_LEASE = local.overwrite_fqdn == "" ? join(" ", libvirt_domain.domain[count.index].network_interface[0].addresses) : ""
+    }
     command = <<-EOF
-      HOST="${local.overwrite_fqdn != "" ? local.overwrite_fqdn : "${libvirt_domain.domain[count.index].name}.${var.base_configuration["domain"]}"}"
+      IP=""
 
-      # 1) Resolve via nsswitch (/etc/hosts, mDNS, DNS...) - IPv4 only
-      IP=$(getent ahostsv4 "$HOST" 2>/dev/null | awk '{print $1; exit}')
+      # 1) Use IP from libvirt DHCP lease (works for local, static-DHCP, and Avahi setups
+      #    since Avahi VMs still get a DHCP IP — avoids mDNS resolution on the Terraform host)
+      if [ -n "$IP_FROM_LEASE" ]; then
+        for addr in $IP_FROM_LEASE; do
+          if echo "$addr" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
+            IP="$addr"
+            break
+          fi
+        done
+      fi
 
-      # 2) Fallback: direct DNS query
+      # 2) Resolve via nsswitch (/etc/hosts, mDNS, DNS...) - IPv4 only
+      if [ -z "$IP" ]; then
+        IP=$(getent ahostsv4 "$HOST" 2>/dev/null | awk '{print $1; exit}')
+      fi
+
+      # 3) avahi-resolve fallback for .local domains (when lease IP unavailable)
+      if [ -z "$IP" ] && command -v avahi-resolve >/dev/null 2>&1; then
+        IP=$(avahi-resolve --name "$HOST" 2>/dev/null | awk '{print $2}' | head -1)
+      fi
+
+      # 4) Direct DNS query fallback
       if [ -z "$IP" ]; then
         IP=$(host -t A "$HOST" 2>/dev/null | awk '/has address/{print $4}' | head -1)
       fi
 
-      # 3) Last resort: let nc resolve the name itself, forced to IPv4
+      # 5) Last resort: let nc resolve the name itself, forced to IPv4
       if [ -z "$IP" ]; then
         echo "WARN: could not pre-resolve $HOST to an IPv4 address, trying by name" >&2
         IP="$HOST"


### PR DESCRIPTION
## What does this PR change?

Fix SSH wait provisioner to support Avahi (mDNS) deployments

## Problem

When use_avahi = true, the VM hostname resolves to a .local mDNS address (e.g. uyuni-server.tf.local). The previous provisioner relied on getent ahostsv4 and host -t A to resolve it,  both go through standard DNS and cannot resolve mDNS multicast names, causing the SSH wait to always time out: `ERROR: timed out waiting for SSH on uyuni-server.tf.local (uyuni-server.tf.local)`

##  Root cause

mDNS (.local) is multicast-based and requires nss-mdns to be configured on the host running Terraform. This is not guaranteed and standard DNS tools cannot see it.

##  Fix

Since VMs already have qemu_agent = true and wait_for_lease = true, libvirt knows the DHCP-assigned IP via the QEMU guest agent, even for Avahi VMs (Avahi is an additional naming layer on top of DHCP, not a replacement). We now pass that IP directly to the provisioner via an environment variable, bypassing name resolution entirely.

##  Resolution order:
  1. libvirt DHCP lease IP (new — primary path, works for local/static-DHCP/Avahi)
  2. getent ahostsv4 — nsswitch chain
  3. avahi-resolve --name — explicit mDNS fallback if lease not available
  4. host -t A — standard DNS fallback
  5. Raw hostname — last resort (previous behavior)
