### PR TITLE
Add use_dhcp_ip provider setting for VMs not declared in DNS

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -14,7 +14,7 @@ Legal values for released software are:
 - `5.0-released` (latest released maintenance update for SUSE Manager 5.0 and Tools)
 - `5.1-released` (latest released maintenance update for Multi Linux Manager 5.1 and Tools)
 - `5.2-released` (latest released maintenance update for Multi Linux Manager 5.2 and Tools)
-- `uyuni-released` (latest released version for Uyuni Server, Proxy and Tools, from systemsmanagement:Uyuni:Stable)
+- `uyuni-released` (latest released version for Uyuni Server, Proxy, and Tools, from systemsmanagement:Uyuni:Stable)
 
 Legal values for work-in-progress software are:
 
@@ -1173,6 +1173,32 @@ and inside the VM:
 suma-bv-43-min-opensuse156arm.mgr.suse.de
 ```
 
+
+## Connecting to VMs not in DNS
+
+By default, Terraform resolves the VM's FQDN via DNS to establish SSH connections during provisioning. This is the safest approach when VMs are declared in our infrastructure's DNS, as it always yields the correct routable IP even if the DHCP lease contains an unroutable address.
+
+If you deploy VMs without declaring them in DNS, provisioning will fail because the FQDN cannot be resolved. In that case, set `use_dhcp_ip = true` in `provider_settings` to instruct Terraform to connect directly using the IP address obtained from the libvirt DHCP lease:
+
+```hcl
+module "suse_manager" {
+  source = "./modules/suse_manager"
+  ...
+  provider_settings = {
+    use_dhcp_ip = true
+  }
+  ...
+}
+```
+
+**When to use each mode:**
+
+| Mode | `use_dhcp_ip` | Use when |
+|------|---------------|----------|
+| DNS (default) | `false` | VMs are declared in DNS; DHCP lease IP may be unroutable |
+| DHCP IP | `true` | VMs are not declared in DNS; DHCP lease IP is routable |
+
+Note that `use_dhcp_ip = true` requires the DHCP lease IP to be directly reachable from the Terraform host. If the lease IP is unroutable in your setup, declare the VM in DNS and use the default mode instead.
 
 ## Debugging facilities
 

--- a/backend_modules/libvirt/README.md
+++ b/backend_modules/libvirt/README.md
@@ -69,6 +69,7 @@ Following settings apply to all modules that create one or more hosts of the sam
 | manufacturer    | string         | `Intel`                                                      | The System Management BIOS manufacturer                     |
 | product         | string         | `Genuine`                                                    | The System Management BIOS product                          |
 | xslt            | string         | `null` ([apart from specific roles](Default-values-by-role)) | XSLT contents to apply on the libvirt domain                |
+| use_dhcp_ip     | bool           | `false`                                                      | Use the DHCP lease IP for SSH connections instead of DNS resolution. Set to `true` for VMs not declared in your DNS infrastructure. See [Connecting to VMs not in DNS](../../README_ADVANCED.md#connecting-to-vms-not-in-dns) |
 
 An example follows:
 

--- a/backend_modules/libvirt/host/main.tf
+++ b/backend_modules/libvirt/host/main.tf
@@ -27,6 +27,7 @@ locals {
     mac             = null
     cpu_model       = "custom"
     xslt            = null
+    use_dhcp_ip     = false
     },
     contains(local.x86_64_v2_images, var.image) ? { cpu_model = "host-model", xslt = file("${path.module}/cpu_features.xsl") } : {},
     contains(var.roles, "server") ? { memory = 4096, vcpu = 2 } : {},
@@ -268,12 +269,12 @@ resource "terraform_data" "provisioning" {
     environment = {
       HOST          = local.overwrite_fqdn != "" ? local.overwrite_fqdn : "${libvirt_domain.domain[count.index].name}.${var.base_configuration["domain"]}"
       IP_FROM_LEASE = local.overwrite_fqdn == "" ? join(" ", libvirt_domain.domain[count.index].network_interface[0].addresses) : ""
+      USE_DHCP_IP   = local.provider_settings["use_dhcp_ip"] ? "true" : "false"
     }
     command = <<-EOF
       IP=""
 
-      # 1) Use IP from libvirt DHCP lease (works for local, static-DHCP, and Avahi setups
-      #    since Avahi VMs still get a DHCP IP — avoids mDNS resolution on the Terraform host)
+      # Extract IPv4 from libvirt DHCP lease if available
       if [ -n "$IP_FROM_LEASE" ]; then
         for addr in $IP_FROM_LEASE; do
           if echo "$addr" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
@@ -283,25 +284,27 @@ resource "terraform_data" "provisioning" {
         done
       fi
 
-      # 2) Resolve via nsswitch (/etc/hosts, mDNS, DNS...) - IPv4 only
-      if [ -z "$IP" ]; then
-        IP=$(getent ahostsv4 "$HOST" 2>/dev/null | awk '{print $1; exit}')
-      fi
-
-      # 3) avahi-resolve fallback for .local domains (when lease IP unavailable)
-      if [ -z "$IP" ] && command -v avahi-resolve >/dev/null 2>&1; then
-        IP=$(avahi-resolve --name "$HOST" 2>/dev/null | awk '{print $2}' | head -1)
-      fi
-
-      # 4) Direct DNS query fallback
-      if [ -z "$IP" ]; then
-        IP=$(host -t A "$HOST" 2>/dev/null | awk '/has address/{print $4}' | head -1)
-      fi
-
-      # 5) Last resort: let nc resolve the name itself, forced to IPv4
-      if [ -z "$IP" ]; then
-        echo "WARN: could not pre-resolve $HOST to an IPv4 address, trying by name" >&2
-        IP="$HOST"
+      if [ "$USE_DHCP_IP" = "true" ]; then
+        # DHCP IP mode: use lease IP directly, no DNS resolution
+        if [ -z "$IP" ]; then
+          echo "ERROR: no IPv4 address in DHCP lease for $HOST" >&2
+          exit 1
+        fi
+      else
+        # DNS mode: fall back through resolution methods if lease IP unavailable
+        if [ -z "$IP" ]; then
+          IP=$(getent ahostsv4 "$HOST" 2>/dev/null | awk '{print $1; exit}')
+        fi
+        if [ -z "$IP" ] && command -v avahi-resolve >/dev/null 2>&1; then
+          IP=$(avahi-resolve --name "$HOST" 2>/dev/null | awk '{print $2}' | head -1)
+        fi
+        if [ -z "$IP" ]; then
+          IP=$(host -t A "$HOST" 2>/dev/null | awk '/has address/{print $4}' | head -1)
+        fi
+        if [ -z "$IP" ]; then
+          echo "WARN: could not pre-resolve $HOST to an IPv4 address, trying by name" >&2
+          IP="$HOST"
+        fi
       fi
 
       for i in $(seq 1 24); do
@@ -316,7 +319,11 @@ resource "terraform_data" "provisioning" {
   count = var.provision ? var.quantity : 0
 
   connection {
-    host     = local.overwrite_fqdn != "" ? local.overwrite_fqdn : "${libvirt_domain.domain[count.index].name}.${var.base_configuration["domain"]}"
+    host     = local.overwrite_fqdn != "" ? local.overwrite_fqdn : (
+      local.provider_settings["use_dhcp_ip"]
+      ? [for addr in libvirt_domain.domain[count.index].network_interface[0].addresses : addr if !can(regex(":", addr))][0]
+      : "${libvirt_domain.domain[count.index].name}.${var.base_configuration["domain"]}"
+    )
     user     = "root"
     password = "linux"
     // ssh connection through a bastion host


### PR DESCRIPTION
## What does this PR change?


###  Problem

Terraform provisioning fails for libvirt VMs that are not declared in DNS infrastructure.
The SSH connection and SSH-readiness check both rely on resolving the VM's FQDN (e.g.
toto-mlm-5-2-server.mgr.suse.de), which fails when developers intentionally deploy without registering the host in DNS.

The FQDN-based approach was introduced to handle deployments where the libvirt DHCP lease returns an unroutable IP — DNS provides the correct routable address in those cases. Both approaches are valid depending on the infrastructure setup, but there was no way to choose between them.

###  Solution

Add a use_dhcp_ip boolean flag to provider_settings (default: false) that controls how Terraform connects to VMs during provisioning:

- use_dhcp_ip = false (default): existing behavior — resolves FQDN via DNS. Safe for VMs declared in DNS, handles unroutable DHCP lease IPs.
- use_dhcp_ip = true: uses the IPv4 address from the libvirt DHCP lease directly. Required for VMs not declared in DNS, assumes the lease IP is routable.

Both the local-exec SSH-readiness check and the connection block respect the flag, so the behavior is consistent end-to-end.

##  Changes

  - backend_modules/libvirt/host/main.tf: add use_dhcp_ip = false default to provider_settings; branch local-exec script and connection host on the flag
  - backend_modules/libvirt/README.md: document use_dhcp_ip in the host modules provider_settings table
  - README_ADVANCED.md: add "Connecting to VMs not in DNS" section explaining when to use each mode

## Tests

 - CI: https://ci.suse.de/user/manager/my-views/view/RRTG/job/manager-4.3-dev-acceptance-tests/3568/
 Need test on dev env.