### PR TITLE
Fix: install qemu-guest-agent via cloud-init packages directive on ubuntu2604

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -599,19 +599,22 @@ apt:
         =eJaK
         -----END PGP PUBLIC KEY BLOCK-----
 
+# WORKAROUND: install via packages directive to avoid apt lock race with cloud-init's own apt-get update
+packages:
+  - avahi-daemon
+  - qemu-guest-agent
+
 runcmd:
   # WORKAROUND: cloud-init in Ubuntu 26.04 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
   - systemctl restart ssh
+  - systemctl start qemu-guest-agent
 %{ if install_salt_bundle ~}
-  - "apt-get -yq update"
-  - "DEBIAN_FRONTEND=noninteractive apt-get -yq install venv-salt-minion avahi-daemon qemu-guest-agent"
+  - "DEBIAN_FRONTEND=noninteractive apt-get -yq install venv-salt-minion"
 %{ else ~}
-  - "apt-get -yq update"
-  - "DEBIAN_FRONTEND=noninteractive apt-get -yq install salt-minion avahi-daemon qemu-guest-agent"
+  - "DEBIAN_FRONTEND=noninteractive apt-get -yq install salt-minion"
 %{ endif ~}
   - "rm -f /etc/apt/sources.list.d/tools_pool_repo.list"
-  - systemctl start qemu-guest-agent
   - "rpm --version &>/dev/null && rpm -qa | sort >/installed_packages.txt || dpkg --list | grep '^ii' >/installed_packages.txt"
 %{ endif }
 


### PR DESCRIPTION
## What does this PR change?

  On Ubuntu 26.04, cloud-init v26.1 wraps its own apt-get update with eatmydata and holds the apt lock. When runcmd runs immediately after and calls apt-get install, it hits that lock and fails silently in under 2 seconds — leaving qemu-guest-agent uninstalled and Terraform unable to retrieve the domain IP.

  Moving qemu-guest-agent and avahi-daemon to the packages: directive lets cloud-init handle installation with proper lock management, before runcmd runs.
