### PR TITLE
AWS: remove Leap 15.6 AMI

### DIFF
--- a/backend_modules/aws/base/ami.tf
+++ b/backend_modules/aws/base/ami.tf
@@ -2,7 +2,7 @@ data "aws_region" "current" {}
 
 data "aws_ami" "tumbleweedo" {
   # Only execute this lookup if the region is eu-central-1 (Frankfurt)
-  count = data.aws_region.current.id == "eu-central-1" ? 1 : 0
+  count = data.aws_region.current.region == "eu-central-1" ? 1 : 0
 
   most_recent = true
   owners      = ["self"] // custom built AMI
@@ -15,28 +15,6 @@ data "aws_ami" "tumbleweedo" {
   filter {
     name   = "state"
     values = ["available"]
-  }
-}
-
-
-data "aws_ami" "opensuse156o" {
-  most_recent = true
-  name_regex  = "^openSUSE-Leap-15.6-"
-  owners      = ["679593333241"]
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "root-device-type"
-    values = ["ebs"]
   }
 }
 

--- a/backend_modules/aws/base/main.tf
+++ b/backend_modules/aws/base/main.tf
@@ -69,7 +69,6 @@ locals {
     iam_instance_profile = length(aws_iam_instance_profile.metering_full_access_instance_profile) > 0 ? aws_iam_instance_profile.metering_full_access_instance_profile[0].name : null
     ami_info = {
       tumbleweedo                     = { ami = one(data.aws_ami.tumbleweedo[*].image_id) }, // custom Tumbleweed AMI                           }
-      opensuse156o                    = { ami = data.aws_ami.opensuse156o.image_id },
       opensuse160o                    = { ami = data.aws_ami.opensuse160o.image_id },
       sles15sp4o                      = { ami = data.aws_ami.sles15sp4o.image_id },
       sles15sp5o                      = { ami = data.aws_ami.sles15sp5o.image_id },


### PR DESCRIPTION
## What does this PR change?

The Leap 15.6 AMI is no longer available in AWS.
