### PR TITLE
Let the SonarCloud scan check out fork pull requests

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,6 +23,7 @@ jobs:
       with:
         ref: ${{ github.event.workflow_run.head_sha }}
         fetch-depth: 0 # Deep clone required for accurate blame information
+        allow-unsafe-pr-checkout: true
 
     - name: Find the pull request the run belongs to
       if: github.event_name == 'workflow_run'


### PR DESCRIPTION
Sets `allow-unsafe-pr-checkout: true` on the checkout step of the SonarCloud workflow. `actions/checkout` v7 otherwise refuses to check out a fork's head from a `workflow_run` workflow, so every pull request scan died at that step and no analysis ever reached SonarCloud.

The scan hangs off `workflow_run` because a fork gets no `SONAR_TOKEN` on a `pull_request` run, and almost every pull request here comes from a fork. Nothing in the job runs code from the checkout: the scanner only parses `.tf`, `.sh` and `.py`, `sonar-project.properties` is replaced with the copy from the base branch so a pull request cannot repoint the scan, and `GITHUB_TOKEN` is read-only.