### PR TITLE
Remove tests on prs

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -29,15 +29,6 @@ Legal values for work-in-progress software are:
 **Important:** sumaform only supports containerized deployments for SUSE Manager versions 5.0 and later.
 Please use `server_containerized` and `proxy_containerized` modules with product versions `head` and `5.0-X`.
 
-Legal values for CI:
-
-`uyuni-pr` is a special product version used internally to test Pull Requests. Packages are under a subproject in systemsmanagement:Uyuni:Master:TEST and systemsmanagement:Uyuni:Master:PR.
-This is not meant to be used outside the Continous Integration system (CI).
-
-Similarly, `4.3-pr` is used for testing Pull Requests on Manager-4.3.
-
-Because packages are under different subprojects for each CI run and each Pull Request, repositories will be added later as additional repositories.
-
 Note: the version of Salt on minions is determined by this value, as Salt is obtained from SUSE Manager Tools repos.
 
 Note: on clients and minions only, the version number can be omitted to take the default for the distribution, eg. `released` and `nightly` are legal values.

--- a/backend_modules/libvirt/host/combustion
+++ b/backend_modules/libvirt/host/combustion
@@ -80,7 +80,7 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
 
 # SL Micro 6.0 is being used in both Uyuni and Multi-Linux Manager
 # we do not support yet Leap Micro 6.0, even in Uyuni
-%{ if product_version == "uyuni-master" || product_version == "uyuni-released" || product_version == "uyuni-pr" }
+%{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
 zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/SLMicro6-Uyuni-Client-Tools/SL-Micro6/ client_tools_repo
 %{ else }
 zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Products/SUSE-Manager-Tools-For-SL-Micro/6/x86_64/product/ tools_pool_repo
@@ -92,14 +92,14 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
 
 # SL Micro 6.1 is being used in both Uyuni and Multi-Linux Manager
 # we do not support yet Leap Micro 6.1, even in Uyuni
-  %{ if product_version == "uyuni-master" || product_version == "uyuni-released" || product_version == "uyuni-pr" }
+  %{ if product_version == "uyuni-master" || product_version == "uyuni-released" }
     zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org"}/repositories/systemsmanagement:/Uyuni:/Master:/SLMicro6-Uyuni-Client-Tools/SL-Micro6/ client_tools_repo
   %{ else }
     zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Products/SUSE-Manager-Tools-For-SL-Micro/6/x86_64/product/ tools_pool_repo
   %{ endif }
 
   %{ if container_server || container_proxy }
-    %{ if product_version == "uyuni-master" || product_version == "uyuni-pr" }
+    %{ if product_version == "uyuni-master" }
       zypper ar http://${ use_mirror_images ? mirror : "download.opensuse.org" }/repositories/systemsmanagement:/Uyuni:/Master:/ContainerUtils/openSUSE_Leap_16.0/ container_utils_repo
     %{ endif }
     %{ if product_version == "5.1-released" }
@@ -166,11 +166,7 @@ zypper ar http://${ use_mirror_images ? mirror : "dist.suse.de/ibs"}/SUSE/Produc
   for i in ${additional_repos}; do
     name=$(echo $i | cut -d= -f1)
     url=$(echo $i | cut -d= -f2)
-    %{ if product_version == "uyuni-pr" }
-      zypper ar --no-gpgcheck $url $name
-    %{ else }
-      zypper ar $url $name
-    %{ endif }
+    zypper ar $url $name
   done
 %{ endif }
 

--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -236,7 +236,7 @@ zypper:
       enabled: true
       gpgcheck: false
       name: tools_pool_repo
-%{ if product_version == "4.3-nightly" || product_version == "4.3-released" || product_version == "4.3-pr" ~}
+%{ if product_version == "4.3-nightly" || product_version == "4.3-released" ~}
     # the SUSE certificates are needed because of the containerized proxy tests
     - id: ca_suse
       name: ca_suse
@@ -252,7 +252,7 @@ runcmd:
 %{ else ~}
   - "zypper -n in avahi nss-mdns qemu-guest-agent"
 %{ endif ~}
-%{ if product_version == "4.3-nightly" || product_version == "4.3-released" || product_version == "4.3-pr" ~}
+%{ if product_version == "4.3-nightly" || product_version == "4.3-released" ~}
   # the SUSE certificates are needed because of the containerized proxy tests
   - "zypper -n in ca-certificates-suse"
 %{ endif ~}

--- a/backend_modules/null/base/variables.tf
+++ b/backend_modules/null/base/variables.tf
@@ -84,7 +84,7 @@ variable "is_server_paygo_instance" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-nightly, 4.3-released, 4.3-pr, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-nightly, 4.3-released, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = ""
 }

