### PR TITLE
Revert "Remove EOL opensuse156o client tools repo"

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -158,12 +158,17 @@ runcmd:
 %{ endif ~}
 %{ endif ~}
 
-%{ if image == "opensuse160o" ~}
+%{ if image == "opensuse156o" || image == "opensuse160o" ~}
 
 zypper:
   repos:
     - id: tools_pool_repo
+%{ if image == "opensuse156o" ~}
+      baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+%{ endif ~}
+%{ if image == "opensuse160o" ~}
       baseurl: http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_16-Uyuni-Client-Tools/openSUSE_Leap_16.0/
+%{ endif ~}
       enabled: true
       gpgcheck: false
       name: tools_pool_repo


### PR DESCRIPTION
Reverts uyuni-project/sumaform#2210

The previous PR broke deployments because it affected the controller and no venv-salt-minion was available. 