### PR TITLE
Use the legacy iPXE option ROM for PXE booted terminals

### DIFF
--- a/backend_modules/libvirt/host/pxe_boot.xsl
+++ b/backend_modules/libvirt/host/pxe_boot.xsl
@@ -51,11 +51,18 @@
     </xsl:element>
   </xsl:template>
 
-  <!-- Boot order = 1 for network -->
+  <!-- Boot order = 1 for network, with the legacy BIOS iPXE option ROM -->
+  <!-- qemu defaults to efi-virtio.rom, which on SLE 16.1 hypervisors holds only
+       EFI images. SeaBIOS then has no network boot device and the terminal
+       silently boots from its disk instead of PXE booting. -->
   <xsl:template match="/domain/devices/interface[@type = 'network']">
     <xsl:element name="interface">
       <xsl:apply-templates select="node()|@*"/>
       <xsl:text>  </xsl:text>
+      <xsl:element name="rom">
+        <xsl:attribute name="file">/usr/share/qemu/pxe-virtio.rom</xsl:attribute>
+      </xsl:element>
+      <xsl:text>&#x0A;      </xsl:text>
       <xsl:element name="boot">
         <xsl:attribute name="order">1</xsl:attribute>
       </xsl:element>


### PR DESCRIPTION
## What does this PR change?

Pins the PXE booted terminal's network interface to `/usr/share/qemu/pxe-virtio.rom`, the legacy BIOS iPXE option ROM.

qemu defaults `virtio-net-pci` to `efi-virtio.rom`. On SLE 15 SP7 hypervisors that file is a combined ROM holding both a legacy x86 image and the EFI ones, so a SeaBIOS guest can netboot from it. On SLE 16.1 hypervisors it holds EFI images only, so the option ROM never runs, SeaBIOS ends up with no network boot device, and the terminal boots from its disk. The boot order in the domain XML is correct — it just has nothing to point at.

Without the ROM, SeaBIOS goes straight to the disk:

```
Press ESC for boot menu.

Booting from Hard Disk...
GRUB loading.......
```

With it:

```
Booting from ROM...
iPXE (PCI 00:03.0) starting execution...ok
iPXE 1.21.1+git20250827.61b4585e2 -- Open Source Network Boot Firmware
net0: 52:54:00:2a:53:9c using virtio-net on 0000:00:03.0 (Ethernet) [open]
Configuring (net0 52:54:00:2a:53:9c)...
```

`pxe-virtio.rom` comes from `qemu-ipxe`, which `qemu-x86` requires, so it is present on every supported hypervisor — verified on suma-01 (SLE 16.1) and suma-02 through suma-05 (SLE 15 SP7).
