### PR TITLE
AWS: Leap 16 setup

### DIFF
--- a/backend_modules/aws/host/user_data.yaml
+++ b/backend_modules/aws/host/user_data.yaml
@@ -37,6 +37,8 @@ runcmd:
 
 %{ if image == "opensuse160o" ~}
 runcmd:
+  - zypper addrepo -G -e http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_16-Uyuni-Client-Tools/openSUSE_Leap_16.0/ temp_tools_pool_repo
+  - zypper ref
 %{ if install_salt_bundle ~}
   - zypper in --allow-vendor-change --no-confirm venv-salt-minion
 %{ else ~}
@@ -45,6 +47,10 @@ runcmd:
   - zypper removerepo --all
   - zypper --non-interactive modifyservice --disable openSUSE || true
   - zypper --non-interactive removeservice openSUSE || true
+  # WORKAROUND: cloud-init in SLES 16 does not take care of the following
+  - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config.d/root.conf
+  - echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config.d/root.conf
+  - systemctl restart sshd
 
 %{ endif ~}
 

--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -35,20 +35,20 @@ change_searchlist_netconfig:
     - name: /etc/sysconfig/network/config
     - pattern: NETCONFIG_DNS_STATIC_SEARCHLIST=.*
     - repl: NETCONFIG_DNS_STATIC_SEARCHLIST="{{ grains['domain'] }}"
-    - onlyif: test -f /etc/sysconfig/network/config
+    - onlyif: test -f /etc/sysconfig/network/config && command -v netconfig
 
 netconfig_update:
   cmd.run:
     - name: netconfig update -f
     - require:
       - file: change_searchlist_netconfig
-    - onlyif: test -f /etc/sysconfig/network/config
+    - onlyif: test -f /etc/sysconfig/network/config && command -v netconfig
 
 change_searchlist:
   file.append:
     - name: /etc/resolv.conf
     - text: search {{ grains['domain'] }}
-    - unless: test -f /etc/sysconfig/network/config
+    - unless: test -f /etc/sysconfig/network/config && command -v netconfig
 
 # set the hostname and FQDN name in /etc/hosts
 # this is not needed if a proper DNS server is in place, but when using avahi this


### PR DESCRIPTION
## What does this PR change?

A couple adjustments needed to make the Leap 16 controller work in Uyni AWS CI:

1) Add Uyuni tools repo and SSH permissions in the cloud init phase
2) Check that netconfig is actually available on the system before attempting an update of related configuration files
