### PR TITLE
Export the Ubuntu 26.04 minion hostnames on the controller

### DIFF
--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -194,6 +194,10 @@ grains.get('ubuntu2204_sshminion') }}" {% else %}# no UBUNTU2204 ssh minion defi
 grains.get('ubuntu2404_minion') }}" {% else %}# no UBUNTU2404 minion defined {% endif %}
 {% if grains.get('ubuntu2404_sshminion') | default(false, true) %}export UBUNTU2404_SSHMINION="{{
 grains.get('ubuntu2404_sshminion') }}" {% else %}# no UBUNTU2404 ssh minion defined {% endif %}
+{% if grains.get('ubuntu2604_minion') | default(false, true) %}export UBUNTU2604_MINION="{{
+grains.get('ubuntu2604_minion') }}" {% else %}# no UBUNTU2604 minion defined {% endif %}
+{% if grains.get('ubuntu2604_sshminion') | default(false, true) %}export UBUNTU2604_SSHMINION="{{
+grains.get('ubuntu2604_sshminion') }}" {% else %}# no UBUNTU2604 ssh minion defined {% endif %}
 {% if grains.get('debian12_minion') | default(false, true) %}export DEBIAN12_MINION="{{ grains.get('debian12_minion')
 }}" {% else %}# no DEBIAN12 minion defined {% endif %}
 {% if grains.get('debian12_sshminion') | default(false, true) %}export DEBIAN12_SSHMINION="{{


### PR DESCRIPTION
## What does this PR change?

Exports `UBUNTU2604_MINION` and `UBUNTU2604_SSHMINION` on the controller.

The `ubuntu2604_minion` and `ubuntu2604_sshminion` grains are already set by
the controller module, but `salt/controller/bashrc` never turned them into
environment variables, so the testsuite could not see those clients.

The build validation rake tasks are generated from the controller environment
(`jenkins:generate_rake_files_build_validation` collects every `*_MINION`
variable), while the feature files are generated from the checked in
`features/build_validation/init_clients/*.feature`. Because the two sources had
diverged, the Ubuntu 26.04 feature files existed but no matching rake task did,
and the 5.2 build validation failed with:

```
Don't know how to build task 'cucumber:build_validation_add_maintenance_update_repositories_ubuntu2604_minion'
Did you mean?  cucumber:build_validation_add_maintenance_update_repositories_ubuntu2204_minion
```

Every other grain declared in `modules/controller/main.tf` was cross checked
against the template, `ubuntu2604` was the only one missing.
