### PR TITLE
Remove EOL opensuse156o client tools repo

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -158,17 +158,12 @@ runcmd:
 %{ endif ~}
 %{ endif ~}
 
-%{ if image == "opensuse156o" || image == "opensuse160o" ~}
+%{ if image == "opensuse160o" ~}
 
 zypper:
   repos:
     - id: tools_pool_repo
-%{ if image == "opensuse156o" ~}
-      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
-%{ endif ~}
-%{ if image == "opensuse160o" ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_16-Uyuni-Client-Tools/openSUSE_Leap_16.0/
-%{ endif ~}
       enabled: true
       gpgcheck: false
       name: tools_pool_repo


### PR DESCRIPTION
## What does this PR change?

openSUSE Leap 15.6 (`opensuse156o`) is EOL, so this drops its client tools repository configuration in `backend_modules/libvirt/host/user_data.yaml`.

The block previously handled both `opensuse156o` and `opensuse160o`; it now only handles `opensuse160o` (the redundant inner conditional was collapsed).

Follow-up to a review comment from @mcalmer on #2172.