### PR TITLE
Change way to list packages

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -40,6 +40,7 @@ runcmd:
 %{ endif ~}
   - zypper --non-interactive install venv-salt-minion avahi avahi-lang openssh-server-config-rootlogin which ca-certificates ca-certificates-suse
   - systemctl restart sshd
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 # end of Tumbleweed block
 %{ endif ~}
 
@@ -74,6 +75,7 @@ runcmd:
 %{ else ~}
   - "yum -y install salt-minion avahi nss-mdns qemu-guest-agent"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "centos8o" ~}
@@ -115,6 +117,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "centos9o" ~}
@@ -156,6 +159,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "opensuse156o" || image == "opensuse160o" ~}
@@ -193,6 +197,7 @@ runcmd:
   - "zypper --non-interactive modifyservice --disable openSUSE || true"
   - "zypper --non-interactive removeservice openSUSE || true"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "sles12sp5o" ~}
@@ -215,6 +220,7 @@ runcmd:
 %{ else ~}
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "sles15sp3o" ~}
@@ -239,6 +245,7 @@ runcmd:
 %{ endif ~}
   # WORKAROUND: cloud-init in SLES 15 SP3 does not take care of the following
   - "systemctl start 'qemu-ga@virtio\\x2dports-org.qemu.guest_agent.0'"
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "sles15sp4o" ~}
@@ -274,6 +281,7 @@ runcmd:
   # the SUSE certificates are needed because of the containerized proxy tests
   - "zypper -n in ca-certificates-suse"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "sles15sp5o" ~}
@@ -296,6 +304,7 @@ runcmd:
 %{ else ~}
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "sles15sp6o" ~}
@@ -318,6 +327,7 @@ runcmd:
 %{ else ~}
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "sles15sp7o" ~}
@@ -341,6 +351,7 @@ runcmd:
   - "zypper -n in avahi avahi-lang nss-mdns qemu-guest-agent iptables"
 %{ endif ~}
   - "zypper -n removerepo --all"
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "sles160o" ~}
@@ -367,6 +378,7 @@ runcmd:
 %{ else ~}
   - "zypper -n in avahi avahi-lang nss-mdns qemu-guest-agent iptables"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "slemicro55o" ~}
@@ -531,6 +543,7 @@ runcmd:
 %{ endif ~}
   - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "ubuntu2404o" ~}
@@ -579,7 +592,8 @@ runcmd:
 %{ endif ~}
   - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
-%{ endif } 
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
+%{ endif }
 
 %{ if image == "debian12o" ~}
 apt:
@@ -662,6 +676,7 @@ runcmd:
 %{ endif ~}
   - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
   - systemctl start qemu-guest-agent
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "almalinux8o" ~}
@@ -686,6 +701,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "almalinux9o" ~}
@@ -713,6 +729,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent dbus-tools"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "almalinux10o" }
@@ -737,6 +754,7 @@ runcmd:
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart sshd
   - "dnf -y install venv-salt-minion avahi nss-mdns qemu-guest-agent dbus-tools"
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif }
 
 %{ if image == "amazonlinux2o" ~}
@@ -764,6 +782,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "amazonlinux2023o" ~}
@@ -799,6 +818,7 @@ runcmd:
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent"
 %{ endif ~}
   - systemctl start qemu-guest-agent
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "libertylinux9o" ~}
@@ -848,6 +868,7 @@ runcmd:
   - dnf -y install salt-minion avahi nss-mdns qemu-guest-agent dbus-tools tar
 %{ endif ~}
   - systemctl enable --now qemu-guest-agent
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "openeuler2403o" ~}
@@ -868,6 +889,7 @@ runcmd:
   - dnf -y install salt-minion avahi nss-mdns qemu-guest-agent
 %{ endif }
   - systemctl start qemu-guest-agent
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif }
 
 %{ if image == "rocky8o" ~}
@@ -893,6 +915,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install avahi nss-mdns salt-minion dbus-tools"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "rocky9o" ~}
@@ -920,6 +943,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install avahi nss-mdns salt-minion dbus-tools"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "rocky10o" }
@@ -947,6 +971,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install avahi nss-mdns qemu-guest-agent salt-minion dbus-tools"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif }
 
 %{ if image == "oraclelinux8o" ~}
@@ -971,6 +996,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install avahi nss-mdns qemu-guest-agent salt-minion"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "oraclelinux9o" ~}
@@ -998,6 +1024,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent dbus-tools tar"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
 %{ if image == "oraclelinux10o" }
@@ -1025,6 +1052,7 @@ runcmd:
 %{ else ~}
   - "dnf -y install salt-minion avahi nss-mdns qemu-guest-agent dbus-tools tar"
 %{ endif ~}
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif }
 
 %{ if image == "opensuse156armo" || image == "opensuse160armo" ~}
@@ -1054,8 +1082,6 @@ runcmd:
   # WORKAROUND: cloud-init in opensuse 15.6 and 16.0 does not take care of the following
   - echo "PermitRootLogin yes" > /etc/ssh/sshd_config.d/root.conf
   - systemctl restart sshd.service
+  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}
 
-runcmd:
-  # Log a list of installed RPM/DEB packages for the debuigging purposes
-  - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"


### PR DESCRIPTION
## What does this PR change?

Fix cloud-init breakage and disabled Ubuntu head repo workaround

`backend_modules/libvirt/host/user_data.yaml`

The standalone runcmd block added at the bottom of the file to log installed packages was breaking cloud-init for all images. YAML does not allow duplicate top-level keys — when an OS-specific block (e.g. ubuntu2404o) already defines runcmd, the unconditional one at the bottom silently replaced it, causing SSH configuration, package installation, and other setup
  steps to be skipped entirely.
