### PR TITLE
Forward StorageClass to external Kubernetes installs

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -92,6 +92,7 @@ module "controller" {
     helm_chart_name                              = var.kubernetes_server_helm_chart_name
     helm_chart_url                               = var.kubernetes_server_helm_chart_url
     container_registry                           = var.kubernetes_server_container_registry
+    kubernetes_storage_class                     = var.kubernetes_server_storage_class
     use_devel_oci                                = var.use_devel_oci
     install_cert_manager                         = var.install_cert_manager
     deploy_coco_attestation                      = var.deploy_coco_attestation

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -966,6 +966,12 @@ variable "kubernetes_server_container_registry" {
   default     = ""
 }
 
+variable "kubernetes_server_storage_class" {
+  description = "StorageClass used by the Uyuni server when installing into an external Kubernetes cluster"
+  type        = string
+  default     = null
+}
+
 variable "use_devel_oci" {
   description = "true to use devel OCIs for external Kubernetes cluster installs"
   default     = false

--- a/modules/cucumber_testsuite/main.tf
+++ b/modules/cucumber_testsuite/main.tf
@@ -708,6 +708,7 @@ module "controller" {
   kubernetes_server_helm_chart_name             = coalesce(lookup(local.helm_chart_name, "server_kubernetes", null), "server-helm")
   kubernetes_server_helm_chart_url              = coalesce(lookup(local.helm_chart_url, "server_kubernetes", null), "oci://registry.suse.de/devel/galaxy/manager/head/charts/suse/multi-linux-manager/5.2")
   kubernetes_server_container_registry          = lookup(local.container_registries, "server_kubernetes", null) != null ? lookup(local.container_registries, "server_kubernetes", null) : ""
+  kubernetes_server_storage_class               = lookup(local.kubernetes_storage_class, "server_kubernetes", var.kubernetes_storage_class)
   use_devel_oci                                 = var.use_devel_oci
   install_cert_manager                          = var.install_cert_manager
   deploy_coco_attestation                       = var.deploy_coco_attestation


### PR DESCRIPTION
## What does this PR change?

Forwards the StorageClass selected through `cucumber_testsuite` to the controller when Sumaform installs Uyuni into an external Kubernetes cluster.

External mode does not instantiate `server_kubernetes`; Helm runs from the controller instead. Without this bridge, the existing `kubernetes_storage_class` input is dropped and the chart falls back to the cluster default. The controller now receives the selected class and the existing Helm values template emits it as `server-helm.volumes.storageClass`.

The value remains an arbitrary StorageClass name: there is no benchmark-specific allowlist or dependency on local-path, NFS, or any other provisioner. A null value remains unchanged and continues to use the cluster default. Sumaform does not create or manage the StorageClass.

Validation:

- OpenTofu and Terraform example validation
- External-mode plan assertion that `nfs-csi` reaches the controller grain
- Salt template assertion that the explicit class is rendered and a null class omits the Helm value

No external cluster or live Helm release was mutated during validation.