--- a/backend_modules/null/host/variables.tf
+++ b/backend_modules/null/host/variables.tf
@@ -127,7 +127,7 @@ variable "volume_provider_settings" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/build_host/variables.tf
+++ b/modules/build_host/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/client/variables.tf
+++ b/modules/client/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released"
   type        = string
   default     = null
 }

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -2,7 +2,6 @@ variable "testsuite-branch" {
   default = {
     "4.3-released"   = "Manager-4.3"
     "4.3-nightly"    = "Manager-4.3"
-    "4.3-pr"         = "Manager-4.3"
     "4.3-VM-released"= "Manager-4.3"
     "4.3-VM-nightly" = "Manager-4.3"
     "5.0-released"   = "Manager-5.0"
@@ -16,7 +15,6 @@ variable "testsuite-branch" {
     "uyuni-master"   = "master"
     "uyuni-main"     = "master"
     "uyuni-released" = "master"
-    "uyuni-pr"       = "master"
   }
 }
 

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -921,7 +921,7 @@ variable "server_instance_id" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/cucumber_testsuite/variables.tf
+++ b/modules/cucumber_testsuite/variables.tf
@@ -84,7 +84,7 @@ variable "host_settings" {
 
 // server
 variable "product_version" {
-  description = "One of: head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/minion/variables.tf
+++ b/modules/minion/variables.tf
@@ -13,7 +13,7 @@ variable "roles" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/proxy/main.tf
+++ b/modules/proxy/main.tf
@@ -2,7 +2,6 @@ variable "images" {
   default = {
     "4.3-released"   = "sles15sp4o"
     "4.3-nightly"    = "sles15sp4o"
-    "4.3-pr"         = "sles15sp4o"
     "4.3-build_image"= "sles15sp4o"
     "4.3-VM-nightly" = "sles15sp4o"
     "4.3-VM-released"= "sles15sp4o"
@@ -10,7 +9,6 @@ variable "images" {
     "uyuni-master"   = "opensuse156o"
     "uyuni-main"     = "opensuse156o"
     "uyuni-released" = "opensuse156o"
-    "uyuni-pr"       = "opensuse156o"
   }
 }
 

--- a/modules/proxy/variables.tf
+++ b/modules/proxy/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released"
   type        = string
   default     = null
 }

--- a/modules/proxy_containerized/main.tf
+++ b/modules/proxy_containerized/main.tf
@@ -11,7 +11,6 @@ variable "images" {
     "uyuni-master"   = "tumbleweedo"
     "uyuni-main"     = "tumbleweedo"
     "uyuni-released" = "tumbleweedo"
-    "uyuni-pr"       = "tumbleweedo"
   }
 }
 

--- a/modules/proxy_containerized/variables.tf
+++ b/modules/proxy_containerized/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/proxy_kubernetes/main.tf
+++ b/modules/proxy_kubernetes/main.tf
@@ -6,7 +6,6 @@ variable "images" {
     "uyuni-master"   = "tumbleweedo"
     "uyuni-main"     = "tumbleweedo"
     "uyuni-released" = "tumbleweedo"
-    "uyuni-pr"       = "tumbleweedo"
   }
 }
 

--- a/modules/proxy_kubernetes/variables.tf
+++ b/modules/proxy_kubernetes/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -2,7 +2,6 @@ variable "images" {
   default = {
     "4.3-released"    = "sles15sp4o"
     "4.3-nightly"     = "sles15sp4o"
-    "4.3-pr"          = "sles15sp4o"
     "4.3-build_image" = "sles15sp4o"
     "4.3-paygo"       = "suma-server-43-paygo"
     "4.3-VM-nightly"  = "suma43VM-ign"
@@ -11,7 +10,6 @@ variable "images" {
     "uyuni-master"    = "opensuse156o"
     "uyuni-main"      = "opensuse156o"
     "uyuni-released"  = "opensuse156o"
-    "uyuni-pr"        = "opensuse156o"
   }
 }
 

--- a/modules/server/variables.tf
+++ b/modules/server/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released"
   type        = string
   default     = null
 }

--- a/modules/server_containerized/main.tf
+++ b/modules/server_containerized/main.tf
@@ -13,7 +13,6 @@ variable "images" {
     "uyuni-master"   = "tumbleweedo"
     "uyuni-main"     = "tumbleweedo"
     "uyuni-released" = "tumbleweedo"
-    "uyuni-pr"       = "tumbleweedo"
   }
 }
 

