### PR TITLE
Synchronize with NTP at boot on Debian

### DIFF
--- a/backend_modules/libvirt/host/user_data.yaml
+++ b/backend_modules/libvirt/host/user_data.yaml
@@ -690,6 +690,9 @@ apt:
 
 
 bootcmd:
+  # HACK: We are still at image creation date, synchronize with the outer world
+  - systemctl restart systemd-timesyncd
+  - /lib/systemd/systemd-time-wait-sync --timeout=20
   # HACK: Make "gnupg" to be installed before configuring repos, so gpg key can be imported
   - DEBIAN_FRONTEND=noninteractive apt-get -yq update
   - DEBIAN_FRONTEND=noninteractive apt-get -yq install gnupg


### PR DESCRIPTION
## What does this PR change?

Synchronize with NTP at boot on Debian. Addresses :
```
W: OpenPGP signature verification failed: http://deb.debian.org/debian trixie InRelease: Sub-process /usr/bin/sqv returned an error code (1), error message is: Verifying signature:  

         Not live until 2026-07-11T08:32:59Z Verifying signature:            Not live until 2026-07-11T08:33:00Z Verifying signature:            Not live until 2026-07-11T08:34:12Z

E: The repository 'http://deb.debian.org/debian trixie InRelease' is not signed.
```