### PR TITLE
Point CentOS 7 repos at a working vault archive

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -47,6 +47,7 @@ runcmd:
 %{ if image == "centos7o" ~}
 bootcmd:
   # HACK: mirrorlist.centos.org doesn't exist anymore
+  - sed -i 's,mirror.centos.org/centos/$releasever,archive.kernel.org/centos-vault/7.9.2009,g' /etc/yum.repos.d/*.repo
   - sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
   - sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
   - sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo


### PR DESCRIPTION
Rewrites the CentOS 7 base, updates, extras and centosplus baseurls to `archive.kernel.org/centos-vault/7.9.2009` before the existing `mirror.centos.org` → `vault.centos.org` hop, so those four repos never land on the vault.

`vault.centos.org` serves `repomd.xml` but returns HTTP 403 for the `*-primary.sqlite.bz2` metadata objects that `repomd.xml` references. yum prefers the sqlite databases over `primary.xml.gz`, so a metadata refresh on `centos7o` fails and takes any package install down with it — even one that only needs a local repo, since yum refreshes every enabled repo before resolving:

```
http://vault.centos.org/centos/7/os/x86_64/repodata/6d0c3a48...-primary.sqlite.bz2: [Errno 14] HTTPS Error 403 - Forbidden
failure: repodata/6d0c3a48...-primary.sqlite.bz2 from base: [Errno 256] No more mirrors to try.
```

The 403 is edge-cache dependent, so the same request succeeds on one client and fails on the next one provisioned two minutes later. `archive.kernel.org` carries a complete 7.9.2009 tree and serves the sqlite metadata, so base, updates and extras keep working and the packages in them stay installable.

The release is spelled out because `archive.kernel.org/centos-vault/` only keeps point-release trees — there is no `7/` directory — and 7.9.2009 is the last CentOS 7 release there will be. The pattern keeps the literal `$releasever` because that is the text in the stock repo file; single quotes stop the cloud-init shell from expanding it.

The three existing seds are unchanged and all still needed: `mirrorlist.centos.org` is NXDOMAIN, the stock `baseurl` lines ship commented out, and the `mirror.centos.org` → `vault.centos.org` swap still covers the repos this change does not touch (all of them disabled).

Verified on a deployed `centos7o` client — before the change `yum makecache` exits 1 with the 403 above; after it, `makecache` and an install of a base-only package both succeed:

```
# yum makecache
MAKECACHE_EXIT=0
# yum -y install telnet
Installed:
  telnet.x86_64 1:0.17-66.el7
Complete!
```
