### PR TITLE
Find the pull request of a fork branch in the SonarCloud scan

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -29,13 +29,13 @@ jobs:
       if: github.event_name == 'workflow_run'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
       run: |
-        pull_request=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
-          --jq 'map(select(.state == "open")) | first')
+        pull_request=$(gh api "repos/${GITHUB_REPOSITORY}/pulls" -X GET \
+          -f state=open -f head="${HEAD_OWNER}:${HEAD_BRANCH}" --jq 'first')
         if [ -z "$pull_request" ] || [ "$pull_request" = "null" ]; then
-          echo "No open pull request for ${HEAD_SHA}, skipping the scan"
+          echo "No open pull request for ${HEAD_OWNER}:${HEAD_BRANCH}, skipping the scan"
           exit 0
         fi
         {


### PR DESCRIPTION
## What does this PR change?

The SonarCloud scan runs on `workflow_run` so that pull requests from forks can reach `SONAR_TOKEN`. It looked the pull request up with the `commits/{sha}/pulls` endpoint, which only answers for commits that live in the upstream repository. For a pull request opened from a fork it comes back empty, so the scan logged `No open pull request for <sha>, skipping the scan` and exited without analysing anything.

Seen on [run 34396252540](https://github.com/uyuni-project/sumaform/actions/runs/34396252540), the first scan to get past the checkout guard fixed in #2287: it checked the fork commit out correctly and then skipped on the lookup.

This looks the pull request up by head instead, using `head_repository.owner.login` and `head_branch` from the `workflow_run` payload. Verified against #2286: `commits/dc6b01db/pulls` returns an empty list, while `pulls?state=open&head=ktsamis:fix-sonarcloud-cleartext` returns the pull request. The same query resolves same-repository branches, so there is no separate path for them.

Like #2287, this only takes effect once it is on master: `workflow_run` always uses the default branch's copy of the workflow file.
