### PR TITLE
Mount the additional disks on Kubernetes servers

### DIFF
--- a/salt/server_kubernetes/additional_disk.sls
+++ b/salt/server_kubernetes/additional_disk.sls
@@ -1,0 +1,43 @@
+{% set local_path = grains.get('local_path_provisioner_path') | default('/opt/local-path-provisioner', true) %}
+{% set var_pgsql_host_path = grains.get('kubernetes_var_pgsql_host_path') | default(local_path ~ '/var-pgsql18', true) %}
+
+# xfs, like the root filesystem. The var-pgsql18 volume is mounted straight on
+# the PostgreSQL data directory, and initdb refuses to run in a directory that
+# holds the lost+found an ext filesystem creates.
+
+{% if grains.get('repository_disk_size') | int > 0 %}
+
+local_path_provisioner_disk:
+  blockdev.formatted:
+    - name: /dev/{{ grains['data_disk_device'] }}
+    - fs_type: xfs
+  mount.mounted:
+    - name: {{ local_path }}
+    - device: /dev/{{ grains['data_disk_device'] }}
+    - fstype: xfs
+    - mkmnt: True
+    - persist: True
+    - require:
+      - blockdev: local_path_provisioner_disk
+
+{% endif %}
+
+{% if grains.get('database_disk_size') | int > 0 %}
+
+var_pgsql_disk:
+  blockdev.formatted:
+    - name: /dev/{{ grains['second_data_disk_device'] }}
+    - fs_type: xfs
+  mount.mounted:
+    - name: {{ var_pgsql_host_path }}
+    - device: /dev/{{ grains['second_data_disk_device'] }}
+    - fstype: xfs
+    - mkmnt: True
+    - persist: True
+    - require:
+      - blockdev: var_pgsql_disk
+{% if grains.get('repository_disk_size') | int > 0 %}
+      - mount: local_path_provisioner_disk
+{% endif %}
+
+{% endif %}

--- a/salt/server_kubernetes/init.sls
+++ b/salt/server_kubernetes/init.sls
@@ -2,6 +2,7 @@
 
 include:
   - repos
+  - server_kubernetes.additional_disk
   {% if grains.get('install_rke2') == true %}
   - kubernetes_common.install_rke2
   - server_kubernetes.set-persistent-volumes


### PR DESCRIPTION
## What does this PR change?

The `server_kubernetes` role never used the disks it asks for. Terraform attaches
them and sets the `data_disk_device` and `second_data_disk_device` grains, but no
state formats or mounts them. Everything ends up on the root disk.

On a benchmark environment with `repository_disk_size = 300` and
`database_disk_size = 60`, `lsblk` shows vdb and vdc raw with no partition table,
and `/opt/local-path-provisioner` sitting on the 40G root disk.

`server`, `server_containerized` and `proxy` all have an `additional_disk` state.
`server_kubernetes` was copy-pasted from `server` and this one was dropped. None
of them can be reused as they are: they mount `/var/spacewalk` and `/var/lib/pgsql`,
or call `mgr-storage-server` for podman volumes.

This adds `server_kubernetes.additional_disk`:

- the repository disk is mounted on the local-path-provisioner path, which holds
  the `var-spacewalk` volume and every dynamic volume
- the database disk is mounted on the `var-pgsql18` volume path below it

Those are the defaults already used by
[volume-configuration-var-spacewalk.yml](https://github.com/uyuni-project/sumaform/blob/master/salt/server_kubernetes/volume-configuration-var-spacewalk.yml)
and
[volume-configuration-var-pgsql.yml](https://github.com/uyuni-project/sumaform/blob/master/salt/server_kubernetes/volume-configuration-var-pgsql.yml),
so no grain overrides are needed. `kubernetes_var_pgsql_host_path` is honoured if
set.

Both disks are formatted with xfs, like the root filesystem. The `var-pgsql18`
volume is mounted straight on `/var/lib/pgsql/data` in the db container, so with
an ext filesystem `initdb` fails:

```
initdb: error: directory "/var/lib/pgsql/data" exists but is not empty
initdb: detail: It contains a lost+found directory, perhaps due to it being a mount point.
```

The whole device is formatted, with no partition table. That keeps the state to
two declarations and avoids the nvme device naming special case the other roles
need.

The state is included first so it runs before RKE2, the static persistent volumes
and local-path-provisioner write to those paths. That also means
`set_up_local-path-provisioner` restores the SELinux context of both filesystems
after they are mounted.
