### PR TITLE
Allow to specify ARM's images list

### DIFF
--- a/modules/build_validation/main.tf
+++ b/modules/build_validation/main.tf
@@ -37,7 +37,7 @@ module "base_arm" {
   name_prefix     = var.environment_configuration.name_prefix
   use_avahi       = false
   domain          = var.platform_location_configuration[var.location].domain
-  images          = ["opensuse156armo", "opensuse160armo", "raspios13o"]
+  images          = var.base_configurations.base_arm.images
 
   # Always use Prague's mirror, even if the test suite runs in Salt Lake City
   mirror            = var.platform_location_configuration["prg2"].mirror


### PR DESCRIPTION
## What does this PR change?

Allow to specify ARM's images list in susemanager-ci

(it differs between 4.3 and 5.2: openSUSE 15.6 versus 16.0 ; also, we have sometimes raspi OS 13)
