### PR TITLE
Request the published SL Micro 6 tools repository name on nightly

### DIFF
--- a/salt/repos/client_tools/client_tools_mlm.sls
+++ b/salt/repos/client_tools/client_tools_mlm.sls
@@ -188,9 +188,14 @@ tools_pool_repo:
 # Devel Tools Repos
 {% if 'nightly' in grains.get('product_version') | default('', true) %} {# Devel Tools Repos #}
 
+# WORKAROUND: this project publishes its product repository under a "Beta" name,
+# unlike every other Stable: tools project, because SL Micro 6 client tools are
+# still fed from Devel:Galaxy:Manager:5.1:MLMTools-SL-Micro-6. Drop the "Beta"
+# infix once SL Micro 6.0 and 6.1 move to the full git workflow
+# see https://github.com/SUSE/spacewalk/issues/31465
 tools_additional_repo:
   pkgrepo.managed:
-  - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLMicro-6/product/repo/Multi-Linux-ManagerTools-SL-Micro-6-{{ grains.get("cpuarch") }}/
+  - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Stable:/MLMTools-SLMicro-6/product/repo/Multi-Linux-ManagerTools-Beta-SL-Micro-6-{{ grains.get("cpuarch") }}/
   - refresh: True
   - priority: 98
 


### PR DESCRIPTION
## What does this PR change?

Fixes SUSE/spacewalk#31465 — the SL Micro 6 devel client tools repository 404s on every arch for `nightly`.

`Devel:Galaxy:Manager:Stable:MLMTools-SLMicro-6` publishes its kiwi product repository under a **Beta** name,
unlike every other `Stable:` tools project:

```
.../Stable:/MLMTools-SLMicro-6/product/repo/Multi-Linux-ManagerTools-Beta-SL-Micro-6-x86_64/   -> 200
.../Stable:/MLMTools-SLMicro-6/product/repo/Multi-Linux-ManagerTools-SL-Micro-6-x86_64/        -> 404
```

The `nightly` branch of the `SL-Micro` block asked for the second one, so SL Micro 6 minions got no devel tools
repository on any non-`head` product version.

```diff
-.../Stable:/MLMTools-SLMicro-6/product/repo/Multi-Linux-ManagerTools-SL-Micro-6-{{ cpuarch }}/
+.../Stable:/MLMTools-SLMicro-6/product/repo/Multi-Linux-ManagerTools-Beta-SL-Micro-6-{{ cpuarch }}/
```

## Why the Beta name, and why this is a workaround

Releng confirmed the naming is deliberate, not a leftover. SL Micro 6 client tools are still fed from the older
`Devel:Galaxy:Manager:5.1:MLMTools-SL-Micro-6` project, which is the base for
<https://src.suse.de/products/MultiLinuxManagerTools-SL-Micro>. A full switch to the `Stable:` project is not
possible until SL Micro 6.0 and 6.1 themselves move to the full git workflow — expected around September 2026,
with client tools migrating alongside them. Until then the setup is a hybrid and the Beta product name stays.

So this requests the name that exists today and carries a `WORKAROUND` comment pointing at the card, which
records the revert condition: when
`.../Stable:/MLMTools-SLMicro-6/product/repo/Multi-Linux-ManagerTools-SL-Micro-6-x86_64/` returns 200, drop the
`Beta` infix here and in the mirror config.

## Verification

Probed on `dist.suse.de` (2026-07-31). The project publishes the Beta-named repository for all four arches, so
the `cpuarch` substitution resolves everywhere we build and the arch loop needs no change:

```
Multi-Linux-ManagerTools-Beta-SL-Micro-6-{aarch64,ppc64le,s390x,x86_64}/
```

The CI/BV mirror already carries the `x86_64` one, so no infrastructure change is needed for this PR.

## Related

- Card with the full releng answer and the revert table: SUSE/spacewalk#31465
- Separate bug in the `head` branch of the same block, already open: #2250
