### PR TITLE
Add possibility to override mirror grain in build validation

### DIFF
--- a/modules/build_validation/bv_server_containerized/main.tf
+++ b/modules/build_validation/bv_server_containerized/main.tf
@@ -19,6 +19,7 @@ module "server_containerized" {
   database_disk_size             = var.database_disk_size
   container_tag                  = "latest"
   beta_enabled                   = false
+  mirror                         = var.mirror
   server_mounted_mirror          = var.mirror
   java_debugging                 = true
   auto_accept                    = false

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -72,7 +72,7 @@ module "server_containerized" {
     cc_username                    = var.base_configuration["cc_username"]
     cc_password                    = var.base_configuration["cc_password"]
     channels                       = var.channels
-    mirror                         = var.base_configuration["mirror"]
+    mirror                         = var.mirror != null ? var.mirror : var.base_configuration["mirror"]
     server_mounted_mirror          = var.server_mounted_mirror
     server_username                = var.server_username
     server_password                = var.server_password

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -394,6 +394,11 @@ variable "volume_provider_settings" {
   default     = {}
 }
 
+variable "mirror" {
+  description = "Override for the mirror grain, defaults to base_configuration mirror"
+  default     = null
+}
+
 variable "server_mounted_mirror" {
   description = "hostname of a mounted mirror in the server (to get packages from it)"
   default     = null


### PR DESCRIPTION
## What does this PR change?

For peripheral server, mirror should not be configure so the server try to sync from hub.
Currently, mirror is set a the base level, this will not work if you need it for server hub and not peripheral
Add possibility to overwrite the mirror with local value