### PR TITLE
Use the SL Micro 6 tools project for SL Micro 6 head clients

### DIFF
--- a/salt/repos/client_tools/client_tools_mlm.sls
+++ b/salt/repos/client_tools/client_tools_mlm.sls
@@ -198,7 +198,7 @@ tools_additional_repo:
 
 tools_additional_repo:
   pkgrepo.managed:
-    - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE15/images/repo/ManagerTools-Beta-SLE15-Pool-{{ grains.get("cpuarch") }}-Media1/
+    - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SL-Micro-6/product/repo/Multi-Linux-ManagerTools-Beta-SL-Micro-6-{{ grains.get("cpuarch") }}/
     - refresh: True
     - priority: 98
 


### PR DESCRIPTION
## What does this PR change?

SL Micro 6 clients on `head` were getting **SLE 15** client tools.

There is no issue behind this one — it came out of reading through `client_tools_mlm.sls` while investigating a
different problem in the same block, so the description below stands in for the card.

The `head` branch of the `SL-Micro` block in `salt/repos/client_tools/client_tools_mlm.sls` pointed at
`Devel:Galaxy:Manager:Main:MLMTools-Beta-SLE15` / `ManagerTools-Beta-SLE15-Pool-<arch>-Media1`. That looks like a
copy-paste from the `SLE Micro` block further down, where sharing the SLE 15 tools project *is* correct — SLE
Micro 5 has no tools project of its own. The URL has been there unchanged since the file was split out in
615fac0b (June 2025), so this is not a regression, just a bug nobody tripped over.

This points it at the SL Micro 6 tools project instead:

```diff
-.../Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SLE15/images/repo/ManagerTools-Beta-SLE15-Pool-{{ cpuarch }}-Media1/
+.../Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SL-Micro-6/product/repo/Multi-Linux-ManagerTools-Beta-SL-Micro-6-{{ cpuarch }}/
```

`product/repo/` is the same layout the `nightly` branch right above already uses for
`Devel:Galaxy:Manager:Stable:MLMTools-SLMicro-6`, so the two branches of this block now mirror each other.

## Mirror side

The CI/BV minima mirrors did not carry this path — they mirrored `Micro_60/`, the project's OBS package
repository, which nothing in sumaform requested either before or after this change.
**galaxy/infrastructure!1252** swaps that entry for the `product/repo/` one, so the mirrors follow this PR:

- <https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/1252>

The two need to land together: merging this PR alone would leave head SL Micro 6 runs pointing at a path the
mirrors do not have, and merging the MR alone removes a repository nothing uses. Once both are in, a highstate on
`manager.mgr.suse.de` plus `minima.sh` on both mirrors picks it up.

## Verification

Checked on `dist.suse.de` (2026-07-31) — the project publishes all four arches, so the `cpuarch` substitution
resolves everywhere we build:

```
http://dist.suse.de/ibs/Devel:/Galaxy:/Manager:/Main:/MLMTools-Beta-SL-Micro-6/product/repo/  -> 200
  Multi-Linux-ManagerTools-Beta-SL-Micro-6-{aarch64,ppc64le,s390x,x86_64}/
```

Both mirror sites publish it too (`dist.suse.de` and `ibs-mirror.slc1.suse.org`, both 200), so unlike the SLE 16
entry this needs no per-site pin.

## Not in scope

The `nightly` branch of the same block requests `Multi-Linux-ManagerTools-SL-Micro-6-<arch>` from the `Stable:`
project, which publishes only the `Beta`-named repository — see SUSE/spacewalk#31465. Releng confirmed that
naming is deliberate until SL Micro 6.0/6.1 move to the full git workflow, so it is tracked and fixed separately.
