### PR TITLE
Drop unused third-party apt repositories before installing Salt

### DIFF
--- a/.github/workflows/ci-validation.yml
+++ b/.github/workflows/ci-validation.yml
@@ -18,6 +18,8 @@ jobs:
 #        packages: salt-common
 #        version: 1.0
 #        execute_install_scripts: true
+    - name: Remove unused third-party apt repositories
+      run: sudo rm -f /etc/apt/sources.list.d/*google* /etc/apt/sources.list.d/*microsoft*
     - name: Install Salt using bootstrap
       run: |
         curl -fsSL https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh -o install_salt.sh


### PR DESCRIPTION
Removes the Google Chrome and Microsoft apt repositories from the runner before the Salt bootstrap runs, so the Salt validation job only depends on the Ubuntu and SaltStack repositories it actually uses.

Both come preinstalled on the Ubuntu runner image. When one serves an inconsistent index, `apt-get update` fails, salt-bootstrap treats that as fatal, and every validation step dies with `salt-call: command not found`:

```
Err:24 https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages
  Hash Sum mismatch
 * ERROR: Failed to run install_ubuntu_onedir_deps()!!!
```