### PR TITLE
Enable sonarcloud for sumaform

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,75 @@
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches:
+      - master
+  workflow_run:
+    workflows: [CI validation tests]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
+      with:
+        ref: ${{ github.event.workflow_run.head_sha }}
+        fetch-depth: 0 # Deep clone required for accurate blame information
+
+    - name: Find the pull request the run belongs to
+      if: github.event_name == 'workflow_run'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      run: |
+        pull_request=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+          --jq 'map(select(.state == "open")) | first')
+        if [ -z "$pull_request" ] || [ "$pull_request" = "null" ]; then
+          echo "No open pull request for ${HEAD_SHA}, skipping the scan"
+          exit 0
+        fi
+        {
+          echo "PR_NUMBER=$(echo "$pull_request" | jq -r '.number')"
+          echo "PR_BASE=$(echo "$pull_request" | jq -r '.base.ref')"
+          echo "PR_BRANCH=${HEAD_BRANCH}"
+        } >>"$GITHUB_ENV"
+
+    - name: Take the analysis configuration from the base branch
+      if: github.event_name == 'workflow_run' && env.PR_NUMBER != ''
+      run: |
+        git fetch origin "${PR_BASE}"
+        git checkout FETCH_HEAD -- sonar-project.properties
+
+    - name: Scan the pull request
+      if: github.event_name == 'workflow_run' && env.PR_NUMBER != ''
+      uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f #v8.2.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_HOST_URL: https://sonarcloud.io
+      with:
+        args: >
+          -Dsonar.host.url=https://sonarcloud.io
+          -Dsonar.organization=uyuni-project
+          -Dsonar.projectKey=uyuni-project_sumaform
+          -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+          -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
+          -Dsonar.pullrequest.branch=${{ env.PR_BRANCH }}
+          -Dsonar.pullrequest.base=${{ env.PR_BASE }}
+
+    - name: Scan master
+      if: github.event_name == 'push'
+      uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f #v8.2.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_HOST_URL: https://sonarcloud.io

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,21 @@
+sonar.projectKey=uyuni-project_sumaform
+sonar.organization=uyuni-project
+
+# Analyze all files in the current directory
+sonar.sources=.
+
+# Focus analysis on HCL, Python, and Shell scripts
+sonar.inclusions=**/*.tf, **/*.sh, **/*.py
+
+# Ignore documentation and image build configurations
+sonar.exclusions=**/*.md, images/**
+
+# Most of the Python under salt/ is a Jinja template rendered by Salt rather than
+# valid Python. The analyzer reads an assignment such as
+#   HUB_FQDN = {{ hub_fqdn | tojson }}
+# as a set literal nested in a set literal and reports python:S6662 on every one
+# of them. Ignore that single rule there instead of excluding the files, so the
+# remaining Python rules still apply.
+sonar.issue.ignore.multicriteria=jinjapy
+sonar.issue.ignore.multicriteria.jinjapy.ruleKey=python:S6662
+sonar.issue.ignore.multicriteria.jinjapy.resourceKey=salt/**/*.py


### PR DESCRIPTION
Adds a SonarCloud workflow and project configuration so pushes to `master` and pull requests get scanned, with analysis scoped to the Terraform, shell and Python sources. `python:S6662` is ignored under `salt/`, where most of the Python is a Jinja template and the analyzer reads `{{ var | tojson }}` as a set literal.

The pull request scan is chained on the `CI validation tests` workflow via `workflow_run` rather than running on `pull_request` directly, because pull requests opened from forks — which is how nearly all of them arrive here — cannot reach the `SONAR_TOKEN` secret otherwise. That scan analyses untrusted content, so it takes `sonar-project.properties` from the base branch and passes the SonarCloud host, organization and project key on the command line, where they override anything a pull request could set. The `workflow_run` trigger only takes effect once this is on `master`, so no scan appears on this pull request itself.
