### PR TITLE
Start ssh systemd service instead of sshd

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -697,7 +697,7 @@ bootcmd:
 runcmd:
   # HACK: cloud-init in Debian 12/13 does not take care of the following
   - echo "PermitRootLogin yes" >> /etc/ssh/sshd_config
-  - systemctl restart sshd
+  - systemctl restart ssh
 %{ if install_salt_bundle ~}
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq update"
   - "DEBIAN_FRONTEND=noninteractive apt-get -yq install venv-salt-minion avahi-daemon qemu-guest-agent"


### PR DESCRIPTION
## What does this PR change?

For all debian 12, debian 13, and raspi OS, start `ssh` systemd service instead of `sshd`:

- debian12 and debian13 support both ssh and sshd
- raspios13 supports only ssh
