### PR TITLE
Rename ssh_minion grain/env var to sshminion

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -63,7 +63,7 @@ module "controller" {
     build_host        = length(var.buildhost_configuration["hostnames"]) > 0 ? var.buildhost_configuration["hostnames"][0] : null
     redhat_minion     = length(var.redhat_configuration["hostnames"]) > 0 ? var.redhat_configuration["hostnames"][0] : null
     debian_minion     = length(var.debian_configuration["hostnames"]) > 0 ? var.debian_configuration["hostnames"][0] : null
-    ssh_minion        = length(var.sshminion_configuration["hostnames"]) > 0 ? var.sshminion_configuration["hostnames"][0] : null
+    sshminion         = length(var.sshminion_configuration["hostnames"]) > 0 ? var.sshminion_configuration["hostnames"][0] : null
     pxeboot_mac       = var.pxeboot_configuration["private_mac"]
     kvm_host          = length(var.kvmhost_configuration["hostnames"]) > 0 ? var.kvmhost_configuration["hostnames"][0] : null
     monitoring_server = length(var.monitoringserver_configuration["hostnames"]) > 0 ? var.monitoringserver_configuration["hostnames"][0] : null

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -20,7 +20,7 @@ export SERVER="{{ grains.get('server') }}"
 {% endif %}
 {% if grains.get('build_host') | default(false, true) %}export BUILD_HOST="{{ grains.get('build_host') }}"{% else %}# no build host defined
 {% endif %}
-{% if grains.get('ssh_minion') | default(false, true) %}export SSH_MINION="{{ grains.get('ssh_minion') }}" {% else %}# no SSH minion defined
+{% if grains.get('sshminion') | default(false, true) %}export SSHMINION="{{ grains.get('sshminion') }}" {% else %}# no SSH minion defined
 {% endif %}
 {% if grains.get('redhat_minion') | default(false, true) %}export RHLIKE_MINION="{{ grains.get('redhat_minion') }}" {%
 else %}# no RedHat-like minion defined {% endif %}


### PR DESCRIPTION
## What does this PR change?

Renames the **generic** (non-BV) SSH minion naming to match the testsuite and CI:

- `modules/controller/main.tf`: grain key `ssh_minion` → `sshminion`
- `salt/controller/bashrc`: `grains.get('ssh_minion')` → `grains.get('sshminion')` and the exported controller env var `SSH_MINION` → `SSHMINION`

The build-validation `sshminion` modules were already renamed (#1662); this is the last place still using the old `ssh_minion` / `SSH_MINION` form. `ssh_minion_opts` in `salt/server/master-custom.conf` is a Salt master configuration key and is intentionally left unchanged.

Part of Epic SUSE/spacewalk#25062 (Minion Name Standardization).

### ⚠️ Merge coordination
All product versions consume sumaform **master**, so this env-var rename must land together with the testsuite PRs that switch `constants.rb` to read `SSHMINION`. **Merge this PR first**, then:
- uyuni-project/uyuni#12279 (master)
- SUSE/spacewalk#31271 (Manager-5.2), SUSE/spacewalk#31272 (Manager-5.1), SUSE/spacewalk#31273 (Manager-5.0), SUSE/spacewalk#31274 (Manager-4.3)
