### PR TITLE
Skip MLM client tools repos on Ubuntu 26.04

### DIFF
--- a/salt/repos/client_tools/client_tools_mlm.sls
+++ b/salt/repos/client_tools/client_tools_mlm.sls
@@ -343,6 +343,8 @@ clean_repo_metadata:
 {% set short_release = release | replace('.', '') %}
 
 # Release client tools
+{# WORKAROUND: remove when we hit first MU for 5.2 #}
+{% if release != "26.04" %}
 {% set tools_update_repo = 'http://' + grains.get("mirror") | default("dist.suse.de/ibs", true) + '/SUSE/Updates/MultiLinuxManagerTools/Ubuntu-' + release + '/' + grains.get("cpuarch") + '/update/' %}
 tools_update_repo:
   pkgrepo.managed:
@@ -359,8 +361,11 @@ tools_update_repo_raised_priority:
             Package: *
             Pin: release l=SUSE:Updates:MultiLinuxManagerTools:Ubuntu-{{ release }}:{{ grains.get("cpuarch") }}:update
             Pin-Priority: 800
+{% endif %} {# release != "26.04" #}
 
 {% if 'beta' in grains.get('product_version') | default('', true) %}
+{# WORKAROUND: remove when we hit first MU for 5.2 #}
+{% if release != "26.04" %}
 
 {% set beta_tools_update_repo = 'http://' + grains.get("mirror") | default("dist.suse.de/ibs", true) + '/SUSE/Updates/MultiLinuxManagerTools-Beta/Ubuntu-' + release + '/' + grains.get("cpuarch") + '/update/' %}
 beta_tools_update_repo:
@@ -378,6 +383,7 @@ beta_tools_update_repo_raised_priority:
             Package: *
             Pin: release l=SUSE:Updates:MultiLinuxManagerTools-Beta:Ubuntu-{{ release }}:{{ grains.get("cpuarch") }}:update
             Pin-Priority: 800
+{% endif %} {# release != "26.04" #}
 
 {% endif %}
 


### PR DESCRIPTION
## What does this PR change?

Skips the `MultiLinuxManagerTools` and `MultiLinuxManagerTools-Beta` client tools repositories on Ubuntu 26.04 minions, along with their apt pin priority files.

Both repositories are published but empty for Ubuntu 26.04:

| Repo | Ubuntu 24.04 x86_64 | Ubuntu 26.04 x86_64 |
|---|---|---|
| [`MultiLinuxManagerTools`](http://dist.suse.de/ibs/SUSE/Updates/MultiLinuxManagerTools/Ubuntu-26.04/x86_64/update/) | 41 packages | published, **0 packages** |
| [`MultiLinuxManagerTools-Beta`](http://dist.suse.de/ibs/SUSE/Updates/MultiLinuxManagerTools-Beta/Ubuntu-26.04/x86_64/update/) | 29 packages | published, **0 packages** |

The 26.04 paths exist with signed metadata but a zero-byte `Packages` index. Only `x86_64` is published for Ubuntu (no `aarch64` tree exists for any Ubuntu release), so the guards key off the release.

This is a temporary workaround, to be reverted once the repositories are populated with the first MU for 5.2. It is deliberately kept as two independent, purely additive blocks — a `{# WORKAROUND #}` comment plus an `{% if release != "26.04" %}` / `{% endif %}` pair around each repo — so each can be reverted by deleting three lines, without touching the surrounding conditions.

Follow-up card to track the revert: SUSE/spacewalk#31453