### PR TITLE
FIX: remove incorrect netplan workaround from ubuntu2604 cloud-init config

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -600,10 +600,6 @@ apt:
         -----END PGP PUBLIC KEY BLOCK-----
 
 runcmd:
-  # WORKAROUND: wrong interface name in noble's netplan configuration
-  - sed -i 's/eth0:/ens3:/' /etc/netplan/50-cloud-init.yaml
-  - netplan apply
-  - systemctl restart systemd-networkd
   # WORKAROUND: cloud-init in Ubuntu 26.04 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart ssh


### PR DESCRIPTION
## What does this PR change?

  The ubuntu2604 runcmd block incorrectly inherited the ubuntu2404 ("noble") netplan workaround, which restarts systemd-networkd to rename eth0 to ens3. On ubuntu2604 ("resolute") the interface is already named ens3, so the sed is a no-op but the systemctl restart systemd-networkd tears the network down. The subsequent apt-get calls fail silently, leaving qemu-guest-agent uninstalled and preventing Terraform from retrieving the VM's IP address.