### PR TITLE
Align deblike/rhlike controller configuration and grain names

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -60,8 +60,8 @@ module "controller" {
     client            = length(var.client_configuration["hostnames"]) > 0 ? var.client_configuration["hostnames"][0] : null
     minion            = length(var.minion_configuration["hostnames"]) > 0 ? var.minion_configuration["hostnames"][0] : null
     build_host        = length(var.buildhost_configuration["hostnames"]) > 0 ? var.buildhost_configuration["hostnames"][0] : null
-    redhat_minion     = length(var.redhat_configuration["hostnames"]) > 0 ? var.redhat_configuration["hostnames"][0] : null
-    debian_minion     = length(var.debian_configuration["hostnames"]) > 0 ? var.debian_configuration["hostnames"][0] : null
+    rhlike_minion     = length(var.rhlike_configuration["hostnames"]) > 0 ? var.rhlike_configuration["hostnames"][0] : null
+    deblike_minion    = length(var.deblike_configuration["hostnames"]) > 0 ? var.deblike_configuration["hostnames"][0] : null
     sshminion         = length(var.sshminion_configuration["hostnames"]) > 0 ? var.sshminion_configuration["hostnames"][0] : null
     pxeboot_mac       = var.pxeboot_configuration["private_mac"]
     kvm_host          = length(var.kvmhost_configuration["hostnames"]) > 0 ? var.kvmhost_configuration["hostnames"][0] : null

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -115,15 +115,15 @@ variable "sshminion_configuration" {
   }
 }
 
-variable "redhat_configuration" {
-  description = "use module.<REDHAT_NAME>.configuration, see main.tf.libvirt-testsuite.example"
+variable "rhlike_configuration" {
+  description = "use module.<RHLIKE_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
     hostnames = []
   }
 }
 
-variable "debian_configuration" {
-  description = "use module.<DEBIAN_NAME>.configuration, see main.tf.libvirt-testsuite.example"
+variable "deblike_configuration" {
+  description = "use module.<DEBLIKE_NAME>.configuration, see main.tf.libvirt-testsuite.example"
   default = {
     hostnames = []
   }

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -648,9 +648,8 @@ module "controller" {
   client_configuration           = contains(local.hosts, "suse_client") ? module.suse_client.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [], private_macs = [] }
   minion_configuration           = contains(local.hosts, "suse_minion") ? module.suse_minion.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [], private_macs = [] }
   sshminion_configuration        = contains(local.hosts, "suse_sshminion") ? module.suse_sshminion.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [], private_macs = [] }
-  # TODO: rename redhat_configuration and debian_configuration to rhlike_configuration and deblike_configuration once the renaming is done: https://github.com/SUSE/spacewalk/issues/25062
-  redhat_configuration           = contains(local.hosts, "rhlike_minion") ? module.rhlike_minion.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [], private_macs = [] }
-  debian_configuration           = contains(local.hosts, "deblike_minion") ? module.deblike_minion.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [], private_macs = [] }
+  rhlike_configuration           = contains(local.hosts, "rhlike_minion") ? module.rhlike_minion.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [], private_macs = [] }
+  deblike_configuration          = contains(local.hosts, "deblike_minion") ? module.deblike_minion.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [], private_macs = [] }
   buildhost_configuration        = contains(local.hosts, "build_host") ? module.build_host.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [], private_macs = [] }
   pxeboot_configuration          = contains(local.hosts, "pxeboot_minion") ? module.pxeboot_minion.configuration : { private_mac = null, private_ip = null, private_name = null, image = null }
   kvmhost_configuration          = contains(local.hosts, "kvm_host") ? module.kvm_host.configuration : { hostnames = [], ids = [], ipaddrs = [], macaddrs = [], private_macs = [] }

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -22,9 +22,9 @@ export SERVER="{{ grains.get('server') }}"
 {% endif %}
 {% if grains.get('sshminion') | default(false, true) %}export SSHMINION="{{ grains.get('sshminion') }}" {% else %}# no SSH minion defined
 {% endif %}
-{% if grains.get('redhat_minion') | default(false, true) %}export RHLIKE_MINION="{{ grains.get('redhat_minion') }}" {%
+{% if grains.get('rhlike_minion') | default(false, true) %}export RHLIKE_MINION="{{ grains.get('rhlike_minion') }}" {%
 else %}# no RedHat-like minion defined {% endif %}
-{% if grains.get('debian_minion') | default(false, true) %}export DEBLIKE_MINION="{{ grains.get('debian_minion') }}" {%
+{% if grains.get('deblike_minion') | default(false, true) %}export DEBLIKE_MINION="{{ grains.get('deblike_minion') }}" {%
 else %}# no Debian-like minion defined {% endif %}
 {% if grains.get('pxeboot_mac') | default(false, true) %}export PXEBOOT_MAC="{{ grains.get('pxeboot_mac') }}" {% else
 %}# no PXE boot MAC defined {% endif %}


### PR DESCRIPTION
## What does this PR change?

Finishes the `deblike` / `rhlike` minion-family naming standardization in sumaform.

The `cucumber_testsuite` minion modules were already renamed to `rhlike_minion` / `deblike_minion`, but they were still wired into controller variables and grains that kept the legacy `redhat_*` / `debian_*` names (an in-code `TODO` flagged this). This PR completes the rename so the whole chain is consistent:

```
module rhlike_minion  -> var rhlike_configuration  -> grain rhlike_minion  -> env RHLIKE_MINION
module deblike_minion -> var deblike_configuration -> grain deblike_minion -> env DEBLIKE_MINION
```

Changes:
- `modules/cucumber_testsuite/main.tf`: `redhat_configuration`/`debian_configuration` -> `rhlike_configuration`/`deblike_configuration`; removed the `TODO`
- `modules/controller/variables.tf`: renamed the two variable declarations
- `modules/controller/main.tf`: grains `redhat_minion`/`debian_minion` -> `rhlike_minion`/`deblike_minion`
- `salt/controller/bashrc`: grain lookups feeding the env-var export

The exported controller env vars `RHLIKE_MINION` / `DEBLIKE_MINION` are **unchanged**, so the testsuite consumes them exactly as before — this rename is internal to sumaform. User `main.tf` files are unaffected (they declare the `rhlike_minion` / `deblike_minion` host_settings keys, which do not change).

Follow-up of SUSE/spacewalk#25062. Closes SUSE/spacewalk#31346.