--- a/modules/server_containerized/variables.tf
+++ b/modules/server_containerized/variables.tf
@@ -108,7 +108,7 @@ variable "tftpd_container_tag" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/server_kubernetes/main.tf
+++ b/modules/server_kubernetes/main.tf
@@ -8,7 +8,6 @@ variable "images" {
     "uyuni-master"   = "tumbleweedo"
     "uyuni-main"     = "tumbleweedo"
     "uyuni-released" = "tumbleweedo"
-    "uyuni-pr"       = "tumbleweedo"
   }
 }
 

--- a/modules/server_kubernetes/variables.tf
+++ b/modules/server_kubernetes/variables.tf
@@ -215,7 +215,7 @@ variable "db_container_tag" {
 }
 
 variable "product_version" {
-  description = "One of: head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/sshminion/variables.tf
+++ b/modules/sshminion/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.1-nightly, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/modules/virthost/variables.tf
+++ b/modules/virthost/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 4.3-released, 4.3-nightly, 4.3-pr, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.1-nightly, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released, uyuni-pr"
+  description = "One of: 4.3-released, 4.3-nightly, 4.3-build_image, 4.3-VM-nightly, 4.3-VM-released, 5.1-nightly, 5.1-released, 5.1-nightly, 5.2-nightly, 5.2-released, head, head-staging, uyuni-master, uyuni-main, uyuni-released"
   type        = string
   default     = null
 }

--- a/salt/repos/additional.sls
+++ b/salt/repos/additional.sls
@@ -6,14 +6,9 @@
   pkgrepo.managed:
     - humanname: {{ label }}_repo
   {%- if grains['os_family'] == 'Debian' %}
-  {%- if 'uyuni-pr' in grains.get('product_version', '') or '4.3-pr' in grains.get('product_version', '') %}
-    - name: deb [trusted=yes] {{ url }} /
-    - file: /etc/apt/sources.list.d/sumaform_additional_repos.list
-  {%- else %}
     - name: deb {{ url }} /
     - file: /etc/apt/sources.list.d/sumaform_additional_repos.list
     - key_url: {{ url }}/Release.key
-  {%- endif %}
   {%- else %}
     - baseurl: {{ url }}
     - refresh: True

--- a/salt/repos/default_settings.sls
+++ b/salt/repos/default_settings.sls
@@ -112,7 +112,7 @@ suse_res7_key:
       - file: suse_res7_key
 {% endif %}
 
