### PR TITLE
Fix SonarCloud-reported defects in Salt scripts and CI

### DIFF
--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -22,7 +22,7 @@ jobs:
       run: sudo rm -f /etc/apt/sources.list.d/*google* /etc/apt/sources.list.d/*microsoft*
     - name: Install Salt using bootstrap
       run: |
-        curl -fsSL https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh -o install_salt.sh
+        curl -fsSL --proto '=https' --proto-redir '=https' --tlsv1.2 https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh -o install_salt.sh
         sudo sh install_salt.sh -P -x python3
     - name: Validate server states
       if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,8 @@
 **/.*.sw*
 .*.sw*
 
+__pycache__/
+*.py[cod]
+
 .idea
 sumaform.iml

--- a/salt/_states/manage_config.py
+++ b/salt/_states/manage_config.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 import re
+import shutil
+import tempfile
 
 def _check_file(name):
     ret = True
@@ -57,75 +59,81 @@ def manage_lines(name, key_value, mgrctl=False, regex_escape_keys=False):
         return _error(ret, f"key_value is '{key_value}' and should be a valid yaml dict")
 
     if not isinstance(key_value, dict):
-        return _error(ret, f"key_value must be a valid dictionary")
+        return _error(ret, "key_value must be a valid dictionary")
 
     name = Path(name)
     file_path = name
+    temp_dir = None
 
-    if mgrctl:
-        file_path = f"/tmp/{os.path.basename(name)}"
-        cmd = f"mgrctl cp server:{name} {file_path}"
-        try:
-            mgrctl_rc = __salt__["cmd.run_all"](cmd)
-            rc = mgrctl_rc.get("retcode", -1)
-        except Exception as e:
-            return _error(ret, "Error while trying to copy file with mgrctl:  {0}".format(e))
-        if rc != 0:
-            return _error(ret, f"{cmd} failed with rc {rc}: {mgrctl_rc.get('stderr')}")
+    try:
+        if mgrctl:
+            temp_dir = tempfile.mkdtemp()
+            file_path = os.path.join(temp_dir, os.path.basename(name))
+            cmd = f"mgrctl cp server:{name} {file_path}"
+            try:
+                mgrctl_rc = __salt__["cmd.run_all"](cmd)
+                rc = mgrctl_rc.get("retcode", -1)
+            except Exception as e:
+                return _error(ret, "Error while trying to copy file with mgrctl:  {0}".format(e))
+            if rc != 0:
+                return _error(ret, f"{cmd} failed with rc {rc}: {mgrctl_rc.get('stderr')}")
 
-        cmd = f"mgrctl exec 'stat -c \"%U %G\" \"{name}\"'"
-        try:
-            mgrctl_rc = __salt__['cmd.run_all'](cmd)
-            rc = mgrctl_rc.get("retcode", -1)
-        except Exception as e:
-            return _error(ret, "Error while trying to get file user and group with mgrctl:  {0}".format(e))
-        if rc != 0:
-            return _error(ret, f"{cmd} failed with rc {rc}: {mgrctl_rc.get('stderr')}")
-        user, group = mgrctl_rc.get("stdout", "root root").split()
+            cmd = f"mgrctl exec 'stat -c \"%U %G\" \"{name}\"'"
+            try:
+                mgrctl_rc = __salt__['cmd.run_all'](cmd)
+                rc = mgrctl_rc.get("retcode", -1)
+            except Exception as e:
+                return _error(ret, "Error while trying to get file user and group with mgrctl:  {0}".format(e))
+            if rc != 0:
+                return _error(ret, f"{cmd} failed with rc {rc}: {mgrctl_rc.get('stderr')}")
+            user, group = mgrctl_rc.get("stdout", "root root").split()
 
 
-    check_res, check_msg = _check_file(file_path)
-    if not check_res:
-        return _error(ret, check_msg)
+        check_res, check_msg = _check_file(file_path)
+        if not check_res:
+            return _error(ret, check_msg)
 
