### PR TITLE
Move test suite controller to openSUSE Leap 16.0

### DIFF
--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -4,7 +4,7 @@ locals {
   manufacturer = lookup(var.provider_settings, "manufacturer", "Intel")
   product      = lookup(var.provider_settings, "product", "Genuine")
   // List of images that can benefit from cpu passthrough or host-model.
-  // In particular, opensuse156o covers the controller and sles15sp7o is required for the upgrade test to sles160o
+  // In particular, opensuse160o covers the controller and sles15sp7o is required for the upgrade test to sles160o
   x86_64_v2_images = ["opensuse156o", "almalinux10o", "almalinux9o", "amazonlinux2023o", "libertylinux9o", "openeuler2403o", "oraclelinux9o", "oraclelinux10o", "rocky9o", "rocky10o", "sles15sp7o", "sles160o", "opensuse160o", "slemicro55o", "slmicro60o", "slmicro61o", "slmicro62o", "ubuntu2404o", "ubuntu2604o", "tumbleweedo"]
   combustion_images  = ["slmicro60o", "slmicro61o", "slmicro62o", "sles160o"]
   gpg_keys = [

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -193,7 +193,7 @@ module "controller" {
     salt_migration_minion    = length(var.salt_migration_minion_configuration["hostnames"]) > 0 ? var.salt_migration_minion_configuration["hostnames"][0] : null
   }
 
-  image   = "opensuse156o"
+  image   = "opensuse160o"
   provider_settings = var.provider_settings
 }
 

--- a/salt/controller/apache_https.sls
+++ b/salt/controller/apache_https.sls
@@ -7,22 +7,19 @@ apache2_service_stopped:
     - name: apache2
     - enable: False
 
-# Install Apache SSL package (needed for certificate generation tools)
-apache2_ssl_package:
-  pkg.installed:
-    - name: apache2-mod_nss
-
-# Generate Self-Signed Certificate (used by Python script)
+# Generate Self-Signed Certificate (used by Python script).
+# Note: apache2-mod_nss was dropped in Leap 16. The cert is generated with
+# openssl and served by the Python script (apache is stopped), so we only need
+# to make sure the SSL directories exist.
 self_signed_cert:
   cmd.run:
     - name: |
+        mkdir -p /etc/apache2/ssl.key /etc/apache2/ssl.crt
         openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
         -keyout /etc/apache2/ssl.key/selfsigned.key \
         -out /etc/apache2/ssl.crt/selfsigned.crt \
         -subj '/CN={{ server_name }}/O=Controller/OU=Testsuite'
     - unless: test -f /etc/apache2/ssl.crt/selfsigned.crt
-    - require:
-      - pkg: apache2_ssl_package
 
 # Manage the Python Script file
 https_python_script_file:

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -265,7 +265,7 @@ export PRODUCT="SUSE Multi-Linux Manager"
 {% endif %}
 
 # Ruby specific settings
-export GEM_PATH="/usr/lib64/ruby/gems/3.3.0"
+export GEM_PATH="/usr/lib64/ruby/gems/3.4.0"
 export PLAYWRIGHT_CLI_EXECUTABLE_PATH=/usr/local/bin/playwright
 
 {% if grains.get('prometheus_push_gateway_url') | default(false, true) %}

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -38,11 +38,11 @@ cucumber_requisites:
       - gcc
       - make
       - wget
-      - ruby3.3
-      - ruby3.3-devel
+      - ruby3.4
+      - ruby3.4-devel
+      - ruby3.4-devel-extra
       - ca-certificates-mozilla
       - apache2-worker
-      - apache2-mod_nss
       - cantarell-fonts
       - git-core
       - aaa_base-extras
@@ -53,34 +53,45 @@ cucumber_requisites:
 
 /usr/bin/ruby:
   file.symlink:
-    - target: /usr/bin/ruby.ruby3.3
+    - target: /usr/bin/ruby.ruby3.4
     - force: True
 
 /usr/bin/gem:
   file.symlink:
-    - target: /usr/bin/gem.ruby3.3
+    - target: /usr/bin/gem.ruby3.4
     - force: True
 
 /usr/bin/irb:
   file.symlink:
-    - target: /usr/bin/irb.ruby3.3
+    - target: /usr/bin/irb.ruby3.4
     - force: True
 
+# On Leap 16 the default /usr/bin/{rake,bundle,rdoc,ri} are ELF wrappers and
+# ruby3.4 registers no update-alternatives group, so point them at the Ruby
+# script variants (*.ruby.ruby3.4) via symlinks instead of `update-alternatives`.
 ruby_set_rake_version:
-  cmd.run:
-    - name: update-alternatives --set rake /usr/bin/rake.ruby.ruby3.3
+  file.symlink:
+    - name: /usr/bin/rake
+    - target: /usr/bin/rake.ruby.ruby3.4
+    - force: True
 
 ruby_set_bundle_version:
-  cmd.run:
-    - name: update-alternatives --set bundle /usr/bin/bundle.ruby.ruby3.3
+  file.symlink:
+    - name: /usr/bin/bundle
+    - target: /usr/bin/bundle.ruby.ruby3.4
+    - force: True
 
 ruby_set_rdoc_version:
-  cmd.run:
-    - name: update-alternatives --set rdoc /usr/bin/rdoc.ruby.ruby3.3
+  file.symlink:
+    - name: /usr/bin/rdoc
+    - target: /usr/bin/rdoc.ruby.ruby3.4
+    - force: True
 
 ruby_set_ri_version:
-  cmd.run:
-    - name: update-alternatives --set ri /usr/bin/ri.ruby.ruby3.3
+  file.symlink:
+    - name: /usr/bin/ri
+    - target: /usr/bin/ri.ruby.ruby3.4
+    - force: True
 
 # Distro Chromium is kept ONLY to provide the shared libraries (libgbm, NSS, fonts, ...)
 # that the Playwright-managed Chromium needs. It is not the browser Playwright launches.
@@ -126,7 +137,7 @@ playwright_cli_env:
 
 install_gems_via_bundle:
   cmd.run:
-    - name: bundle.ruby.ruby3.3 install --gemfile Gemfile
+    - name: bundle.ruby.ruby3.4 install --gemfile Gemfile
     - cwd: /root/spacewalk/testsuite
     - require:
       - pkg: cucumber_requisites
@@ -231,10 +242,15 @@ google_cert_db:
    - creates: /root/.pki/nssdb
 
 # Health-check testing
+{% if grains['osfullname'] == 'Leap' and grains['osrelease'] | int >= 16 %}
+{% set health_check_path = 'openSUSE_Leap_' + grains['osrelease'] %}
+{% else %}
+{% set health_check_path = grains.get("osrelease") %}
+{% endif %}
 health_check_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/healthcheck:/Stable/{{ grains.get("osrelease") }}
-    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/healthcheck:/Stable/{{ grains.get("osrelease") }}/repodata/repomd.xml.key
+    - baseurl: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/healthcheck:/Stable/{{ health_check_path }}
+    - gpgkey: http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/healthcheck:/Stable/{{ health_check_path }}/repodata/repomd.xml.key
     - gpgcheck: 0
     - refresh: True
 

--- a/salt/repos/ruby.sls
+++ b/salt/repos/ruby.sls
@@ -3,16 +3,19 @@
 ruby_add_devel_repository:
     pkgrepo.managed:
       - name: ruby_devel
-      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby/15.6/
+      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby/{{ grains['osrelease'] }}/
       - refresh: True
       - gpgautoimport: True
 
+{# The ruby extensions devel repo has no Leap 16+ build; only add it on Leap 15.x #}
+{% if grains['osrelease_info'][0] < 16 %}
 ruby_gems_add_devel_repository:
     pkgrepo.managed:
       - name: ruby_devel_extensions
-      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/15.6/
+      - baseurl: http://download.opensuse.org/repositories/devel:/languages:/ruby:/extensions/{{ grains['osrelease'] }}/
       - refresh: True
       - gpgautoimport: True
+{% endif %}
 
 {% endif %}
 

--- a/salt/repos/tools.sls
+++ b/salt/repos/tools.sls
@@ -1,5 +1,4 @@
 {% if grains['os'] == 'SUSE' and (
-      'controller' in grains.get('roles') or
       'grafana' in grains.get('roles') or
       'mirror' in grains.get('roles') or
       grains.get('evil_minion_count') or


### PR DESCRIPTION
## What does this PR change?

Migrates the test suite **controller** VM image from openSUSE Leap 15.6 (EOL since April 2026) to openSUSE Leap 16.0.

- `modules/controller/main.tf` now uses `opensuse160o` (already defined in the libvirt and AWS base backends). This is the single, central place the controller image is set — both the cucumber testsuite and build-validation paths call `../controller` with no image override, so this covers all environments.
- `backend_modules/libvirt/host/main.tf`: updated a stale comment that still referenced `opensuse156o` as the controller image (the `opensuse156o` entry itself stays in the `x86_64_v2_images` list — it's still used by Leap 15.6 minion clients).

Only the controller is affected; client/minion, dhcp_dns, proxy, server and mirror images are untouched.

### Repository changes (salt)

**`salt/repos/tools.sls` — controller no longer pulls `systemsmanagement:sumaform:tools`.**
On Leap 16 this repo was only ever added on the **controller** — never on minions. tools.sls is guarded by role (`controller` / `grafana` / `mirror` / evil-minion / `monitored`), and the only one of those that runs on Leap 16 is the controller; plain minions (including the Leap 16 minions in the build validation) do not match the condition and have never referenced this repo. The only package the controller needs from that family is `node_exporter`, which openSUSE Leap 16.0 ships in its base repo, so the controller does not need the tools repo at all on Leap 16. It is therefore removed from the list of roles that add it. `tools` remains in place unchanged for the `grafana` / `mirror` / evil-minion / `monitored` roles, which run on SLE / Leap 15.x where the repo builds normally.

Note: `systemsmanagement:sumaform:tools` has no working Leap 16 build (its packages are decade-old frozen copies whose Go bootstrap sources were removed from Factory, and modern equivalents now live in the Leap 16 base repo). Porting it is only relevant if the grafana/monitoring/evil-minion roles are ever moved to Leap 16, which is out of scope here.

**`salt/controller/init.sls` — health-check repo now uses the Leap 16 naming.**
The `systemsmanagement:Uyuni:healthcheck:Stable` repo names its Leap repositories `openSUSE_Leap_<version>`, so on Leap 16 the controller now points at `openSUSE_Leap_16.0` (older distros keep the previous bare-`osrelease` path). `mgr-health-check` is published and installable there.

This is part of migrating the test-suite controller host OS to Leap 16.0. Companion PRs:
- uyuni: `controller-dev` container Dockerfile → Leap 16.0 — **merged**: https://github.com/uyuni-project/uyuni/pull/12313
- susemanager-ci: environment image lists + Uyuni Master AWS controller override + README matrix → Leap 16.0: https://github.com/SUSE/susemanager-ci/pull/2131

Controller provisioning on Leap 16.0 is validated via the manual core-stage terracumber run alongside the uyuni controller-dev image. Azure `opensuse160o` parity is a deferred follow-up (not required for libvirt-based CI).

Links: https://github.com/SUSE/spacewalk/issues/31270


