### PR TITLE
Always use PRG mirror for ARM

### DIFF
--- a/modules/build_validation/main.tf
+++ b/modules/build_validation/main.tf
@@ -39,7 +39,8 @@ module "base_arm" {
   domain          = var.platform_location_configuration[var.location].domain
   images          = ["opensuse156armo", "opensuse160armo", "raspios13o"]
 
-  mirror            = var.platform_location_configuration[var.location].mirror
+  # Always use Prague's mirror, even if the test suite runs in Salt Lake City
+  mirror            = var.platform_location_configuration["prg2"].mirror
   use_mirror_images = true
 
   testsuite = true


### PR DESCRIPTION
## What does this PR change?

Always use PRG mirror for ARM, even if the test suite runs in SLC, as we have only one ARM hypervisor in PRG.

Depends on https://sd.suse.com/servicedesk/customer/portal/1/SD-232240.