-    changes = {}
-    for key in key_value:
-        re_key = key
-        if regex_escape_keys:
-            re_key = re.escape(key)
-        repl_changes = __salt__["file.replace"](
-            file_path,
-            f"^{re_key} *=.*",
-            f"{key} = {key_value[key]}",
-            count=0,
-            flags=8,
-            bufsize=1,
-            append_if_not_found=True,
-            prepend_if_not_found=False,
-            not_found_content=None,
-            backup=False,
-            dry_run=False,
-            show_changes=True,
-            ignore_if_missing=False,
-            backslash_literal=False,
-        )
+        changes = {}
+        for key in key_value:
+            re_key = key
+            if regex_escape_keys:
+                re_key = re.escape(key)
+            repl_changes = __salt__["file.replace"](
+                file_path,
+                f"^{re_key} *=.*",
+                f"{key} = {key_value[key]}",
+                count=0,
+                flags=8,
+                bufsize=1,
+                append_if_not_found=True,
+                prepend_if_not_found=False,
+                not_found_content=None,
+                backup=False,
+                dry_run=False,
+                show_changes=True,
+                ignore_if_missing=False,
+                backslash_literal=False,
+            )
 
-        if repl_changes:
-            changes[key] = repl_changes
+            if repl_changes:
+                changes[key] = repl_changes
 
-    if len(changes) > 0:
-        ret["changes"] = changes
-        ret["comment"] = "Changes were made"
-        ret["result"] = True
+        if len(changes) > 0:
+            ret["changes"] = changes
+            ret["comment"] = "Changes were made"
+            ret["result"] = True
 
-    if mgrctl:
-        cmd = f"mgrctl cp --user {user} --group {group} {file_path} server:{name}"
-        try:
-            mgrctl_rc = __salt__["cmd.run_all"](cmd)
-            rc = mgrctl_rc.get("retcode", -1)
-        except Exception as e:
-            return _error(ret, "Error while trying to copy file to container with mgrctl:  {0}".format(e))
-        if rc != 0:
-            return _error(ret, f"{cmd} failed with rc {rc}: {mgrctl_rc.get('stderr')}")
+        if mgrctl:
+            cmd = f"mgrctl cp --user {user} --group {group} {file_path} server:{name}"
+            try:
+                mgrctl_rc = __salt__["cmd.run_all"](cmd)
+                rc = mgrctl_rc.get("retcode", -1)
+            except Exception as e:
+                return _error(ret, "Error while trying to copy file to container with mgrctl:  {0}".format(e))
+            if rc != 0:
+                return _error(ret, f"{cmd} failed with rc {rc}: {mgrctl_rc.get('stderr')}")
 
-    return ret
+        return ret
+    finally:
+        if temp_dir:
+            shutil.rmtree(temp_dir, ignore_errors=True)

--- a/salt/controller/https_server.py
+++ b/salt/controller/https_server.py
@@ -17,6 +17,7 @@ Handler = http.server.SimpleHTTPRequestHandler
 
 # Set up the SSL context
 context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+context.minimum_version = ssl.TLSVersion.TLSv1_2
 try:
     context.load_cert_chain(certfile=CERT_FILE, keyfile=KEY_FILE)
 except FileNotFoundError:

--- a/salt/first_deployment_highstate.sh
+++ b/salt/first_deployment_highstate.sh
@@ -5,6 +5,7 @@
 
 function is_transactional() {
   command -v transactional-update >/dev/null 2>&1
+  return $?
 }
 
 FILE_ROOT="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"

--- a/salt/jenkins/basic-security.groovy
+++ b/salt/jenkins/basic-security.groovy
@@ -1,7 +1,8 @@
 #!groovy
 
-import jenkins.model.*
-import hudson.security.*
+import jenkins.model.Jenkins
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy
+import hudson.security.HudsonPrivateSecurityRealm
 import static jenkins.model.Jenkins.instance as jenkins
 import jenkins.install.InstallState
 

--- a/salt/jenkins/configure-jenkins.sh
+++ b/salt/jenkins/configure-jenkins.sh
@@ -18,6 +18,7 @@ fi
 cli_call() {
   echo "[INFO] Running CLI call with arguments: ${@}"
   java -jar /tmp/jenkins-cli.jar -s ${URL} -auth admin:"$(cat /var/lib/jenkins/secrets/initialAdminPassword)" ${@}
+  return $?
 }
 
 # Only credential 2.6.1 is compatible with current LTS 2.303.3

