### PR TITLE
Run the SonarCloud scan alongside the validation jobs

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,7 +6,7 @@ on:
       - master
   workflow_run:
     workflows: [CI validation tests]
-    types: [completed]
+    types: [requested]
 
 permissions:
   contents: read
@@ -17,7 +17,6 @@ jobs:
   sonarcloud:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       with:


### PR DESCRIPTION
Runs the SonarCloud scan on the `requested` event of the CI validation workflow instead of its `completed` event, so it runs alongside the validation jobs and reports on the pull request at the same time as they do.

The `workflow_run` indirection stays: a pull request from a fork gets no `SONAR_TOKEN`, so the scan cannot run on the `pull_request` event itself. Dropping the job condition follows from the trigger — on a `requested` event the triggering run has no conclusion yet.
