### PR TITLE
Raspios13o image does not exist online

### DIFF
--- a/backend_modules/libvirt/base/main.tf
+++ b/backend_modules/libvirt/base/main.tf
@@ -35,7 +35,7 @@ locals {
     ubuntu2604o              = "${var.use_mirror_images ? "http://${var.mirror}" : "http://cloud-images.ubuntu.com"}/resolute/current/resolute-server-cloudimg-amd64.img"
     debian12o                = "${var.use_mirror_images ? "http://${var.mirror}" : "http://cloud.debian.org"}/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2"
     debian13o                = "${var.use_mirror_images ? "http://${var.mirror}" : "http://cloud.debian.org"}/images/cloud/trixie/latest/debian-13-genericcloud-amd64.qcow2"
-    raspios13o               = "http://${var.mirror}/images/raspberrypi-testing.qcow2"
+    raspios13o               = "${var.use_mirror_images ? "http://${var.mirror}" : "http://minima-mirror-ci-bv.mgr.suse.de"}/images/raspberrypi-testing.qcow2"
     slemicro52-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_52/SUSE-MicroOS.x86_64-sumaform.qcow2"
     slemicro53-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_53/SLE-Micro.x86_64-sumaform.qcow2"
     slemicro54-ign           = "${var.use_mirror_images ? "http://${var.mirror}" : "http://download.opensuse.org"}/repositories/systemsmanagement:/sumaform:/images:/microos/images_54/SLE-Micro.x86_64-sumaform.qcow2"


### PR DESCRIPTION
## What does this PR change?

Raspios13o image does not exist online.

It must be prepared manually and dropped onto our mirrors.
