### PR TITLE
Skip workaround for MLMTools-Beta-Ubuntu in head release

### DIFF
--- a/salt/repos/client_tools/client_tools_mlm.sls
+++ b/salt/repos/client_tools/client_tools_mlm.sls
@@ -400,6 +400,7 @@ additional_tools_update_repo_raised_priority:
             Pin: release l=Devel:Galaxy:Manager:Stable:MLMTools-Ubuntu{{ release }}
             Pin-Priority: 800
 
+{# workaround: disable because of https://bugzilla.suse.com/show_bug.cgi?id=1271613
 {% elif 'head' == grains.get('product_version') | default('', true) %}
 
 {% set additional_tools_update_repo = 'http://' + grains.get("mirror") | default("dist.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-Ubuntu' + release + '/xUbuntu_' + release + '-debbuild' %}
@@ -418,6 +419,7 @@ tools_additional_tools_update_repo:
             Package: *
             Pin: release l=Devel:Galaxy:Manager:Main:MLMTools-Beta-Ubuntu{{ release }}
             Pin-Priority: 800
+#}
 
 {% endif %} {# Devel Tools Repos #}
 {% endif %} {# grains['os'] == 'Ubuntu' #}

--- a/salt/repos/client_tools/client_tools_mlm.sls
+++ b/salt/repos/client_tools/client_tools_mlm.sls
@@ -400,7 +400,7 @@ additional_tools_update_repo_raised_priority:
             Pin: release l=Devel:Galaxy:Manager:Stable:MLMTools-Ubuntu{{ release }}
             Pin-Priority: 800
 
-{# workaround: disable because of https://bugzilla.suse.com/show_bug.cgi?id=1271613
+{# WORKAROUND: disable because of https://bugzilla.suse.com/show_bug.cgi?id=1271613
 {% elif 'head' == grains.get('product_version') | default('', true) %}
 
 {% set additional_tools_update_repo = 'http://' + grains.get("mirror") | default("dist.suse.de", true) + '/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-Ubuntu' + release + '/xUbuntu_' + release + '-debbuild' %}


### PR DESCRIPTION
## What does this PR change?
Workaround
Disable beta channel for ubuntu until https://bugzilla.suse.com/show_bug.cgi?id=1271613 is fixed to unlock head pipeline