--- a/salt/locust/locust-exporter.py
+++ b/salt/locust/locust-exporter.py
@@ -16,7 +16,7 @@ class LocustCollector(object):
     try:
         response = requests.get(url).content.decode('Utf-8')
     except requests.exceptions.ConnectionError:
-        print "Failed to connect to Locust:", url
+        print("Failed to connect to Locust:", url)
         return
 
     response = json.loads(response)
@@ -51,20 +51,20 @@ class LocustCollector(object):
             mtype = 'counter'
         metric = Metric('locust_requests_'+mtr, 'Locust requests '+mtr, mtype)
         for stat in response['stats']:
-            if not 'Total' in stat['name']:
+            if 'Total' not in stat['name']:
                 metric.add_sample('locust_requests_'+mtr, value=stat[mtr], labels={'path':stat['name'], 'method':stat['method']})
         yield metric
 
 if __name__ == '__main__':
   # Usage: locust_exporter.py <port> <locust_host:port>
   if len(sys.argv) != 3:
-      print 'Usage: locust_exporter.py <port> <locust_host:port>'
+      print('Usage: locust_exporter.py <port> <locust_host:port>')
       exit(1)
   else:
     try:
         start_http_server(int(sys.argv[1]))
         REGISTRY.register(LocustCollector(str(sys.argv[2])))
-        print "Connecting to locust on: " + sys.argv[2]
+        print("Connecting to locust on: " + sys.argv[2])
         while True: time.sleep(1)
     except KeyboardInterrupt:
         exit(0)

--- a/salt/server/wait_for_reposync.py
+++ b/salt/server/wait_for_reposync.py
@@ -34,12 +34,10 @@ client = Server(MANAGER_URL, verbose=0)
 
 session_key = client.auth.login(username, password)
 
-channels = filter(lambda c: c["label"] == channel, client.channel.listVendorChannels(session_key))
+channels = [c for c in client.channel.listVendorChannels(session_key) if c["label"] == channel]
 if not channels:
     print("Channel not found.")
     sys.exit(1)
-
-id = channels[0]["id"]
 
 print("Waiting for reposync to finish...")
 

--- a/salt/server_containerized/check_peripheral_registered.py
+++ b/salt/server_containerized/check_peripheral_registered.py
@@ -14,6 +14,7 @@ HUB_CA = "/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT"
 
 # Validate the hub certificate against the hub CA we already downloaded.
 ctx = ssl.create_default_context(cafile=HUB_CA)
+ctx.minimum_version = ssl.TLSVersion.TLSv1_2
 hub = xmlrpc.client.ServerProxy("https://%s/rpc/api" % HUB_FQDN, context=ctx)
 
 session = hub.auth.login(USERNAME, PASSWORD)

--- a/salt/server_containerized/register_peripheral.py
+++ b/salt/server_containerized/register_peripheral.py
@@ -12,6 +12,7 @@ HUB_CA = "/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT"
 
 # Validate the hub certificate against the hub CA we already downloaded.
 ctx = ssl.create_default_context(cafile=HUB_CA)
+ctx.minimum_version = ssl.TLSVersion.TLSv1_2
 hub = xmlrpc.client.ServerProxy("https://%s/rpc/api" % HUB_FQDN, context=ctx)
 
 session = hub.auth.login(USERNAME, PASSWORD)


### PR DESCRIPTION
Fixes the SonarCloud findings that are real defects and applies the cleanups it asks for. Two were actual breakage: `wait_for_reposync.py` filtered channels with `filter()`, which returns an iterator on Python 3, so the "Channel not found" branch could never be taken and `channels[0]` raised `TypeError`; and `locust-exporter.py` still used Python 2 `print` statements, so it failed to parse at all under the interpreter its shebang resolves to.

The rest is hardening and style: TLSv1.2 as the minimum on the three SSL contexts, a private temporary directory in place of a predictable `/tmp` path in the `manage_config` state (removed in a `finally` block on every exit path), `--proto '=https'` on the salt-bootstrap download, explicit function returns, `not in`, explicit Groovy imports, and a `__pycache__` ignore rule. The cloud hotspots and the `python:S6662` Jinja false positives are deliberately untouched — the former are correct for throwaway test environments, the latter are handled by an ignore rule in #2283.
