### PR TITLE
Rename container_repository to container_registry

### DIFF
--- a/.github/workflows/ci-validation/salt-server-containerized-validation
+++ b/.github/workflows/ci-validation/salt-server-containerized-validation
@@ -47,7 +47,7 @@ create_sample_activation_key: true
 create_sample_bootstrap_script: true
 publish_private_ssl_key: true
 testsuite: true
-container_repository: containers.example.com
+container_registry: containers.example.com
 container_runtime: podman
 provision: true
 EOF

--- a/README_BUILD_VALIDATION_MODULE.md
+++ b/README_BUILD_VALIDATION_MODULE.md
@@ -197,6 +197,6 @@ This file is passed to Terraform alongside the tfvars file and the wrapper templ
 
 ## Relationship to susemanager-ci
 
-All environment-specific configuration is stored in susemanager-ci. Before deploying, the Jenkins pipeline runs `prepare_tfvars.py` to assemble the final `terraform.tfvars` from the static per-environment tfvars file, `location.tfvars`, and dynamic values injected from Jenkins (container repositories, Cucumber branch, product version overrides, etc.).
+All environment-specific configuration is stored in susemanager-ci. Before deploying, the Jenkins pipeline runs `prepare_tfvars.py` to assemble the final `terraform.tfvars` from the static per-environment tfvars file, `location.tfvars`, and dynamic values injected from Jenkins (container registries, Cucumber branch, product version overrides, etc.).
 
 See the [susemanager-ci terracumber_config README](https://github.com/SUSE/susemanager-ci/blob/master/terracumber_config/README.md) for the full picture of how configuration flows from susemanager-ci into this module.

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -114,7 +114,7 @@ module "cucumber_testsuite" {
       # runtime = "podman"
 
       # Override where to get the containers from
-      # container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
+      # container_registry = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
 
       # Override the default image names for Server and Database containers
       # container_image = "server"

--- a/main.tf.libvirt.example
+++ b/main.tf.libvirt.example
@@ -49,8 +49,8 @@ module "server" {
   // If you want to run the containers on podman.
   // runtime = "podman"
 
-  // To override the default container repository containing the images
-  // container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/containers/uyuni"
+  // To override the default container registry containing the images
+  // container_registry = "registry.opensuse.org/systemsmanagement/uyuni/master/servercontainer/containers/uyuni"
 
   // To override the default images names for Server and Database containers
   // container_image = "server"

--- a/main.tf.libvirt.rke.example
+++ b/main.tf.libvirt.rke.example
@@ -121,7 +121,7 @@ module "cucumber_testsuite" {
       # runtime = "rke2"
 
       # Override where to get the containers from
-      # container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
+      # container_registry = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
 
       # Name of the helm chart. The last sting of the OCI url.
       # helm_chart_name = "server-helm"
@@ -143,7 +143,7 @@ module "cucumber_testsuite" {
       # runtime = "rke2"
 
       # Override where to get the containers from
-      # container_repository = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
+      # container_registry = "registry.opensuse.org/systemsmanagement/uyuni/master/containers/uyuni"
 
       # Name of the helm chart. The last sting of the OCI url.
       # helm_chart_name = "proxy-helm"

--- a/modules/build_validation/bv_proxy_containerized/main.tf
+++ b/modules/build_validation/bv_proxy_containerized/main.tf
@@ -10,7 +10,7 @@ module "proxy_containerized" {
   }
   string_registry      = var.string_registry
   runtime              = "podman"
-  container_repository = var.container_repository
+  container_registry   = var.container_registry
   container_tag        = "latest"
   auto_configure       = false
   ssh_key_path         = var.ssh_key_path

--- a/modules/build_validation/bv_proxy_containerized/variables.tf
+++ b/modules/build_validation/bv_proxy_containerized/variables.tf
@@ -22,7 +22,7 @@ variable "string_registry" {
   type        = bool
 }
 
-variable "container_repository" {
+variable "container_registry" {
   description = "where to find the proxy container images"
   default     = ""
 }

--- a/modules/build_validation/bv_server_containerized/main.tf
+++ b/modules/build_validation/bv_server_containerized/main.tf
@@ -10,7 +10,7 @@ module "server_containerized" {
     vcpu   = var.vcpu
   }
   runtime              = "podman"
-  container_repository = var.container_repository
+  container_registry   = var.container_registry
   container_image      = var.container_image
   main_disk_size       = 100
 

--- a/modules/build_validation/bv_server_containerized/variables.tf
+++ b/modules/build_validation/bv_server_containerized/variables.tf
@@ -27,7 +27,7 @@ variable "mirror" {
   default     = null
 }
 
-variable "container_repository" {
+variable "container_registry" {
   description = "where to find the server container images"
   default     = ""
 }

--- a/modules/build_validation/main.tf
+++ b/modules/build_validation/main.tf
@@ -119,7 +119,7 @@ module "server_containerized" {
     vcpu   = 10
   }
   runtime              = "podman"
-  container_repository = var.server_container_repository
+  container_registry   = var.server_container_registry
   container_image      = var.server_container_image
   main_disk_size       = 100
 
@@ -162,7 +162,7 @@ module "server2_containerized" {
   image              = var.base_os != null ? var.base_os : var.environment_configuration.server2_containerized.image
   string_registry    = var.environment_configuration.server2_containerized.string_registry
   mirror             = var.platform_location_configuration[var.location].mirror
-  container_repository = var.server_container_repository
+  container_registry   = var.server_container_registry
   container_image      = var.server_container_image
   additional_repos   = var.server_additional_repos
   ssh_key_path       = var.controller_public_ssh_key_path
@@ -177,7 +177,7 @@ module "server3_containerized" {
   image              = var.base_os != null ? var.base_os : var.environment_configuration.server3_containerized.image
   string_registry    = var.environment_configuration.server3_containerized.string_registry
   mirror             = var.platform_location_configuration[var.location].mirror
-  container_repository = var.server_container_repository
+  container_registry   = var.server_container_registry
   container_image      = var.server_container_image
   additional_repos   = var.server_additional_repos
   ssh_key_path       = var.controller_public_ssh_key_path
@@ -192,7 +192,7 @@ module "server4_containerized" {
   image              = var.base_os != null ? var.base_os : var.environment_configuration.server4_containerized.image
   string_registry    = var.environment_configuration.server4_containerized.string_registry
   mirror             = var.platform_location_configuration[var.location].mirror
-  container_repository = var.server_container_repository
+  container_registry   = var.server_container_registry
   container_image      = var.server_container_image
   additional_repos   = var.server_additional_repos
   ssh_key_path       = var.controller_public_ssh_key_path
@@ -236,7 +236,7 @@ module "proxy_containerized" {
   }
   string_registry      = var.environment_configuration.proxy_containerized.string_registry
   runtime              = "podman"
-  container_repository = var.proxy_container_repository
+  container_registry   = var.proxy_container_registry
   container_tag        = "latest"
   auto_configure       = false
   ssh_key_path         = var.controller_public_ssh_key_path
@@ -254,7 +254,7 @@ module "proxy2_containerized" {
   mac                = var.environment_configuration.proxy2_containerized.mac
   image              = var.base_os != null ? var.base_os : var.environment_configuration.proxy2_containerized.image
   string_registry    = var.environment_configuration.proxy2_containerized.string_registry
-  container_repository = var.proxy_container_repository
+  container_registry   = var.proxy_container_registry
   additional_repos   = var.proxy_additional_repos
   ssh_key_path       = var.controller_public_ssh_key_path
 }
@@ -268,7 +268,7 @@ module "proxy3_containerized" {
   mac                = var.environment_configuration.proxy3_containerized.mac
   image              = var.base_os != null ? var.base_os : var.environment_configuration.proxy3_containerized.image
   string_registry    = var.environment_configuration.proxy3_containerized.string_registry
-  container_repository = var.proxy_container_repository
+  container_registry   = var.proxy_container_registry
   additional_repos   = var.proxy_additional_repos
   ssh_key_path       = var.controller_public_ssh_key_path
 }

--- a/modules/build_validation/variables.tf
+++ b/modules/build_validation/variables.tf
@@ -57,7 +57,7 @@ variable "scc_ptf_password" {
   default = null
 }
 
-variable "server_container_repository" {
+variable "server_container_registry" {
   type = string
   description = "Server container registry path, not needed for 4.3"
   default = ""
@@ -69,7 +69,7 @@ variable "server_additional_repos" {
   default     = {}
 }
 
-variable "proxy_container_repository" {
+variable "proxy_container_registry" {
   type = string
   description = "Proxy container registry path, not needed for 4.3"
   default = ""

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -49,8 +49,8 @@ locals {
     host_key => lookup(var.host_settings[host_key], "sles_registration_code", null) if var.host_settings[host_key] != null }
   runtimes                  = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "runtime", "podman") if var.host_settings[host_key] != null }
-  container_repositories    = { for host_key in local.hosts :
-    host_key => lookup(var.host_settings[host_key], "container_repository", null) if var.host_settings[host_key] != null }
+  container_registries      = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "container_registry", null) if var.host_settings[host_key] != null }
   container_images    = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "container_image", null) if var.host_settings[host_key] != null }
   httpd_container_images = { for host_key in local.hosts :
@@ -69,8 +69,8 @@ locals {
     host_key => lookup(var.host_settings[host_key], "tftpd_container_tag", null) if var.host_settings[host_key] != null }
   container_tags    = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "container_tag", null) if var.host_settings[host_key] != null }
-  db_container_repositories    = { for host_key in local.hosts :
-    host_key => lookup(var.host_settings[host_key], "db_container_repository", null) if var.host_settings[host_key] != null }
+  db_container_registries      = { for host_key in local.hosts :
+    host_key => lookup(var.host_settings[host_key], "db_container_registry", null) if var.host_settings[host_key] != null }
   db_container_images    = { for host_key in local.hosts :
     host_key => lookup(var.host_settings[host_key], "db_container_image", null) if var.host_settings[host_key] != null }
   db_container_tags    = { for host_key in local.hosts :
@@ -178,10 +178,10 @@ module "server_containerized" {
   image                          = lookup(local.images, "server_containerized", "default")
   name                           = lookup(local.names, "server_containerized", "server")
   runtime                        = lookup(local.runtimes, "server_containerized", "podman")
-  container_repository           = lookup(local.container_repositories, "server_containerized", "")
+  container_registry             = lookup(local.container_registries, "server_containerized", "")
   container_image                = lookup(local.container_images, "server_containerized", "")
   container_tag                  = lookup(local.container_tags, "server_containerized", "")
-  db_container_repository        = lookup(local.db_container_repositories, "server_containerized", "")
+  db_container_registry          = lookup(local.db_container_registries, "server_containerized", "")
   db_container_image             = lookup(local.db_container_images, "server_containerized", "")
   db_container_tag               = lookup(local.db_container_tags, "server_containerized", "")
   deploy_coco_attestation        = var.deploy_coco_attestation
@@ -238,10 +238,10 @@ module "server_kubernetes" {
   image                          = lookup(local.images, "server_kubernetes", "default")
   name                           = lookup(local.names, "server_kubernetes", "server")
   runtime                        = lookup(local.runtimes, "server_kubernetes", "podman")
-  container_repository           = lookup(local.container_repositories, "server_kubernetes", "")
+  container_registry             = lookup(local.container_registries, "server_kubernetes", "")
   container_image                = lookup(local.container_images, "server_kubernetes", "")
   container_tag                  = lookup(local.container_tags, "server_kubernetes", "")
-  db_container_repository        = lookup(local.db_container_repositories, "server_kubernetes", "")
+  db_container_registry          = lookup(local.db_container_registries, "server_kubernetes", "")
   db_container_image             = lookup(local.db_container_images, "server_kubernetes", "")
   db_container_tag               = lookup(local.db_container_tags, "server_kubernetes", "")
   beta_enabled                   = var.beta_enabled
@@ -332,7 +332,7 @@ module "proxy_containerized" {
   name                   = lookup(local.names, "proxy_containerized", "proxy")
 
   runtime                = lookup(local.runtimes, "proxy_containerized", "podman")
-  container_repository   = lookup(local.container_repositories, "proxy_containerized", "")
+  container_registry     = lookup(local.container_registries, "proxy_containerized", "")
   httpd_container_image  = lookup(local.httpd_container_images, "proxy_containerized", "")
   salt_broker_container_image = lookup(local.salt_broker_container_images, "proxy_containerized", "")
   squid_container_image  = lookup(local.squid_container_images, "proxy_containerized", "")
@@ -370,7 +370,7 @@ module "proxy_kubernetes" {
   name                   = lookup(local.names, "proxy_kubernetes", "proxy")
 
   runtime                = lookup(local.runtimes, "proxy_kubernetes", "podman")
-  container_repository   = lookup(local.container_repositories, "proxy_kubernetes", "")
+  container_registry     = lookup(local.container_registries, "proxy_kubernetes", "")
   httpd_container_image  = lookup(local.httpd_container_images, "proxy_kubernetes", "")
   salt_broker_container_image = lookup(local.salt_broker_container_images, "proxy_kubernetes", "")
   squid_container_image  = lookup(local.squid_container_images, "proxy_kubernetes", "")

--- a/modules/proxy_containerized/main.tf
+++ b/modules/proxy_containerized/main.tf
@@ -47,7 +47,7 @@ module "proxy_containerized" {
     server_password           = var.server_configuration["password"]
     auto_configure            = var.auto_configure
     container_runtime         = var.runtime
-    container_repository      = var.container_repository
+    container_registry        = var.container_registry
     string_registry           = var.string_registry
     httpd_container_image     = var.httpd_container_image
     salt_broker_container_image = var.salt_broker_container_image
@@ -74,7 +74,7 @@ output "configuration" {
     username             = var.server_configuration["username"]
     password             = var.server_configuration["password"]
     runtime              = var.runtime
-    container_repository = var.container_repository
+    container_registry   = var.container_registry
     auto_configure       = var.auto_configure
   }
 }

--- a/modules/proxy_containerized/variables.tf
+++ b/modules/proxy_containerized/variables.tf
@@ -18,7 +18,7 @@ variable "runtime" {
   default = "podman"
 }
 
-variable "container_repository" {
+variable "container_registry" {
   description = "Where to find the proxy container images. Uses the released ones per default."
   default = ""
 }

--- a/modules/proxy_kubernetes/main.tf
+++ b/modules/proxy_kubernetes/main.tf
@@ -43,7 +43,7 @@ module "proxy_kubernetes" {
     server_password                 = var.server_configuration["password"]
     auto_configure                  = var.auto_configure
     container_runtime               = var.runtime
-    container_repository            = var.container_repository
+    container_registry              = var.container_registry
     string_registry                 = var.string_registry
     httpd_container_image           = var.httpd_container_image
     salt_broker_container_image     = var.salt_broker_container_image
@@ -80,7 +80,7 @@ output "configuration" {
     username             = var.server_configuration["username"]
     password             = var.server_configuration["password"]
     runtime              = var.runtime
-    container_repository = var.container_repository
+    container_registry   = var.container_registry
     auto_configure       = var.auto_configure
   }
 }

--- a/modules/proxy_kubernetes/variables.tf
+++ b/modules/proxy_kubernetes/variables.tf
@@ -18,7 +18,7 @@ variable "runtime" {
   default = "rke2"
 }
 
-variable "container_repository" {
+variable "container_registry" {
   description = "Where to find the proxy container images. Uses the released ones per default."
   default = ""
 }

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -51,10 +51,10 @@ module "server_containerized" {
 
   grains = {
     container_runtime              = var.runtime
-    container_repository           = var.container_repository
+    container_registry             = var.container_registry
     container_image                = var.container_image
     container_tag                  = var.container_tag
-    db_container_repository        = var.db_container_repository
+    db_container_registry          = var.db_container_registry
     db_container_image             = var.db_container_image
     db_container_tag               = var.db_container_tag
     deploy_saline                  = var.deploy_saline

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -17,7 +17,7 @@ variable "runtime" {
   default = "podman"
 }
 
-variable "container_repository" {
+variable "container_registry" {
   description = "Where to find the server container images. Uses the released ones per default."
   default = ""
 }
@@ -32,7 +32,7 @@ variable "container_tag" {
   default = ""
 }
 
-variable "db_container_repository" {
+variable "db_container_registry" {
   description = "Where to find the server database container images. Uses the released ones per default."
   default = ""
 }

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -46,10 +46,10 @@ module "server_kubernetes" {
 
   grains = {
     container_runtime              = var.runtime
-    container_repository           = var.container_repository
+    container_registry             = var.container_registry
     container_image                = var.container_image
     container_tag                  = var.container_tag
-    db_container_repository        = var.db_container_repository
+    db_container_registry          = var.db_container_registry
     db_container_image             = var.db_container_image
     db_container_tag               = var.db_container_tag
     helm_chart_url                 = var.helm_chart_url

--- a/modules/server_kubernetes/variables.tf
+++ b/modules/server_kubernetes/variables.tf
@@ -17,7 +17,7 @@ variable "runtime" {
   default = "rke2"
 }
 
-variable "container_repository" {
+variable "container_registry" {
   description = "Where to find the server container images. Uses the released ones per default."
   default = ""
 }
@@ -148,7 +148,7 @@ variable "install_local_path_provisioner" {
   default = true
 }
 
-variable "db_container_repository" {
+variable "db_container_registry" {
   description = "Where to find the server database container images. Uses the released ones per default."
   default = ""
 }

--- a/salt/proxy_containerized/init.sls
+++ b/salt/proxy_containerized/init.sls
@@ -35,8 +35,8 @@ ssh_config_proxy_containerized:
     - mode: 700
 
 # Note: In our registries we don't have released and not released versions at this point in time
-{% if grains.get('container_repository') %}
-  {% set container_repository = grains.get('container_repository') %}
+{% if grains.get('container_registry') %}
+  {% set container_registry = grains.get('container_registry') %}
 {% endif %}
 
 {% if grains.get('container_tag') %}
@@ -51,12 +51,12 @@ config_proxy_containerized:
   file.managed:
     - name: /etc/uyuni/uyuni-tools.yaml
     - contents: |
-        {% if container_repository %}
+        {% if container_registry %}
         {% if grains.get('string_registry') | default(false, true) %}
-        registry: {{ container_repository }}
+        registry: {{ container_registry }}
         {% else %}
         registry:
-          host: {{ container_repository }}
+          host: {{ container_registry }}
         {% endif %}
         {% endif %}
         httpd:

--- a/salt/proxy_kubernetes/install_kubernetes_proxy.sls
+++ b/salt/proxy_kubernetes/install_kubernetes_proxy.sls
@@ -50,7 +50,7 @@ copy_values_proxy:
     - context:
       fqdn: {{ grains.get("fqdn")}}
       cert_manager_namespace: {{ cert_manager_namespace}}
-      container_repository:  {{ grains.get("container_repository")}}
+      container_registry:  {{ grains.get("container_registry")}}
 
 transfer_python_management_file:
   file.managed:

--- a/salt/proxy_kubernetes/values_proxy.yaml
+++ b/salt/proxy_kubernetes/values_proxy.yaml
@@ -5,5 +5,5 @@ global:
 certManagerNamespace: {{ cert_manager_namespace }}
 
 proxy-helm: 
-  repository: {{ container_repository }}
+  repository: {{ container_registry }}
   pullPolicy: "Always"

--- a/salt/server_containerized/install_podman.sls
+++ b/salt/server_containerized/install_podman.sls
@@ -18,7 +18,7 @@ podman_packages:
 {% if 'paygo' not in grains.get('product_version') | default('', true) %}
 podman_login:
   cmd.run:
-    - name: podman login -u {{ grains.get('cc_username') }} -p {{ grains.get('cc_password') }} {{ grains.get("container_repository") }}
+    - name: podman login -u {{ grains.get('cc_username') }} -p {{ grains.get('cc_password') }} {{ grains.get("container_registry") }}
 {% endif %}
 
 # WORKAROUND: see github:saltstack/salt#10852

--- a/salt/server_containerized/mgradm.yaml
+++ b/salt/server_containerized/mgradm.yaml
@@ -10,17 +10,17 @@ scc:
 {% endif %}
 email: {{ grains.get("traceback_email") | default('galaxy-noise@suse.de', true) }}
 emailFrom: {{ grains.get("from_email") | default('galaxy-noise@suse.de', true) }}
-{%- if grains.get('container_repository') %}
+{%- if grains.get('container_registry') %}
 {# WORKAROUND for https://bugzilla.suse.com/show_bug.cgi?id=1254589                            #}
 {# This should be supported by mgradm install podman --config, but currently fails in 5.0.6 BV #}
 {# {%- if 'released' in grains['product_version'] %}                                           #}
-{# registry: {{ grains.get('container_repository') }}                                          #}
+{# registry: {{ grains.get('container_registry') }}                                            #}
 {# {% else %}                                                                                  #}
   {% if grains.get('string_registry') | default(false, true) %}
-registry: {{ grains.get('container_repository') }}
+registry: {{ grains.get('container_registry') }}
   {% else %}
 registry:
-  host: {{ grains.get('container_repository') }}
+  host: {{ grains.get('container_registry') }}
   {% endif %}
 {% endif %}
 {# {% endif %}                                                                                 #}
@@ -32,8 +32,8 @@ tag: {{ grains.get('container_tag') }}
 {% endif %}
 {%- if grains.get('db_container_image') or grains.get('db_container_tag') %}
 pgsql:
-  {%- if grains.get('db_container_repository') %}
-  registry: {{ grains.get('db_container_repository') }}
+  {%- if grains.get('db_container_registry') %}
+  registry: {{ grains.get('db_container_registry') }}
   {% endif %}
   {%- if grains.get('db_container_image') %}
   image: {{ grains.get('db_container_image') }}

--- a/salt/server_kubernetes/install_kubernetes_server.sls
+++ b/salt/server_kubernetes/install_kubernetes_server.sls
@@ -63,7 +63,7 @@ copy_value_yaml_file:
         pass_reportdb: admin
         fqdn: {{ grains.get("fqdn") }}
         cert_manager_namespace: {{ cert_manager_namespace }}
-        container_repository: {{ grains.get("container_repository")}}
+        container_registry: {{ grains.get("container_registry")}}
         deploy_coco_attestation: {{ grains.get("deploy_coco_attestation") }}
         coco_container_image: {{ grains.get("coco_container_image") }}
         coco_container_tag: {{ grains.get("coco_container_tag") }}

--- a/salt/server_kubernetes/values_server.yaml
+++ b/salt/server_kubernetes/values_server.yaml
@@ -41,7 +41,7 @@ certManagerNamespace: {{ cert_manager_namespace }}
 
 # All the server helm chart values can be passed under this property
 server-helm: 
-  repository: {{ container_repository }}
+  repository: {{ container_registry }}
   pullPolicy: "Always"
 {% if deploy_tftp %}
   tftp:


### PR DESCRIPTION
## What does this PR change?

Rename the container_repository variable and grain (and the
db_/server_/proxy_ variants) to container_registry across Terraform
modules, Salt states, examples, CI, and docs.

sumaform part of card: https://github.com/SUSE/spacewalk/issues/27332
