### PR TITLE
Create the ARM base only when the environment declares one

### DIFF
--- a/modules/build_validation/main.tf
+++ b/modules/build_validation/main.tf
@@ -6,6 +6,8 @@ locals {
   host_deblike = lookup(var.module_base_configurations, "deblike", local.base_core)
   base_retail  = lookup(var.module_base_configurations, "retail",  local.base_core)
 
+  base_arm_configuration = try(var.base_configurations.base_arm, null)
+
   server_configuration = length(module.server_containerized) > 0 ? module.server_containerized[0].configuration : module.server[0].configuration
   proxy_configuration = length(module.proxy_containerized) > 0 ? module.proxy_containerized[0].configuration : (length(module.proxy) > 0 ? module.proxy[0].configuration : local.empty_server_proxy_config)
   empty_minion_config = { ids = [], hostnames = [], macaddrs = [], private_macs = [], ipaddrs = [] }
@@ -30,6 +32,7 @@ module "base_arm" {
   }
 
   source = "../base"
+  count  = local.base_arm_configuration != null ? 1 : 0
 
   cc_username     = var.scc_user
   cc_password     = var.scc_password
@@ -37,7 +40,7 @@ module "base_arm" {
   name_prefix     = var.environment_configuration.name_prefix
   use_avahi       = false
   domain          = var.platform_location_configuration[var.location].domain
-  images          = var.base_configurations.base_arm.images
+  images          = coalesce(try(local.base_arm_configuration.images, null), ["opensuse156armo", "opensuse160armo", "raspios13o"])
 
   mirror            = var.platform_location_configuration[var.location].mirror
   use_mirror_images = true
@@ -46,7 +49,7 @@ module "base_arm" {
 
   provider_settings = {
     pool   = "ssd"
-    bridge = try(var.base_configurations.base_arm.bridge, "br1")
+    bridge = coalesce(try(local.base_arm_configuration.bridge, null), "br1")
   }
   ssh_key_path = var.controller_public_ssh_key_path
 }
@@ -756,8 +759,8 @@ module "opensuse156arm_minion" {
     libvirt = libvirt.host_arm
   }
   source             = "../minion"
-  count              = lookup(var.environment_configuration, "opensuse156arm_minion", null) != null ? 1 : 0
-  base_configuration = module.base_arm.configuration
+  count              = local.base_arm_configuration != null && lookup(var.environment_configuration, "opensuse156arm_minion", null) != null ? 1 : 0
+  base_configuration = module.base_arm[0].configuration
   name               = "${var.environment_configuration.opensuse156arm_minion.name}${var.platform_location_configuration[var.location].extension}"
   image              = "opensuse156armo"
   provider_settings = {
@@ -777,8 +780,8 @@ module "opensuse160arm_minion" {
     libvirt = libvirt.host_arm
   }
   source             = "../minion"
-  count              = lookup(var.environment_configuration, "opensuse160arm_minion", null) != null ? 1 : 0
-  base_configuration = module.base_arm.configuration
+  count              = local.base_arm_configuration != null && lookup(var.environment_configuration, "opensuse160arm_minion", null) != null ? 1 : 0
+  base_configuration = module.base_arm[0].configuration
   name               = "${var.environment_configuration.opensuse160arm_minion.name}${var.platform_location_configuration[var.location].extension}"
   image              = "opensuse160armo"
   provider_settings = {
@@ -798,8 +801,8 @@ module "raspios13_minion" {
     libvirt = libvirt.host_arm
   }
   source             = "../minion"
-  count              = lookup(var.environment_configuration, "raspios13_minion", null) != null ? 1 : 0
-  base_configuration = module.base_arm.configuration
+  count              = local.base_arm_configuration != null && lookup(var.environment_configuration, "raspios13_minion", null) != null ? 1 : 0
+  base_configuration = module.base_arm[0].configuration
   name               = "${var.environment_configuration.raspios13_minion.name}${var.platform_location_configuration[var.location].extension}"
   image              = "raspios13o"
   provider_settings = {
@@ -1420,8 +1423,8 @@ module "opensuse156arm_sshminion" {
     libvirt = libvirt.host_arm
   }
   source             = "../sshminion"
-  count              = lookup(var.environment_configuration, "opensuse156arm_sshminion", null) != null ? 1 : 0
-  base_configuration = module.base_arm.configuration
+  count              = local.base_arm_configuration != null && lookup(var.environment_configuration, "opensuse156arm_sshminion", null) != null ? 1 : 0
+  base_configuration = module.base_arm[0].configuration
   name               = "${var.environment_configuration.opensuse156arm_sshminion.name}${var.platform_location_configuration[var.location].extension}"
   image              = "opensuse156armo"
   provider_settings = {
@@ -1440,8 +1443,8 @@ module "opensuse160arm_sshminion" {
     libvirt = libvirt.host_arm
   }
   source             = "../sshminion"
-  count              = lookup(var.environment_configuration, "opensuse160arm_sshminion", null) != null ? 1 : 0
-  base_configuration = module.base_arm.configuration
+  count              = local.base_arm_configuration != null && lookup(var.environment_configuration, "opensuse160arm_sshminion", null) != null ? 1 : 0
+  base_configuration = module.base_arm[0].configuration
   name               = "${var.environment_configuration.opensuse160arm_sshminion.name}${var.platform_location_configuration[var.location].extension}"
   image              = "opensuse160armo"
   provider_settings = {
@@ -1460,8 +1463,8 @@ module "raspios13_sshminion" {
     libvirt = libvirt.host_arm
   }
   source             = "../sshminion"
-  count              = lookup(var.environment_configuration, "raspios13_sshminion", null) != null ? 1 : 0
-  base_configuration = module.base_arm.configuration
+  count              = local.base_arm_configuration != null && lookup(var.environment_configuration, "raspios13_sshminion", null) != null ? 1 : 0
+  base_configuration = module.base_arm[0].configuration
   name               = "${var.environment_configuration.raspios13_sshminion.name}${var.platform_location_configuration[var.location].extension}"
   image              = "raspios13o"
   provider_settings = {


### PR DESCRIPTION
Creates the ARM base only for environments that declare a `base_arm` configuration, instead of always.

Since the ARM image list is read from `base_configurations.base_arm.images`, every environment without that entry now fails to plan with `This map does not have an element with the key "base_arm"` — the personal build validations, the micro and SLE update environments and hub testing.

```
Error: Missing map element

  on modules/build_validation/main.tf line 40, in module "base_arm":
  40:   images          = var.base_configurations.base_arm.images

This map does not have an element with the key "base_arm".
```

`module "base_arm"` gets a `count` on the presence of `base_arm`, so those environments neither read the missing key nor connect to the ARM hypervisor. The six ARM clients carry the same condition, so an environment that declares an ARM minion without a `base_arm` plans to nothing instead of failing on an invalid index into `module.base_arm`.

A `base_arm` without `images` falls back to the list this module used before the refactor, `["opensuse156armo", "opensuse160armo", "raspios13o"]`: the `modules/base` default holds no ARM image, and a null input does not restore it since the variable is not `nullable = false`. The fallback goes through `coalesce`, because a typed `base_configurations` (SUSE/susemanager-ci#2230) gives a base that declares no images a null attribute rather than a missing one. Same for `bridge`.

All current environments declare an ARM base and its clients together, so nothing changes for them.