### PR TITLE
Wait for the Uyuni server pod to be ready

### DIFF
--- a/salt/server_kubernetes/install_kubernetes_server.sls
+++ b/salt/server_kubernetes/install_kubernetes_server.sls
@@ -234,6 +234,18 @@ save_script_to_get_pod_name:
     - user: root
     - group: root
 
+{# helm returns as soon as the release is recorded, so without this the proxy
+   states race ahead and run kubectl exec against a pod that has no running
+   container yet. No --timeout: the deployment's progressDeadlineSeconds bounds
+   the wait, and passing a longer one only looks like it does something. #}
+wait_for_uyuni_server_pod:
+  cmd.run:
+    - name: kubectl rollout status deployment/uyuni -n uyuni
+    - env:
+      - KUBECONFIG: {{ kubeconfig }}
+    - require:
+      - cmd: install_uyuni_on_kubernetes
+
 {% endif %}
 
 {% endif %}


### PR DESCRIPTION
`helm upgrade --install` returns as soon as the release is recorded, and nothing after it waits for the pod. Server provisioning therefore reports success while the pod is still starting, the proxy states race ahead, and the run fails on the proxy with an error that points at the wrong host:

```
error: Internal error occurred: unable to upgrade connection: container not found ("uyuni")
...
cp: cannot stat '/root/config.tar.gz': No such file or directory
Error: failed parsing --set-file data: open ssh.yaml: no such file or directory
```

Block on `kubectl rollout status` so a server that never comes up fails on the server, where the logs are.

Seen in [uyuni-master-dev-acceptance-tests-RKE2 #6250](https://ci.suse.de/job/uyuni-master-dev-acceptance-tests-RKE2/6250/consoleFull), where the server pod was in `CrashLoopBackOff` the whole time.
