### PR TITLE
Build Validation clients: network fixes

### DIFF
--- a/backend_modules/libvirt/host/config.ign
+++ b/backend_modules/libvirt/host/config.ign
@@ -11,21 +11,13 @@
   "storage": {
     "files": [
       {
-        "path": "/etc/sysctl.d/70-disable-ipv6.conf",
-        "overwrite": true,
-        "contents": {
-          "source": "data:,net.ipv6.conf.all.disable_ipv6%3D1%0Anet.ipv6.conf.default.disable_ipv6%3D1%0A"
-        },
-        "mode": 420
-      },
-      {
         "path": "/etc/sysconfig/network/ifcfg-eth0",
         "overwrite": true,
         "contents": {
 %{ if dhcp_dns ~}
-          "source": "data:,BOOTPROTO%3D'static'%0AIPADDR%3D'${dhcp_dns_address}'%0ASTARTMODE%3D'auto'%0AUSERCONTROL%3D'no'%0AIPV6INIT%3Dno%0AIPV6_AUTOCONF%3Dno%0A"
+          "source": "data:,BOOTPROTO%3D'static'%0AIPADDR%3D'${dhcp_dns_address}'%0ASTARTMODE%3D'auto'%0AUSERCONTROL%3D'no'%0A"
 %{ else ~}
-          "source": "data:,BOOTPROTO%3D'dhcp'%0ASTARTMODE%3D'auto'%0AUSERCONTROL%3D'no'%0AIPV6INIT%3Dno%0AIPV6_AUTOCONF%3Dno%0A"
+          "source": "data:,BOOTPROTO%3D'dhcp'%0ASTARTMODE%3D'auto'%0AUSERCONTROL%3D'no'%0A"
 %{ endif ~}
         },
         "mode": 420

--- a/backend_modules/libvirt/host/network_config.yaml
+++ b/backend_modules/libvirt/host/network_config.yaml
@@ -10,6 +10,8 @@ network:
 %{ else }
       dhcp4: true
       dhcp6: false
+      dhcp4-overrides:
+        use-domains: true
 %{ endif }
 %{ else }
 network:

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -838,6 +838,16 @@ yum_repos:
     gpgcheck: false
     name: amazon2
 
+write_files:
+  # Amazon 2023 does not honour DHCP's domain-search by default
+  - path: /etc/systemd/network/99-use-domains.network
+    permissions: '0644'
+    content: |
+      [Match]
+      Name=*
+      [DHCPv4]
+      UseDomains=true
+
 runcmd:
   # WORKAROUND: cloud-init in Amazon Linux 2023 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -705,6 +705,8 @@ runcmd:
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq install salt-minion avahi-daemon qemu-guest-agent"
 %{ endif ~}
   - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
+  # Debian systems do not honour DHCP's domain-search by default
+  - "sed -i -E 's/^hosts:.*/hosts:          files dns myhostname/' /etc/nsswitch.conf"
   - systemctl start qemu-guest-agent
   - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif ~}


### PR DESCRIPTION
## What does this PR change?

 * Fix `hostname -f`:
   - on Amazon 2023, `systemd-networkd` ignores `domain-search` DHCP directives by default
   - on Debian 12 and 13, `netplan` and `systemd-resolved` ignore `domain-search` DHCP directives by default
 * Fix IPv6:
   - on SL Micro 5.2, ignition setup was disabling IPv6
   
Tested within sumaform on suma-05.
