### PR TITLE
Show the SonarCloud scan as a check on the pull request

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -12,6 +12,7 @@ permissions:
   contents: read
   actions: read
   pull-requests: read
+  checks: write
 
 jobs:
   sonarcloud:
@@ -43,6 +44,22 @@ jobs:
           echo "PR_BRANCH=${HEAD_BRANCH}"
         } >>"$GITHUB_ENV"
 
+    - name: Report the scan as in progress on the pull request
+      if: github.event_name == 'workflow_run' && env.PR_NUMBER != ''
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        check_run=$(gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST \
+          -f name='SonarCloud Scan' \
+          -f head_sha="${HEAD_SHA}" \
+          -f status=in_progress \
+          -f details_url="${DETAILS_URL}" \
+          --jq '.id')
+        echo "CHECK_RUN_ID=${check_run}" >>"$GITHUB_ENV"
+
     - name: Take the analysis configuration from the base branch
       if: github.event_name == 'workflow_run' && env.PR_NUMBER != ''
       run: |
@@ -50,6 +67,7 @@ jobs:
         git checkout FETCH_HEAD -- sonar-project.properties
 
     - name: Scan the pull request
+      id: scan
       if: github.event_name == 'workflow_run' && env.PR_NUMBER != ''
       uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f #v8.2.1
       env:
@@ -65,6 +83,22 @@ jobs:
           -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
           -Dsonar.pullrequest.branch=${{ env.PR_BRANCH }}
           -Dsonar.pullrequest.base=${{ env.PR_BASE }}
+
+    - name: Report the scan result on the pull request
+      if: always() && env.CHECK_RUN_ID != ''
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SCAN_OUTCOME: ${{ steps.scan.outcome }}
+      run: |
+        case "${SCAN_OUTCOME}" in
+          success) conclusion=success ;;
+          cancelled) conclusion=cancelled ;;
+          *) conclusion=failure ;;
+        esac
+        gh api "repos/${GITHUB_REPOSITORY}/check-runs/${CHECK_RUN_ID}" -X PATCH \
+          -f status=completed \
+          -f conclusion="${conclusion}"
 
     - name: Scan master
       if: github.event_name == 'push'


### PR DESCRIPTION
Opens a check run named `SonarCloud Scan` on the pull request head commit when the scan starts and closes it with the outcome, so the analysis shows up as a pending check linking to the running job instead of appearing only once the SonarQube Cloud app posts its result.

A `workflow_run` run is attached to the default branch, not to the pull request that triggered it, which is why the job itself is invisible in the checks list. This needs `checks: write` on the workflow token — the token minted per run, unrelated to `SONAR_TOKEN`. Both check-run calls are `continue-on-error`, so a repository whose token cannot write checks still gets its analysis.
