### PR TITLE
Give the SonarCloud scan its own trigger and a pull request check

### DIFF
--- a/.github/workflows/pr-event-trigger.yml
+++ b/.github/workflows/pr-event-trigger.yml
@@ -1,0 +1,30 @@
+name: PR event trigger
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  trigger:
+    name: Publish the pull request number
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Save the pull request number
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: echo "PR_NUMBER=${PR_NUMBER}" > pr-metadata
+
+    - name: Upload the pull request metadata
+      uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 #v5.0.0
+      with:
+        name: pr-metadata
+        path: pr-metadata

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -5,42 +5,89 @@ on:
     branches:
       - master
   workflow_run:
-    workflows: [CI validation tests]
-    types: [requested]
+    workflows: [PR event trigger]
+    types: [completed]
 
 permissions:
   contents: read
   actions: read
   pull-requests: read
+  checks: write
 
 jobs:
   sonarcloud:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.workflow_run.conclusion == 'success'
     steps:
+    - name: Report the scan as in progress on the pull request
+      if: github.event_name == 'workflow_run'
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        check_run=$(gh api "repos/${GITHUB_REPOSITORY}/check-runs" -X POST \
+          -f name='SonarCloud Scan' \
+          -f head_sha="${HEAD_SHA}" \
+          -f status=in_progress \
+          -f details_url="${DETAILS_URL}" \
+          --jq '.id')
+        echo "CHECK_RUN_ID=${check_run}" >>"$GITHUB_ENV"
+
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
       with:
         ref: ${{ github.event.workflow_run.head_sha }}
         fetch-depth: 0 # Deep clone required for accurate blame information
         allow-unsafe-pr-checkout: true
 
+    - name: Download the pull request metadata
+      if: github.event_name == 'workflow_run'
+      uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 #v5.0.0
+      with:
+        name: pr-metadata
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path: ${{ runner.temp }}/pr-metadata
+
     - name: Find the pull request the run belongs to
       if: github.event_name == 'workflow_run'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        BASE_BRANCH: master
       run: |
-        pull_request=$(gh api "repos/${GITHUB_REPOSITORY}/pulls" -X GET \
-          -f state=open -f head="${HEAD_OWNER}:${HEAD_BRANCH}" --jq 'first')
-        if [ -z "$pull_request" ] || [ "$pull_request" = "null" ]; then
-          echo "No open pull request for ${HEAD_OWNER}:${HEAD_BRANCH}, skipping the scan"
+        pr_number=$(sed -n 's/^PR_NUMBER=\([0-9]\{1,\}\)$/\1/p' "${RUNNER_TEMP}/pr-metadata/pr-metadata" | head -1)
+        if [ -z "$pr_number" ]; then
+          echo "The trigger run published no pull request number"
+          exit 1
+        fi
+        if ! pull_request=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" 2>"${RUNNER_TEMP}/lookup-error"); then
+          if ! grep -q 'HTTP 404' "${RUNNER_TEMP}/lookup-error"; then
+            cat "${RUNNER_TEMP}/lookup-error" >&2
+            exit 1
+          fi
+          echo "Pull request ${pr_number} does not exist, skipping the scan"
+          exit 0
+        fi
+        if ! echo "$pull_request" | jq -e --arg repository "${HEAD_REPOSITORY}" \
+            --arg branch "${HEAD_BRANCH}" --arg base "${BASE_BRANCH}" \
+            '.state == "open" and .head.repo.full_name == $repository
+             and .head.ref == $branch and .base.ref == $base' >/dev/null; then
+          echo "Pull request ${pr_number} is not the open ${BASE_BRANCH} pull request for ${HEAD_REPOSITORY} ${HEAD_BRANCH}, skipping the scan"
+          exit 0
+        fi
+        if [ "$(echo "$pull_request" | jq -r '.head.sha')" != "${HEAD_SHA}" ]; then
+          echo "Pull request ${pr_number} is no longer at ${HEAD_SHA}, skipping the scan"
           exit 0
         fi
         {
           echo "PR_NUMBER=$(echo "$pull_request" | jq -r '.number')"
           echo "PR_BASE=$(echo "$pull_request" | jq -r '.base.ref')"
-          echo "PR_BRANCH=${HEAD_BRANCH}"
+          echo "PR_BRANCH=$(echo "$pull_request" | jq -r '.head.ref')"
         } >>"$GITHUB_ENV"
 
     - name: Take the analysis configuration from the base branch
@@ -50,6 +97,7 @@ jobs:
         git checkout FETCH_HEAD -- sonar-project.properties
 
     - name: Scan the pull request
+      id: scan
       if: github.event_name == 'workflow_run' && env.PR_NUMBER != ''
       uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f #v8.2.1
       env:
@@ -65,6 +113,29 @@ jobs:
           -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
           -Dsonar.pullrequest.branch=${{ env.PR_BRANCH }}
           -Dsonar.pullrequest.base=${{ env.PR_BASE }}
+
+    - name: Report the scan result on the pull request
+      if: always() && env.CHECK_RUN_ID != ''
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JOB_STATUS: ${{ job.status }}
+        SCAN_OUTCOME: ${{ steps.scan.outcome }}
+      run: |
+        case "${JOB_STATUS}" in
+          success)
+            if [ "${SCAN_OUTCOME}" = "skipped" ]; then
+              conclusion=skipped
+            else
+              conclusion=success
+            fi
+            ;;
+          cancelled) conclusion=cancelled ;;
+          *) conclusion=failure ;;
+        esac
+        gh api "repos/${GITHUB_REPOSITORY}/check-runs/${CHECK_RUN_ID}" -X PATCH \
+          -f status=completed \
+          -f conclusion="${conclusion}"
 
     - name: Scan master
       if: github.event_name == 'push'


### PR DESCRIPTION
Adds a `PR event trigger` workflow that publishes the pull request number as an artifact, and switches the SonarCloud scan to consume that instead of subscribing to the CI validation tests. The scan no longer breaks silently if the validation workflow is renamed or split, and no longer has to guess which pull request a run belongs to by searching for an open one whose head matches the fork and branch name. The trigger is filtered to pull requests against `master`, the same scope the validation workflow has, so the set of scanned pull requests does not change. Waiting for the trigger workflow costs a few seconds rather than the minutes the validation tests take, so the scan still reports alongside them.

A fork can edit the trigger workflow in its own branch, so the artifact is untrusted: it is unpacked into the runner temporary directory rather than into the checkout, and the number is read back through a pattern that only accepts digits. The pull request it names is used only if it is open, targets `master`, sits on the head repository and branch the `workflow_run` event reports, and is still at the commit being scanned — a number naming any other pull request, including one that happens to share the head commit, skips the scan. Everything the scan is then given comes from that lookup rather than from the artifact. A pull request that does not exist skips the scan quietly; any other lookup failure prints the error and fails the job, so a scan that never ran stays visible instead of passing as a skip.

The scan also opens a check run named `SonarCloud Scan` on the head commit and closes it with the outcome. A `workflow_run` run is attached to the default branch, not to the pull request that triggered it, so the job is otherwise invisible in the checks list and the analysis shows up only once the SonarQube Cloud app posts its result. The check is opened as the first step, before anything that can fail, and closed from the status of the job rather than of the scan alone, so a run that breaks before reaching SonarCloud still reports back to the pull request; a run that deliberately skips the scan closes it as skipped. This needs `checks: write` on the workflow token — the token minted per run, unrelated to `SONAR_TOKEN`. Neither check-run call can fail the job, so a repository whose token cannot write checks still gets its analysis.