-{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-main' in grains.get('product_version', '') or 'uyuni-released' in grains.get('product_version', '') or 'uyuni-pr' in grains.get('product_version', '') %}
+{% if 'uyuni-master' in grains.get('product_version', '') or 'uyuni-main' in grains.get('product_version', '') or 'uyuni-released' in grains.get('product_version', '') %}
 
 uyuni_key:
   file.managed:

--- a/salt/repos/proxy43.sls
+++ b/salt/repos/proxy43.sls
@@ -51,7 +51,7 @@ containers_updates_repo:
 
 {% endif %}
 
-{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] or '4.3-VM-nightly' in grains['product_version'] %}
+{% if '4.3-nightly' in grains['product_version'] or '4.3-VM-nightly' in grains['product_version'] %}
 proxy_devel_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("dist.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/4.3/images/repo/SLE-Module-SUSE-Manager-Proxy-4.3-POOL-{{ grains.get("cpuarch") }}-Media1/

--- a/salt/repos/proxyUyuni.sls
+++ b/salt/repos/proxyUyuni.sls
@@ -8,7 +8,7 @@ proxy_pool_repo:
     - priority: 97
 {% endif %}
 
-{% if 'uyuni-master' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') or '4.3-pr' in grains.get('product_version') %}
+{% if 'uyuni-master' in grains.get('product_version') %}
 proxy_devel_repo:
   pkgrepo.managed:
     - baseurl: http://{{ grains.get("mirror") | default("downloadcontent.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images/repo/Uyuni-Proxy-POOL-{{ grains.get("cpuarch") }}-Media1/

--- a/salt/repos/server43.sls
+++ b/salt/repos/server43.sls
@@ -48,7 +48,7 @@ module_web_scripting_update_repo:
 
 {% endif %}
 
-{% if '4.3-nightly' in grains['product_version'] or '4.3-pr' in grains['product_version'] or '4.3-VM-nightly' in grains['product_version'] %}
+{% if '4.3-nightly' in grains['product_version'] or '4.3-VM-nightly' in grains['product_version'] %}
 
 server_devel_repo:
   pkgrepo.managed:

--- a/salt/server/postgres.sls
+++ b/salt/server/postgres.sls
@@ -23,7 +23,7 @@ postgresql_hba_configuration:
   file.append:
     - name: /var/lib/pgsql/data/pg_hba.conf
     - text: |
-{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-pr', '4.3-released', '4.3-VM-nightly', '4.3-VM-released'] %}
+{%- if grains['product_version'] in ['head', 'beta', '4.3-nightly', '4.3-released', '4.3-VM-nightly', '4.3-VM-released'] %}
         host    all     all       0.0.0.0/0      scram-sha-256
         host    all     all       ::/0           scram-sha-256
 {%- else %}

--- a/salt/server/testsuite.sls
+++ b/salt/server/testsuite.sls
@@ -55,7 +55,7 @@ test_repo_debian_updates:
 {% endif %}
 
 # modify Cobbler to be executed from remote-machines..
-{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-main", "uyuni-released", "uyuni-pr", "head", "head-staging", "4.3-released", "4.3-nightly", "4.3-pr", "4.3-VM-nightly", "4.3-VM-released" ] %}
+{% set products_using_new_cobbler_version = ["uyuni-master", "uyuni-main", "uyuni-released", "head", "head-staging", "4.3-released", "4.3-nightly", "4.3-VM-nightly", "4.3-VM-released" ] %}
 {% set cobbler_use_settings_yaml = grains.get('product_version') | default('', true) in products_using_new_cobbler_version %}
 {% if 'build_image' not in grains.get('product_version', '') and 'paygo' not in grains.get('product_version', '') %}
 cobbler_configuration:
@@ -102,14 +102,14 @@ testsuite_salt_packages:
   pkg.installed:
     - pkgs:
       - salt-ssh
-{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'uyuni-main' in grains.get('product_version') or 'nightly' in grains.get('product_version') or 'uyuni-pr' in grains.get('product_version') or '4.3-pr' in grains.get('product_version') %}
+{% if 'head' in grains.get('product_version') or 'uyuni-master' in grains.get('product_version') or 'uyuni-main' in grains.get('product_version') or 'nightly' in grains.get('product_version') %}
     - fromrepo: testing_overlay_devel_repo
 {% endif %}
     - require:
       - sls: repos
 {% endif %}
 
-{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-main", "uyuni-pr", "4.3-nightly", "4.3-released", "4.3-pr", "4.3-VM-nightly", "4.3-VM-released"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-main", "4.3-nightly", "4.3-released", "4.3-VM-nightly", "4.3-VM-released"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,

--- a/salt/server_containerized/testsuite.sls
+++ b/salt/server_containerized/testsuite.sls
@@ -72,7 +72,7 @@ cobbler_restart:
     - require:
       - cmd: cobbler_configuration
 
-{%- if grains.get('product_version') | default('', true) in ['uyuni-master', 'uyuni-main', 'uyuni-pr', 'uyuni-released'] %}
+{%- if grains.get('product_version') | default('', true) in ['uyuni-master', 'uyuni-main', 'uyuni-released'] %}
 uyuni_key_copy_host:
   file.managed:
     - name: /tmp/uyuni.key
@@ -111,7 +111,7 @@ suse_staging_key_import:
 
 {% endif %}
 
-{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-main", "uyuni-pr", "head", "head-staging", "5.1-nightly", "5.1-released", "5.2-nightly", "5.2-released"] %}
+{% set products_to_use_salt_bundle = ["uyuni-master", "uyuni-main", "head", "head-staging", "5.1-nightly", "5.1-released", "5.2-nightly", "5.2-released"] %}
 {% if grains.get('product_version') | default('', true) in products_to_use_salt_bundle %}
 
 # The following states are needed to ensure "venv-salt-minion" is used during bootstrapping,


### PR DESCRIPTION
## What does this PR change?

Removes the `uyuni-pr` and `4.3-pr` product versions, used only by the Jenkins
"tests on PRs" pipelines, which are being retired. Touches the `product_version`
documentation in every module, the `salt/repos/*` definitions and the mirror's
`minima.yaml`.
 
## See also

 * https://github.com/SUSE/spacewalk/issues/31315
 * https://gitlab.suse.de/galaxy/infrastructure/-/merge_requests/1267
 * https://github.com/SUSE/susemanager-ci/pull/2188
